### PR TITLE
Shard-aware routing with token ranges

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -403,7 +403,7 @@ class RequestHandler {
               poolingOptions.getPoolTimeoutMillis(),
               TimeUnit.MILLISECONDS,
               poolingOptions.getMaxQueueSize(),
-              routingKey);
+              statement);
       GuavaCompatibility.INSTANCE.addCallback(
           connectionFuture,
           new FutureCallback<Connection>() {

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -719,9 +719,7 @@ class SessionManager extends AbstractSession {
         // execute
         // the prepared query. So don't wait if no connection is available, simply abort.
         ListenableFuture<Connection> connectionFuture =
-            entry
-                .getValue()
-                .borrowConnection(0, TimeUnit.MILLISECONDS, 0, statement.getRoutingKey());
+            entry.getValue().borrowConnection(0, TimeUnit.MILLISECONDS, 0, null);
         ListenableFuture<Response> prepareFuture =
             GuavaCompatibility.INSTANCE.transformAsync(
                 connectionFuture,

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -54,7 +54,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -1590,10 +1589,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
 
     private MockRequest(HostConnectionPool pool, int timeoutMillis, int maxQueueSize)
         throws ConnectionException {
-      ByteBuffer routingKey = ByteBuffer.allocate(4);
-      routingKey.putInt(0, 0);
       this.connectionFuture =
-          pool.borrowConnection(timeoutMillis, MILLISECONDS, maxQueueSize, routingKey);
+          pool.borrowConnection(timeoutMillis, MILLISECONDS, maxQueueSize, null);
       requestInitialized =
           GuavaCompatibility.INSTANCE.transform(
               this.connectionFuture,


### PR DESCRIPTION
These changes introduce shard-aware routing for certain token-ranges.

The queries supported must have the form:

SELECT xxx FROM xxx WHERE token(xxx) [<|<=|=|>|>=] xxx AND/OR token(xxx)
[<|<=|=|>|>=]

Both prepared and non-prepared statements  are analyzed. If they comply
to this format, both query-plan and host connection are selected
accordingly.

These modifications were tested in the driver used by a costumer's data
migration and presented up to 50% better performance.