### PR TITLE
Add shard awareness tests

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -67,6 +67,7 @@ import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import java.lang.ref.WeakReference;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -165,6 +166,10 @@ class Connection {
   }
 
   ListenableFuture<Void> initAsync() {
+    return initAsync(0);
+  }
+
+  ListenableFuture<Void> initAsync(int localPort) {
     if (factory.isShutdown)
       return Futures.immediateFailedFuture(
           new ConnectionException(endPoint, "Connection factory is shut down"));
@@ -191,7 +196,8 @@ class Connection {
                   ? factory.manager.metrics
                   : null));
 
-      ChannelFuture future = bootstrap.connect(endPoint.resolve());
+      ChannelFuture future =
+          bootstrap.connect(endPoint.resolve(), new InetSocketAddress(localPort));
 
       writer.incrementAndGet();
       future.addListener(
@@ -1101,10 +1107,16 @@ class Connection {
     Connection open(HostConnectionPool pool)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
+      return open(pool, 0);
+    }
+
+    Connection open(HostConnectionPool pool, int localPort)
+        throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
+            ClusterNameMismatchException {
       pool.host.convictionPolicy.signalConnectionsOpening(1);
       Connection connection = new Connection(buildConnectionName(pool.host), pool.host, this, pool);
       try {
-        connection.initAsync().get();
+        connection.initAsync(localPort).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -166,10 +166,10 @@ class Connection {
   }
 
   ListenableFuture<Void> initAsync() {
-    return initAsync(0);
+    return initAsync(0, 0);
   }
 
-  ListenableFuture<Void> initAsync(int localPort) {
+  ListenableFuture<Void> initAsync(int localPort, int serverPort) {
     if (factory.isShutdown)
       return Futures.immediateFailedFuture(
           new ConnectionException(endPoint, "Connection factory is shut down"));
@@ -196,8 +196,12 @@ class Connection {
                   ? factory.manager.metrics
                   : null));
 
-      ChannelFuture future =
-          bootstrap.connect(endPoint.resolve(), new InetSocketAddress(localPort));
+      InetSocketAddress serverAddress =
+          (serverPort == 0)
+              ? endPoint.resolve()
+              : new InetSocketAddress(endPoint.resolve().getAddress(), serverPort);
+
+      ChannelFuture future = bootstrap.connect(serverAddress, new InetSocketAddress(localPort));
 
       writer.incrementAndGet();
       future.addListener(
@@ -1107,16 +1111,16 @@ class Connection {
     Connection open(HostConnectionPool pool)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
-      return open(pool, 0);
+      return open(pool, 0, 0);
     }
 
-    Connection open(HostConnectionPool pool, int localPort)
+    Connection open(HostConnectionPool pool, int localPort, int serverPort)
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
       pool.host.convictionPolicy.signalConnectionsOpening(1);
       Connection connection = new Connection(buildConnectionName(pool.host), pool.host, this, pool);
       try {
-        connection.initAsync(localPort).get();
+        connection.initAsync(localPort, serverPort).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -411,14 +411,12 @@ class HostConnectionPool implements Connection.Owner {
       if (host.convictionPolicy.canReconnectNow()) {
         if (connectionsPerShard == 0) {
           maybeSpawnNewConnection(shardId);
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         } else if (scheduledForCreation[shardId].compareAndSet(0, connectionsPerShard)) {
           for (int i = 0; i < connectionsPerShard; i++) {
             // We don't respect MAX_SIMULTANEOUS_CREATION here because it's  only to
             // protect against creating connection in excess of core too quickly
             manager.blockingExecutor().submit(new ConnectionTask(shardId));
           }
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         }
       }
       // connections for this shard are still being initialized so pick connection for any shard

--- a/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ShardingInfo.java
@@ -25,18 +25,25 @@ public class ShardingInfo {
   private static final String SCYLLA_PARTITIONER = "SCYLLA_PARTITIONER";
   private static final String SCYLLA_SHARDING_ALGORITHM = "SCYLLA_SHARDING_ALGORITHM";
   private static final String SCYLLA_SHARDING_IGNORE_MSB = "SCYLLA_SHARDING_IGNORE_MSB";
+  private static final String SCYLLA_SHARD_AWARE_PORT = "SCYLLA_SHARD_AWARE_PORT";
 
   private final int shardsCount;
   private final String partitioner;
   private final String shardingAlgorithm;
   private final int shardingIgnoreMSB;
+  private final int shardAwarePort;
 
   private ShardingInfo(
-      int shardsCount, String partitioner, String shardingAlgorithm, int shardingIgnoreMSB) {
+      int shardsCount,
+      String partitioner,
+      String shardingAlgorithm,
+      int shardingIgnoreMSB,
+      int shardAwarePort) {
     this.shardsCount = shardsCount;
     this.partitioner = partitioner;
     this.shardingAlgorithm = shardingAlgorithm;
     this.shardingIgnoreMSB = shardingIgnoreMSB;
+    this.shardAwarePort = shardAwarePort;
   }
 
   public int getShardsCount() {
@@ -55,6 +62,10 @@ public class ShardingInfo {
     return (int) (sum >>> 32);
   }
 
+  public int getShardAwarePort() {
+    return shardAwarePort;
+  }
+
   public static class ConnectionShardingInfo {
     public final int shardId;
     public final ShardingInfo shardingInfo;
@@ -71,6 +82,7 @@ public class ShardingInfo {
     String partitioner = parseString(params, SCYLLA_PARTITIONER);
     String shardingAlgorithm = parseString(params, SCYLLA_SHARDING_ALGORITHM);
     Integer shardingIgnoreMSB = parseInt(params, SCYLLA_SHARDING_IGNORE_MSB);
+    Integer shardAwarePort = parseInt(params, SCYLLA_SHARD_AWARE_PORT);
     if (shardId == null
         || shardsCount == null
         || partitioner == null
@@ -80,8 +92,13 @@ public class ShardingInfo {
         || !shardingAlgorithm.equals("biased-token-round-robin")) {
       return null;
     }
+    if (shardAwarePort == null) {
+      shardAwarePort = 0;
+    }
     return new ConnectionShardingInfo(
-        shardId, new ShardingInfo(shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB));
+        shardId,
+        new ShardingInfo(
+            shardsCount, partitioner, shardingAlgorithm, shardingIgnoreMSB, shardAwarePort));
   }
 
   private static String parseString(Map<String, List<String>> params, String key) {

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/SocketUtils.java
@@ -1,0 +1,23 @@
+package com.datastax.driver.core.utils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+public class SocketUtils {
+
+  public static boolean isTcpPortAvailable(int port) {
+    try {
+      ServerSocket serverSocket = new ServerSocket();
+      try {
+        serverSocket.setReuseAddress(false);
+        serverSocket.bind(new InetSocketAddress(port), 1);
+        return true;
+      } finally {
+        serverSocket.close();
+      }
+    } catch (IOException ex) {
+      return false;
+    }
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -169,6 +169,8 @@ public class CCMBridge implements CCMAccess {
 
   static {
     String inputCassandraVersion = System.getProperty("cassandra.version");
+    String inputScyllaVersion = System.getProperty("scylla.version");
+
     String installDirectory = System.getProperty("cassandra.directory");
     String branch = System.getProperty("cassandra.branch");
 
@@ -177,7 +179,10 @@ public class CCMBridge implements CCMAccess {
       installArgs.add("--install-dir=" + new File(installDirectory).getAbsolutePath());
     } else if (branch != null && !branch.trim().isEmpty()) {
       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
-    } else {
+    } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+      installArgs.add(" --scylla ");
+      installArgs.add("-v " + inputScyllaVersion);
+    } else if (inputCassandraVersion != null && !inputCassandraVersion.trim().isEmpty()) {
       installArgs.add("-v " + inputCassandraVersion);
     }
 
@@ -311,6 +316,8 @@ public class CCMBridge implements CCMAccess {
 
   private final String ipPrefix;
 
+  private final String idPrefix;
+
   private final File ccmDir;
 
   private final boolean isDSE;
@@ -332,6 +339,7 @@ public class CCMBridge implements CCMAccess {
       VersionNumber cassandraVersion,
       VersionNumber dseVersion,
       String ipPrefix,
+      String idPrefix,
       int storagePort,
       int thriftPort,
       int binaryPort,
@@ -343,6 +351,8 @@ public class CCMBridge implements CCMAccess {
     this.cassandraVersion = cassandraVersion;
     this.dseVersion = dseVersion;
     this.ipPrefix = ipPrefix;
+    this.idPrefix = idPrefix;
+
     this.storagePort = storagePort;
     this.thriftPort = thriftPort;
     this.binaryPort = binaryPort;
@@ -863,6 +873,7 @@ public class CCMBridge implements CCMAccess {
     private static final Pattern RANDOM_PORT_PATTERN = Pattern.compile(RANDOM_PORT);
 
     private String ipPrefix = TestUtils.IP_PREFIX;
+    private String idPrefix = "0";
     int[] nodes = {1};
     private int[] jmxPorts = {};
     private boolean start = true;
@@ -886,6 +897,11 @@ public class CCMBridge implements CCMAccess {
      */
     public Builder withIpPrefix(String ipPrefix) {
       this.ipPrefix = ipPrefix;
+      return this;
+    }
+
+    public Builder withIdPrefix(String idPrefix) {
+      this.idPrefix = idPrefix;
       return this;
     }
 
@@ -1067,6 +1083,7 @@ public class CCMBridge implements CCMAccess {
               cassandraVersion,
               dseVersion,
               ipPrefix,
+              idPrefix,
               storagePort,
               thriftPort,
               binaryPort,
@@ -1151,6 +1168,7 @@ public class CCMBridge implements CCMAccess {
       StringBuilder result = new StringBuilder(CCM_COMMAND + " create");
       result.append(" ").append(clusterName);
       result.append(" -i ").append(ipPrefix);
+      result.append(" --id ").append(idPrefix);
       result.append(" ");
       if (nodes.length > 0) {
         result.append(" -n ");

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1046,6 +1046,13 @@ public class CCMBridge implements CCMAccess {
       int binaryPort =
           Integer.parseInt(cassandraConfiguration.get("native_transport_port").toString());
 
+      if (binaryPort == 0) {
+        // for test in scylla we disable the main protocol to test the
+        // `native_shard_aware_transport_port`
+        binaryPort =
+            Integer.parseInt(
+                cassandraConfiguration.get("native_shard_aware_transport_port").toString());
+      }
       // Copy any supplied jmx ports over, and find available ports for the rest
       int numNodes = 0;
       for (int i : nodes) {

--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwareTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwareTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright ScyllaDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.CreateCCM.TestMode.PER_CLASS;
+
+import com.datastax.driver.core.QueryTrace.Event;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+@CreateCCM(PER_CLASS)
+@CCMConfig(numberOfNodes = 3, config = "ring_delay_ms:10000")
+public class ShardAwareTest extends CCMTestsSupport {
+
+  static final Logger logger = LoggerFactory.getLogger(ShardAwareTest.class);
+
+  static void createKeyspaceAndColumnFamily(Session session) {
+    session.execute("DROP KEYSPACE IF EXISTS preparedtests");
+    session.execute(
+        "CREATE KEYSPACE preparedtests WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
+    session.execute("USE preparedtests");
+    session.execute("CREATE TABLE cf0 (a text, b text, c text, PRIMARY KEY (a, b))");
+  }
+
+  void createData(Session session) {
+    session.execute("USE preparedtests");
+    PreparedStatement prepared = session.prepare("INSERT INTO cf0 (a, b, c) VALUES  (?, ?, ?)");
+
+    BoundStatement bs1 = prepared.bind();
+    bs1.setString("a", "a");
+    bs1.setString("b", "b");
+    bs1.setString("c", "c");
+    session.execute(bs1);
+
+    BoundStatement bs2 = prepared.bind();
+    bs2.setString("a", "e");
+    bs2.setString("b", "f");
+    bs2.setString("c", "g");
+    session.execute(bs2);
+
+    BoundStatement bs3 = prepared.bind();
+    bs3.setString("a", "100000");
+    bs3.setString("b", "f");
+    bs3.setString("c", "g");
+    session.execute(bs3);
+  }
+
+  class isLocalQuery<E> implements Predicate<Event> {
+
+    @Override
+    public boolean test(Event x) {
+      return x.getDescription().contains("querying locally");
+    }
+  }
+
+  void verifySameShardInTracing(ResultSet results, String shardName) {
+    ExecutionInfo executionInfo = results.getExecutionInfo();
+
+    QueryTrace trace = executionInfo.getQueryTrace();
+
+    logger.info(
+        "'{}' to {} took {}μs",
+        trace.getRequestType(),
+        trace.getCoordinator(),
+        trace.getDurationMicros());
+    for (Event event : trace.getEvents()) {
+      logger.info(
+          "  {} - {} - [{}] - {}",
+          event.getSourceElapsedMicros(),
+          event.getSource(),
+          event.getThreadName(),
+          event.getDescription());
+      assertThat(event.getThreadName()).isEqualTo(shardName);
+    }
+    assertThat(trace.getEvents().stream().anyMatch(new isLocalQuery<Event>()));
+  }
+
+  void queryData(Session session, boolean verifyInTracing) {
+    PreparedStatement prepared = session.prepare("SELECT * FROM cf0 WHERE a=? AND b=?");
+
+    BoundStatement bs1 = prepared.bind();
+    bs1.setString("a", "a");
+    bs1.setString("b", "b");
+    bs1.enableTracing();
+    ResultSet results1 = session.execute(bs1);
+    Row row1 = results1.one();
+    assertThat(row1).isNotNull();
+    assertThat(row1.getString("a")).isEqualTo("a");
+    assertThat(row1.getString("b")).isEqualTo("b");
+    assertThat(row1.getString("c")).isEqualTo("c");
+
+    if (verifyInTracing) {
+      this.verifySameShardInTracing(results1, "shard 1");
+    }
+
+    BoundStatement bs2 = prepared.bind();
+    bs2.setString("a", "100000");
+    bs2.setString("b", "f");
+    bs2.enableTracing();
+
+    ResultSet results2 = session.execute(bs2);
+    Row row2 = results2.one();
+    assertThat(row2).isNotNull();
+    assertThat(row2.getString("a")).isEqualTo("100000");
+    assertThat(row2.getString("b")).isEqualTo("f");
+    assertThat(row2.getString("c")).isEqualTo("g");
+
+    if (verifyInTracing) {
+      this.verifySameShardInTracing(results2, "shard 0");
+    }
+    BoundStatement bs3 = prepared.bind();
+    bs3.setString("a", "e");
+    bs3.setString("b", "f");
+    bs3.enableTracing();
+
+    ResultSet results3 = session.execute(bs3);
+
+    if (verifyInTracing) {
+      this.verifySameShardInTracing(results3, "shard 1");
+    }
+  }
+
+  @Test(groups = "short")
+  public void verify_same_shard_in_tracing() throws InterruptedException {
+
+    LoadBalancingPolicy loadBalancingPolicy = new TokenAwarePolicy(new RoundRobinPolicy());
+
+    ReconnectionPolicy reconnectionPolicy = new ConstantReconnectionPolicy(1 * 1000);
+
+    // We pass only the first host as contact point, so we know the control connection will be on
+    // this host
+    Cluster cluster =
+        register(
+            Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
+                .withReconnectionPolicy(reconnectionPolicy)
+                .withLoadBalancingPolicy(loadBalancingPolicy)
+                .build());
+    cluster.init();
+    Session session = cluster.connect();
+
+    createKeyspaceAndColumnFamily(session);
+    createData(session);
+    this.queryData(session, true);
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ShardingInfoTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardingInfoTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright ScyllaDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class ShardingInfoTest {
+
+  @Test(groups = "unit")
+  public void should_parsing_and_calculating_shard_id() {
+    /** verify that our murmur hash takes us to correct shard for specific keys */
+    Token.Factory factory = Token.M3PToken.FACTORY;
+
+    Map<String, List<String>> params =
+        new HashMap<String, List<String>>() {
+          {
+            put(
+                "SCYLLA_SHARD",
+                new ArrayList<String>() {
+                  {
+                    add("1");
+                  }
+                });
+            put(
+                "SCYLLA_NR_SHARDS",
+                new ArrayList<String>() {
+                  {
+                    add("12");
+                  }
+                });
+            put(
+                "SCYLLA_PARTITIONER",
+                new ArrayList<String>() {
+                  {
+                    add("org.apache.cassandra.dht.Murmur3Partitioner");
+                  }
+                });
+            put(
+                "SCYLLA_SHARDING_ALGORITHM",
+                new ArrayList<String>() {
+                  {
+                    add("biased-token-round-robin");
+                  }
+                });
+            put(
+                "SCYLLA_SHARDING_IGNORE_MSB",
+                new ArrayList<String>() {
+                  {
+                    add("12");
+                  }
+                });
+          }
+        };
+    ShardingInfo.ConnectionShardingInfo sharding = ShardingInfo.parseShardingInfo(params);
+    assertThat(sharding.shardId).isEqualTo(1);
+
+    byte[] byte_array1 = {
+      'a',
+    };
+    assertThat(sharding.shardingInfo.shardId(factory.hash(ByteBuffer.wrap(byte_array1))))
+        .isEqualTo(4);
+
+    byte[] byte_array2 = {
+      'b',
+    };
+    assertThat(sharding.shardingInfo.shardId(factory.hash(ByteBuffer.wrap(byte_array2))))
+        .isEqualTo(6);
+
+    byte[] byte_array3 = {
+      'c',
+    };
+    assertThat(sharding.shardingInfo.shardId(factory.hash(ByteBuffer.wrap(byte_array3))))
+        .isEqualTo(6);
+
+    byte[] byte_array4 = {
+      'e',
+    };
+    assertThat(sharding.shardingInfo.shardId(factory.hash(ByteBuffer.wrap(byte_array4))))
+        .isEqualTo(4);
+
+    byte[] byte_array5 = {'1', '0', '0', '0', '0', '0'};
+    assertThat(sharding.shardingInfo.shardId(factory.hash(ByteBuffer.wrap(byte_array5))))
+        .isEqualTo(2);
+  }
+}


### PR DESCRIPTION
Adapting few tests from scylladb/python-driver, to cover the shard aware.
Building it ontop of #36, to try and test the new usage of shard-aware port (not done yet)