### PR TITLE
Fix index multiversion

### DIFF
--- a/docs/_utils/multiversion.sh
+++ b/docs/_utils/multiversion.sh
@@ -2,4 +2,4 @@
 
 cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
     --pre-build './docs/_utils/javadoc.sh' \
-    --pre-build "find . -name README.md -execdir mv '{}' index.md ';'"
+    --pre-build "find . -mindepth 2 -name README.md -execdir mv '{}' index.md ';'"


### PR DESCRIPTION
This PR will make the [index page](https://scylladb.github.io/java-driver/latest/index.html) to load properly, now is just throwing a 404 error. All the [other documentation pages](https://scylladb.github.io/java-driver/latest/faq/) are working fine. I have missed this change in the previous commit since I was testing the solution with an ``gh-pages`` branch that already had the missing ``index.html`` file.

This file is linked to the ``README.md`` file located in the root directory, but this was being renamed by the ``make multiversion command``.  What I really was looking for instead was to rename in runtime the ``README.md`` files related documentation, which in practice means to skip a directory level when looking for them.