### PR TITLE
Optional coalescing of schema refresh queries

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2887,17 +2887,28 @@ public class Cluster implements Closeable {
             new ExceptionCatchingRunnable() {
               @Override
               public void runMayThrow() throws InterruptedException, ExecutionException {
-                SchemaRefreshRequest coalesced = null;
-                for (SchemaRefreshRequest request : events) {
-                  coalesced = coalesced == null ? request : coalesced.coalesce(request);
+                if (schemaRefreshRequestDebouncer.maxPendingEvents() > 1) {
+                  SchemaRefreshRequest coalesced = null;
+                  for (SchemaRefreshRequest request : events) {
+                    coalesced = coalesced == null ? request : coalesced.coalesce(request);
+                  }
+                  assert coalesced != null;
+                  logger.trace("Coalesced schema refresh request: {}", coalesced);
+                  controlConnection.refreshSchema(
+                      coalesced.targetType,
+                      coalesced.targetKeyspace,
+                      coalesced.targetName,
+                      coalesced.targetSignature);
+                } else {
+                  for (SchemaRefreshRequest request : events) {
+                    logger.trace("Schema refresh request: {}", request);
+                    controlConnection.refreshSchema(
+                        request.targetType,
+                        request.targetKeyspace,
+                        request.targetName,
+                        request.targetSignature);
+                  }
                 }
-                assert coalesced != null;
-                logger.trace("Coalesced schema refresh request: {}", coalesced);
-                controlConnection.refreshSchema(
-                    coalesced.targetType,
-                    coalesced.targetKeyspace,
-                    coalesced.targetName,
-                    coalesced.targetSignature);
               }
             });
       }


### PR DESCRIPTION
By default the driver has the ability to coalesce schem refresh queries
to try and reduce the number of queries sent. In case a view and a table
refresh is needed a refresh for the keyspace would be generated.

While in most cases thisoptimization is helpfull - in case there are
100s of tables in a single keyspace this will cause fetching all
keyspace information which will cause extra load on the system (in
scylla's case a single shard).

Add the ability to disable this by reusing setting of
maxPendingRefreshSchmaRequests value. If its 1 disable coalescing.

Signed-off-by: Shlomi Livne <shlomi@scylladb.com>