### PR TITLE
Implement advanced shard awareness

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -67,6 +67,7 @@ import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import java.lang.ref.WeakReference;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -165,6 +166,10 @@ class Connection {
   }
 
   ListenableFuture<Void> initAsync() {
+    return initAsync(0);
+  }
+
+  ListenableFuture<Void> initAsync(int localPort) {
     if (factory.isShutdown)
       return Futures.immediateFailedFuture(
           new ConnectionException(endPoint, "Connection factory is shut down"));
@@ -191,7 +196,8 @@ class Connection {
                   ? factory.manager.metrics
                   : null));
 
-      ChannelFuture future = bootstrap.connect(endPoint.resolve());
+      ChannelFuture future =
+          bootstrap.connect(endPoint.resolve(), new InetSocketAddress(localPort));
 
       writer.incrementAndGet();
       future.addListener(
@@ -1101,10 +1107,16 @@ class Connection {
     Connection open(HostConnectionPool pool)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
+      return open(pool, 0);
+    }
+
+    Connection open(HostConnectionPool pool, int localPort)
+        throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
+            ClusterNameMismatchException {
       pool.host.convictionPolicy.signalConnectionsOpening(1);
       Connection connection = new Connection(buildConnectionName(pool.host), pool.host, this, pool);
       try {
-        connection.initAsync().get();
+        connection.initAsync(localPort).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -166,10 +166,10 @@ class Connection {
   }
 
   ListenableFuture<Void> initAsync() {
-    return initAsync(0);
+    return initAsync(0, 0);
   }
 
-  ListenableFuture<Void> initAsync(int localPort) {
+  ListenableFuture<Void> initAsync(int localPort, int serverPort) {
     if (factory.isShutdown)
       return Futures.immediateFailedFuture(
           new ConnectionException(endPoint, "Connection factory is shut down"));
@@ -196,8 +196,12 @@ class Connection {
                   ? factory.manager.metrics
                   : null));
 
-      ChannelFuture future =
-          bootstrap.connect(endPoint.resolve(), new InetSocketAddress(localPort));
+      InetSocketAddress serverAddress =
+          (serverPort == 0)
+              ? endPoint.resolve()
+              : new InetSocketAddress(endPoint.resolve().getAddress(), serverPort);
+
+      ChannelFuture future = bootstrap.connect(serverAddress, new InetSocketAddress(localPort));
 
       writer.incrementAndGet();
       future.addListener(
@@ -1107,16 +1111,16 @@ class Connection {
     Connection open(HostConnectionPool pool)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
-      return open(pool, 0);
+      return open(pool, 0, 0);
     }
 
-    Connection open(HostConnectionPool pool, int localPort)
+    Connection open(HostConnectionPool pool, int localPort, int serverPort)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
       pool.host.convictionPolicy.signalConnectionsOpening(1);
       Connection connection = new Connection(buildConnectionName(pool.host), pool.host, this, pool);
       try {
-        connection.initAsync(localPort).get();
+        connection.initAsync(localPort, serverPort).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -411,14 +411,12 @@ class HostConnectionPool implements Connection.Owner {
       if (host.convictionPolicy.canReconnectNow()) {
         if (connectionsPerShard == 0) {
           maybeSpawnNewConnection(shardId);
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         } else if (scheduledForCreation[shardId].compareAndSet(0, connectionsPerShard)) {
           for (int i = 0; i < connectionsPerShard; i++) {
             // We don't respect MAX_SIMULTANEOUS_CREATION here because it's  only to
             // protect against creating connection in excess of core too quickly
             manager.blockingExecutor().submit(new ConnectionTask(shardId));
           }
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         }
       }
       // connections for this shard are still being initialized so pick connection for any shard

--- a/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
@@ -25,18 +25,25 @@ public class ShardingInfo {
   private static final String SCYLLA_PARTITIONER = "SCYLLA_PARTITIONER";
   private static final String SCYLLA_SHARDING_ALGORITHM = "SCYLLA_SHARDING_ALGORITHM";
   private static final String SCYLLA_SHARDING_IGNORE_MSB = "SCYLLA_SHARDING_IGNORE_MSB";
+  private static final String SCYLLA_SHARD_AWARE_PORT = "SCYLLA_SHARD_AWARE_PORT";
 
   private final int shardsCount;
   private final String partitioner;
   private final String shardingAlgorithm;
   private final int shardingIgnoreMSB;
+  private final int shardAwarePort;
 
   private ShardingInfo(
-      int shardsCount, String partitioner, String shardingAlgorithm, int shardingIgnoreMSB) {
+      int shardsCount,
+      String partitioner,
+      String shardingAlgorithm,
+      int shardingIgnoreMSB,
+      int shardAwarePort) {
     this.shardsCount = shardsCount;
     this.partitioner = partitioner;
     this.shardingAlgorithm = shardingAlgorithm;
     this.shardingIgnoreMSB = shardingIgnoreMSB;
+    this.shardAwarePort = shardAwarePort;
   }
 
   public int getShardsCount() {
@@ -55,6 +62,10 @@ public class ShardingInfo {
     return (int) (sum >>> 32);
   }
 
+  public int getShardAwarePort() {
+    return shardAwarePort;
+  }
+
   public static class ConnectionShardingInfo {
     public final int shardId;
     public final ShardingInfo shardingInfo;
@@ -71,6 +82,7 @@ public class ShardingInfo {
     String partitioner = parseString(params, SCYLLA_PARTITIONER);
     String shardingAlgorithm = parseString(params, SCYLLA_SHARDING_ALGORITHM);
     Integer shardingIgnoreMSB = parseInt(params, SCYLLA_SHARDING_IGNORE_MSB);
+    Integer shardAwarePort = parseInt(params, SCYLLA_SHARD_AWARE_PORT);
     if (shardId == null
         || shardsCount == null
         || partitioner == null
@@ -80,8 +92,13 @@ public class ShardingInfo {
         || !shardingAlgorithm.equals("biased-token-round-robin")) {
       return null;
     }
+    if (shardAwarePort == null) {
+      shardAwarePort = 0;
+    }
     return new ConnectionShardingInfo(
-        shardId, new ShardingInfo(shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB));
+        shardId,
+        new ShardingInfo(
+            shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB, shardAwarePort));
   }
 
   private static String parseString(Map<String, List<String>> params, String key) {

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
@@ -1,0 +1,23 @@
+package com.datastax.driver.core.utils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+public class SocketUtils {
+
+  public static boolean isTcpPortAvailable(int port) {
+    try {
+      ServerSocket serverSocket = new ServerSocket();
+      try {
+        serverSocket.setReuseAddress(false);
+        serverSocket.bind(new InetSocketAddress(port), 1);
+        return true;
+      } finally {
+        serverSocket.close();
+      }
+    } catch (IOException ex) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Make use of new Scylla capability to connect directly to a selected shard. The server now returns a port that exposes new behavior. It looks at the port used on the client-side to decide which shard should the connection be attached to.

It's an edited version of previous @thirstycrow  contribution ->  https://github.com/scylladb/java-driver/pull/31