### PR TITLE
Makes the pool ready after first connection

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -290,7 +290,7 @@ class HostConnectionPool implements Connection.Owner {
     do {
       synchronized(connections[shId]) {
         if ((connections[shId].isEmpty()) && (index < connections.length)) {
-          shId = (shId + ++index) % connections.length;
+          shId = (shardId + ++index) % connections.length;
         } else {
           break;
         }


### PR DESCRIPTION
This patch changes the behavior of the connection pool, making it ready as soon as the first connection is added to it. This prevents clients from timing out when there are many connections to be added.