### PR TITLE
Add CDC partitioner (version 3.10.2)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -103,6 +103,11 @@ public class BoundStatement extends Statement
     return statement.isLWT();
   }
 
+  @Override
+  public Token.Factory getPartitioner() {
+    return statement.getPartitioner();
+  }
+
   /**
    * Returns the prepared statement on which this BoundStatement is based.
    *

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -388,7 +388,11 @@ class HostConnectionPool implements Connection.Owner {
   }
 
   ListenableFuture<Connection> borrowConnection(
-      long timeout, TimeUnit unit, int maxQueueSize, ByteBuffer routingKey) {
+      long timeout,
+      TimeUnit unit,
+      int maxQueueSize,
+      Token.Factory partitioner,
+      ByteBuffer routingKey) {
     Phase phase = this.phase.get();
     if (phase != Phase.READY)
       return Futures.immediateFailedFuture(
@@ -398,7 +402,7 @@ class HostConnectionPool implements Connection.Owner {
     if (host.getShardingInfo() != null) {
       if (routingKey != null) {
         Metadata metadata = manager.cluster.getMetadata();
-        Token t = metadata.newToken(routingKey);
+        Token t = metadata.newToken(partitioner, routingKey);
         shardId = host.getShardingInfo().shardId(t);
       } else {
         shardId = RAND.nextInt(host.getShardingInfo().getShardsCount());

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -488,24 +488,30 @@ public class Metadata {
   }
 
   /**
-   * Returns the set of hosts that are replica for a given partition key.
+   * Returns the set of hosts that are replica for a given partition key. Partitioner can be {@code
+   * null} and then a cluster-wide partitioner will be invoked.
    *
    * <p>Note that this information is refreshed asynchronously by the control connection, when
    * schema or ring topology changes. It might occasionally be stale (or even empty).
    *
    * @param keyspace the name of the keyspace to get replicas for.
+   * @param partitioner the partitioner to use or @{code null} for cluster-wide partitioner.
    * @param partitionKey the partition key for which to find the set of replica.
    * @return the (immutable) set of replicas for {@code partitionKey} as known by the driver. Note
    *     that the result might be stale or empty if metadata was explicitly disabled with {@link
    *     QueryOptions#setMetadataEnabled(boolean)}.
    */
-  public Set<Host> getReplicas(String keyspace, ByteBuffer partitionKey) {
+  public Set<Host> getReplicas(
+      String keyspace, Token.Factory partitioner, ByteBuffer partitionKey) {
     keyspace = handleId(keyspace);
     TokenMap current = tokenMap;
     if (current == null) {
       return Collections.emptySet();
     } else {
-      Set<Host> hosts = current.getReplicas(keyspace, current.factory.hash(partitionKey));
+      if (partitioner == null) {
+        partitioner = current.factory;
+      }
+      Set<Host> hosts = current.getReplicas(keyspace, partitioner.hash(partitionKey));
       return hosts == null ? Collections.<Host>emptySet() : hosts;
     }
   }
@@ -673,8 +679,10 @@ public class Metadata {
   }
 
   /**
-   * Builds a new {@link Token} from a partition key.
+   * Builds a new {@link Token} from a partition key. Partitioner can be {@code null} and then a
+   * cluster-wide partitioner will be invoked.
    *
+   * @param partitioner the partitioner to use or @{code null} for cluster-wide partitioner.
    * @param components the components of the partition key, in their serialized form (obtained with
    *     {@link TypeCodec#serialize(Object, ProtocolVersion)}).
    * @return the token.
@@ -682,12 +690,15 @@ public class Metadata {
    *     happen if metadata was explicitly disabled with {@link
    *     QueryOptions#setMetadataEnabled(boolean)} before startup.
    */
-  public Token newToken(ByteBuffer... components) {
+  public Token newToken(Token.Factory partitioner, ByteBuffer... components) {
     TokenMap current = tokenMap;
     if (current == null)
       throw new IllegalStateException(
           "Token factory not set. This should only happen if metadata was explicitly disabled");
-    return current.factory.hash(SimpleStatement.compose(components));
+    if (partitioner == null) {
+      partitioner = current.factory;
+    }
+    return partitioner.hash(SimpleStatement.compose(components));
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
@@ -239,6 +239,14 @@ public interface PreparedStatement {
   public RetryPolicy getRetryPolicy();
 
   /**
+   * The partitioner for this prepared statement.
+   *
+   * @return the partitioner for this query, or {@code null} if no partitioner has been specified.
+   *     In the latter case, the cluster-wide partitioner will be used.
+   */
+  public Token.Factory getPartitioner();
+
+  /**
    * Returns the prepared Id for this statement.
    *
    * @return the PreparedId corresponding to this statement.

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -103,8 +103,12 @@ class RequestHandler {
       return fallback;
     }
 
+    Token.Factory partitioner = statement.getPartitioner();
     final Set<Host> replicas =
-        manager.cluster.getMetadata().getReplicas(Metadata.quote(keyspace), partitionKey);
+        manager
+            .cluster
+            .getMetadata()
+            .getReplicas(Metadata.quote(keyspace), partitioner, partitionKey);
 
     // replicas are stored in the right order starting with the primary replica
     return replicas.iterator();
@@ -432,6 +436,7 @@ class RequestHandler {
               poolingOptions.getPoolTimeoutMillis(),
               TimeUnit.MILLISECONDS,
               poolingOptions.getMaxQueueSize(),
+              statement.getPartitioner(),
               routingKey);
       GuavaCompatibility.INSTANCE.addCallback(
           connectionFuture,

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -733,7 +733,7 @@ class SessionManager extends AbstractSession {
         ListenableFuture<Connection> connectionFuture =
             entry
                 .getValue()
-                .borrowConnection(0, TimeUnit.MILLISECONDS, 0, statement.getRoutingKey());
+                .borrowConnection(0, TimeUnit.MILLISECONDS, 0, null, statement.getRoutingKey());
         ListenableFuture<Response> prepareFuture =
             GuavaCompatibility.INSTANCE.transformAsync(
                 connectionFuture,

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -223,6 +223,16 @@ public abstract class Statement {
   public abstract String getKeyspace();
 
   /**
+   * The partitioner for this query.
+   *
+   * @return the partitioner for this query, or {@code null} if no partitioner has been specified.
+   *     In the latter case, the cluster-wide partitioner will be used.
+   */
+  public Token.Factory getPartitioner() {
+    return null;
+  }
+
+  /**
    * Sets the retry policy to use for this query.
    *
    * <p>The default retry policy, if this method is not called, is the one returned by {@link

--- a/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
@@ -46,6 +46,7 @@ public class TableOptionsMetadata {
   private static final String CRC_CHECK_CHANCE = "crc_check_chance";
   private static final String EXTENSIONS = "extensions";
   private static final String CDC = "cdc";
+  private static final String SCYLLA_CDC_EXTENSION = "cdc";
   private static final String ADDITIONAL_WRITE_POLICY = "additional_write_policy";
 
   private static final boolean DEFAULT_REPLICATE_ON_WRITE = true;
@@ -84,6 +85,7 @@ public class TableOptionsMetadata {
   private final Double crcCheckChance;
   private final Map<String, ByteBuffer> extensions;
   private final boolean cdc;
+  private final boolean scyllaCDC;
   private final String additionalWritePolicy;
 
   TableOptionsMetadata(Row row, boolean isCompactStorage, VersionNumber version) {
@@ -185,6 +187,8 @@ public class TableOptionsMetadata {
 
     if (is380OrHigher) this.cdc = isNullOrAbsent(row, CDC) ? DEFAULT_CDC : row.getBool(CDC);
     else this.cdc = DEFAULT_CDC;
+
+    this.scyllaCDC = this.extensions.containsKey(SCYLLA_CDC_EXTENSION);
 
     if (is400OrHigher) this.additionalWritePolicy = row.getString(ADDITIONAL_WRITE_POLICY);
     else this.additionalWritePolicy = DEFAULT_ADDITIONAL_WRITE_POLICY;
@@ -419,6 +423,15 @@ public class TableOptionsMetadata {
    */
   public boolean isCDC() {
     return cdc;
+  }
+
+  /**
+   * Returns whether or not Scylla change data capture is enabled for this table.
+   *
+   * @return whether or not Scylla change data capture is enabled for this table.
+   */
+  public boolean isScyllaCDC() {
+    return scyllaCDC;
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -179,7 +179,9 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
     if (partitionKey == null || keyspace == null)
       return childPolicy.newQueryPlan(keyspace, statement);
 
-    final Set<Host> replicas = clusterMetadata.getReplicas(Metadata.quote(keyspace), partitionKey);
+    final Set<Host> replicas =
+        clusterMetadata.getReplicas(
+            Metadata.quote(keyspace), statement.getPartitioner(), partitionKey);
     if (replicas.isEmpty()) return childPolicy.newQueryPlan(loggedKeyspace, statement);
 
     if (replicaOrdering == ReplicaOrdering.NEUTRAL) {

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -1593,7 +1593,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       ByteBuffer routingKey = ByteBuffer.allocate(4);
       routingKey.putInt(0, 0);
       this.connectionFuture =
-          pool.borrowConnection(timeoutMillis, MILLISECONDS, maxQueueSize, routingKey);
+          pool.borrowConnection(timeoutMillis, MILLISECONDS, maxQueueSize, null, routingKey);
       requestInitialized =
           GuavaCompatibility.INSTANCE.transform(
               this.connectionFuture,

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -633,7 +633,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
       assertThat(added.getValue()).hasName(handleId(keyspace));
     }
     for (Metadata m : metadatas())
-      assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE"))).isNotEmpty();
+      assertThat(m.getReplicas(keyspace, null, Bytes.fromHexString("0xCAFEBABE"))).isNotEmpty();
     execute(CREATE_TABLE, keyspace); // to test table drop notifications
     execute(DROP_KEYSPACE, keyspace);
     for (SchemaChangeListener listener : listeners) {
@@ -646,7 +646,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
     for (Metadata m : metadatas()) {
       assertThat(m.getKeyspace(keyspace)).isNull();
-      assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE"))).isEmpty();
+      assertThat(m.getReplicas(keyspace, null, Bytes.fromHexString("0xCAFEBABE"))).isEmpty();
     }
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -48,7 +48,7 @@ public class SingleTokenIntegrationTest extends CCMTestsSupport {
     assertThat(hostsForRange).containsOnly(host1);
 
     ByteBuffer randomPartitionKey = Bytes.fromHexString("0xCAFEBABE");
-    Set<Host> hostsForKey = metadata.getReplicas(keyspace, randomPartitionKey);
+    Set<Host> hostsForKey = metadata.getReplicas(keyspace, null, randomPartitionKey);
     assertThat(hostsForKey).containsOnly(host1);
 
     Set<TokenRange> rangesForHost = metadata.getTokenRanges(keyspace, host1);

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -100,6 +100,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
     Set<Host> replicas =
         metadata.getReplicas(
             ks1,
+            null,
             TypeCodec.cint()
                 .serialize(
                     testKey,
@@ -409,7 +410,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
 
     ProtocolVersion protocolVersion =
         cluster().getConfiguration().getProtocolOptions().getProtocolVersion();
-    assertThat(metadata.newToken(TypeCodec.cint().serialize(1, protocolVersion)))
+    assertThat(metadata.newToken(null, TypeCodec.cint().serialize(1, protocolVersion)))
         .isEqualTo(expected);
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -83,7 +83,7 @@ public class TokenAwarePolicyTest {
     when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
     when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.NEWEST_SUPPORTED);
     when(cluster.getMetadata()).thenReturn(metadata);
-    when(metadata.getReplicas(Metadata.quote("keyspace"), routingKey))
+    when(metadata.getReplicas(Metadata.quote("keyspace"), null, routingKey))
         .thenReturn(Sets.newLinkedHashSet(host1, host2));
     when(childPolicy.newQueryPlan("keyspace", statement))
         .thenReturn(Sets.newLinkedHashSet(host4, host3, host2, host1).iterator());
@@ -177,7 +177,7 @@ public class TokenAwarePolicyTest {
 
       // then: The replicas resolved from the cluster metadata must match node 6 and its replicas.
       List<Host> replicas =
-          Lists.newArrayList(cluster.getMetadata().getReplicas("keyspace", routingKey));
+          Lists.newArrayList(cluster.getMetadata().getReplicas("keyspace", null, routingKey));
       assertThat(replicas)
           .containsExactly(
               sCluster.host(cluster, 1, 6),


### PR DESCRIPTION
Add new class `CDCToken` which implements a Scylla CDC partitioner, as defined here:

https://github.com/scylladb/scylla/blob/master/cdc/cdc_partitioner.cc

Modify `Statement` classes to provide table name alongside already implemented keyspace name, in order to detect if CDC partitioner should be used for a given `Statement`.

Modify `Metadata` to use CDC partitioner instead of cluster-wide partitioner when calculating token for CDC log table. As Scylla token range information is shared between Murmur3 partitioner and CDC partitioner only a single `TokenMap` is used. 

(In case of Scylla) this TokenMap stores `M3PToken` tokens, but queries for `CDCToken` are allowed - `M3PToken` and `CDCToken` are modified to allow comparison between those types (as they are both represented by 64-bit integers).

### Manual testing
I have setup a table with CDC enabled on a 2-node Scylla cluster. Exectued a few prepared statements using Java client, reading from CDC log table with `WHERE` clause on partition key (`cdc$stream_id`) and enabled tracing.

The tracing shows the change works properly (click to enlarge):

![tracings](https://user-images.githubusercontent.com/10003183/93330169-aa69f700-f81e-11ea-9b5a-cd7aca167150.png)