### PR TITLE
fix endless loop trying to connect to a specific shard

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -703,9 +703,9 @@ class HostConnectionPool implements Connection.Owner {
           ShardingInfo shardingInfo = host.getShardingInfo();
           if (shardingInfo != null) {
             shardCount = shardingInfo.getShardsCount();
-            localPort = getAvailablePortForShard(shardCount, shardId, 100);
             if (shardingInfo.getShardAwarePort() != 0) {
               serverPort = shardingInfo.getShardAwarePort();
+              localPort = getAvailablePortForShard(shardCount, shardId, 100);
             }
           }
           logger.debug(

--- a/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
@@ -25,18 +25,25 @@ public class ShardingInfo {
   private static final String SCYLLA_PARTITIONER = "SCYLLA_PARTITIONER";
   private static final String SCYLLA_SHARDING_ALGORITHM = "SCYLLA_SHARDING_ALGORITHM";
   private static final String SCYLLA_SHARDING_IGNORE_MSB = "SCYLLA_SHARDING_IGNORE_MSB";
+  private static final String SCYLLA_SHARD_AWARE_PORT = "SCYLLA_SHARD_AWARE_PORT";
 
   private final int shardsCount;
   private final String partitioner;
   private final String shardingAlgorithm;
   private final int shardingIgnoreMSB;
+  private final int shardAwarePort;
 
   private ShardingInfo(
-      int shardsCount, String partitioner, String shardingAlgorithm, int shardingIgnoreMSB) {
+      int shardsCount,
+      String partitioner,
+      String shardingAlgorithm,
+      int shardingIgnoreMSB,
+      int shardAwarePort) {
     this.shardsCount = shardsCount;
     this.partitioner = partitioner;
     this.shardingAlgorithm = shardingAlgorithm;
     this.shardingIgnoreMSB = shardingIgnoreMSB;
+    this.shardAwarePort = shardAwarePort;
   }
 
   public int getShardsCount() {
@@ -55,6 +62,10 @@ public class ShardingInfo {
     return (int) (sum >>> 32);
   }
 
+  public Integer getShardAwarePort() {
+    return shardAwarePort;
+  }
+
   public static class ConnectionShardingInfo {
     public final int shardId;
     public final ShardingInfo shardingInfo;
@@ -71,6 +82,7 @@ public class ShardingInfo {
     String partitioner = parseString(params, SCYLLA_PARTITIONER);
     String shardingAlgorithm = parseString(params, SCYLLA_SHARDING_ALGORITHM);
     Integer shardingIgnoreMSB = parseInt(params, SCYLLA_SHARDING_IGNORE_MSB);
+    Integer shardAwarePort = parseInt(params, SCYLLA_SHARD_AWARE_PORT);
     if (shardId == null
         || shardsCount == null
         || partitioner == null
@@ -80,8 +92,13 @@ public class ShardingInfo {
         || !shardingAlgorithm.equals("biased-token-round-robin")) {
       return null;
     }
+    if (shardAwarePort == null) {
+      shardAwarePort = 0;
+    }
     return new ConnectionShardingInfo(
-        shardId, new ShardingInfo(shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB));
+        shardId,
+        new ShardingInfo(
+            shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB, shardAwarePort));
   }
 
   private static String parseString(Map<String, List<String>> params, String key) {

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
@@ -1,0 +1,23 @@
+package com.datastax.driver.core.utils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+public class SocketUtils {
+
+  public static boolean isTcpPortAvailable(int port) {
+    try {
+      ServerSocket serverSocket = new ServerSocket();
+      try {
+        serverSocket.setReuseAddress(false);
+        serverSocket.bind(new InetSocketAddress(port), 1);
+        return true;
+      } finally {
+        serverSocket.close();
+      }
+    } catch (IOException ex) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Endless loop occurred when connecting to one of our scylla cluster, which is shared among serveral application, and some of which is still using the cassandra driver, so the connection numbers on each shard varies. 

When scylla driver trying to create a connection to some shard A that has at least 2 more connections than some other shard B in the following loop, it can never success. Because on the server side the new connection is always transferred to shard B, and 
on the client side the new connection, which is connected to shard B, will be closed immediately, if there is already a connection to the same shard in the `connectionsToClose` map, so the connection count on shard B is always less than that on shard A, thus endless loop. In consequence, lots of closed connections stays in TIME_WAIT state, and new connections cannot be established due to exhaust of socket resources.

https://github.com/scylladb/java-driver/blob/3aec70da8bc927afdf69ca455dfd05f81a8bb53e/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java#L670-L677

To fix the problem the `connectionsToClose` is changed to be able to hold more than one connection for each shard. As new connections created, connection count on shard B can eventually be equal to or even more than that on shard A.