### PR TITLE
rebrand docs for scylla

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ the [upgrade guide](/upgrade_guide/).
 
 
 ## License
-&copy; ScyllaDB, all rights reserved.
+&copy; ScyllaDB, all rights reserved. &copy; DataStax, Inc.
 
 © 2016, The Apache Software Foundation.
 
@@ -124,4 +124,3 @@ Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apach
 Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States 
 and/or other countries. 
 No endorsement by The Apache Software Foundation is implied by the use of these marks.
-

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 ```eval_rst
 :orphan:
 ```
-# Datastax Java Driver for Apache Cassandra®
+# Scylla Java Driver for Apache Cassandra®
 
 *If you're reading this on github.com, please note that this is the readme
 for the development version and that some features described here might
 not yet have been released. You can find the documentation for the latest
 version through the [Java driver
-docs](http://docs.datastax.com/en/developer/java-driver/latest/index.html) or via the release tags,
+docs](https://docs.scylladb.com/using-scylla/scylla-java-driver/) or via the release tags,
 [e.g.
-3.10.0](https://github.com/datastax/java-driver/tree/3.10.0).*
+3.10.0](https://github.com/scylladb/java-driver/releases/tag/3.10.2-scylla-0).*
 
 A modern, [feature-rich](manual/) and highly tunable Java client
 library for Apache Cassandra (2.1+) and using exclusively Cassandra's binary protocol 
-and Cassandra Query Language v3. _Use the [DataStax Enterprise Java driver][dse-driver]
-for better compatibility and support for DataStax Enterprise._
+and Cassandra Query Language v3.
 
 **Features:**
 
+* Like all Scylla Drivers, the Scylla Java Driver is **Shard Aware** and contains extensions for a ``tokenAwareHostPolicy`` supported by Scylla 2.3 and onwards. 
+  Using this policy, the driver can select a connection to a particular shard based on the shard’s token. 
+  As a result, latency is significantly reduced because there is no need to pass data between the shards.
 * [Sync](manual/) and [Async](manual/async/) API
 * [Simple](manual/statements/simple/), [Prepared](manual/statements/prepared/), and [Batch](manual/statements/batch/)
   statements
@@ -46,25 +48,16 @@ The driver contains the following modules:
 
 **Useful links:**
 
-- JIRA (bug tracking): https://datastax-oss.atlassian.net/browse/JAVA
-- MAILING LIST: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
-- DATASTAX ACADEMY SLACK: #datastax-drivers on https://academy.datastax.com/slack 
-- TWITTER: [@dsJavaDriver](https://twitter.com/dsJavaDriver) tweets Java
-  driver releases and important announcements (low frequency).
-  [@DataStaxEng](https://twitter.com/datastaxeng) has more news including
-  other drivers, Cassandra, and DSE.
-- DOCS: the [manual](http://docs.datastax.com/en/developer/java-driver/3.10/manual/) has quick
+- SCYLLA UNIVERSITY JAVA [CLASS](https://university.scylladb.com/courses/using-scylla-drivers/lessons/coding-with-java-part-1/) 
+- DOCS: the [manual](https://docs.scylladb.com/using-scylla/scylla-java-driver) has quick
   start material and technical details about the driver and its features.
-- API: https://docs.datastax.com/en/drivers/java/3.10
-- GITHUB REPOSITORY: https://github.com/datastax/java-driver
+- GITHUB REPOSITORY: https://github.com/scylladb/java-driver
 - [changelog](changelog/)
-- [binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.0.tar.gz)
 
 ## Getting the driver
 
 The last release of the driver is available on Maven Central. You can install
-it in your application using the following Maven dependency (_if
-using DataStax Enterprise, install the [DataStax Enterprise Java driver][dse-driver] instead_):
+it in your application using the following Maven dependency 
 
 ```xml
 <dependency>
@@ -98,54 +91,38 @@ The 'extras' module is also published as a separate artifact:
 We also provide a [shaded JAR](manual/shaded_jar/)
 to avoid the explicit dependency to Netty.
 
-If you can't use a dependency management tool, a
-[binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.0.tar.gz)
-is available for download.
-
 ## Compatibility
 
-The Java client driver 3.10.0 ([branch 3.x](https://github.com/datastax/java-driver/tree/3.x)) is compatible with Apache
-Cassandra 2.1, 2.2 and 3.0+ (see [this page](http://docs.datastax.com/en/developer/java-driver/latest/manual/native_protocol/) for
-the most up-to-date compatibility information).
+The Java client driver 3.10.0 ([branch 3.x](https://github.com/scylladb/java-driver/tree/3.x)) is compatible with Apache
+Cassandra 2.1, 2.2 and 3.0+.
 
-UDT and tuple support is available only when using Apache Cassandra 2.1 or higher (see [CQL improvements in Cassandra 2.1](http://www.datastax.com/dev/blog/cql-in-2-1)).
+UDT and tuple support is available only when using Apache Cassandra 2.1 or higher.
 
 Other features are available only when using Apache Cassandra 2.0 or higher (e.g. result set paging,
-[BatchStatement](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java),
-[lightweight transactions](http://www.datastax.com/documentation/cql/3.1/cql/cql_using/use_ltweight_transaction_t.html) 
--- see [What's new in Cassandra 2.0](http://www.datastax.com/documentation/cassandra/2.0/cassandra/features/features_key_c.html)). 
-Trying to use these with a cluster running Cassandra 1.2 will result in 
-an [UnsupportedFeatureException](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java) being thrown.
+[lightweight transactions](https://docs.scylladb.com/using-scylla/lwt/))
 
 The java driver supports Java JDK versions 6 and above.
 
-If using _DataStax Enterprise_, the [DataStax Enterprise Java driver][dse-driver] provides 
-more features and better compatibility.
 
-__Disclaimer__: Some _DataStax/DataStax Enterprise_ products might partially work on 
-big-endian systems, but _DataStax_ does not officially support these systems.
+
+__Disclaimer__: Some _Scylla_ products might partially work on 
+big-endian systems, but _Scylla_ does not officially support these systems.
 
 ## Upgrading from previous versions
 
 If you are upgrading from a previous version of the driver, be sure to have a look at
 the [upgrade guide](/upgrade_guide/).
 
-If you are upgrading to _DataStax Enterprise_, use the [DataStax Enterprise Java driver][dse-driver] for more
-features and better compatibility.
+
 
 ## License
-&copy; DataStax, Inc.
+&copy; ScyllaDB, all rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+© 2016, The Apache Software Foundation.
 
-http://www.apache.org/licenses/LICENSE-2.0
+Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apache Cassandra® 
+Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States 
+and/or other countries. 
+No endorsement by The Apache Software Foundation is implied by the use of these marks.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
-[dse-driver]: http://docs.datastax.com/en/developer/java-driver-dse/latest/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```eval_rst
 :orphan:
 ```
-# Scylla Java Driver for Apache Cassandra®
+# Java Driver for Scylla and Apache Cassandra®
 
 *If you're reading this on github.com, please note that this is the readme
 for the development version and that some features described here might
@@ -124,5 +124,4 @@ Apache®, Apache Cassandra®, Cassandra®, the Apache feather logo and the Apach
 Eye logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States 
 and/or other countries. 
 No endorsement by The Apache Software Foundation is implied by the use of these marks.
-
 


### PR DESCRIPTION
Rebrands the ReadMe page for Scylla 
Changing Links to Scylla sources
Removes Datastax and Datastax enterprise
