### PR TITLE
docs: add multiversion_regex_builder

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
     - latest
-    tags:       
-    - '**'
+    paths:
+    - 'docs/**'
 jobs:
   release:
     name: Build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -76,3 +76,6 @@ multiversion: setup
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+.PHONY: multiversionpreview
+multiversionpreview: multiversion
+	$(POETRY) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ from docutils import nodes
 from sphinx.util import logging
 from recommonmark.transform import AutoStructify
 from recommonmark.parser import CommonMarkParser, splitext, urlparse
+from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +195,8 @@ redirects_file = "_utils/redirections.yaml"
 # -- Options for multiversion extension ----------------------------------
 
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = r'None'
+TAGS = []
+smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
 smv_branch_whitelist = r"^latest$"
 # Defines which version is considered to be the latest stable version.


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/86

The new built-in function `multiversion_regex_builder(versions)` enables maintainers to define versions in an array instead of defining complex regex expressions.

## Example

**Before:** 

`smv_tag_whitelist = r'\b(3.22.0-scylla|3.21.0-scylla|3.22.3-scylla|3.24.0-scylla)\b'`

**Now:** 

`TAGS = ['3.21.0-scylla', '3.22.0-scylla', '3.22.3-scylla', '3.24.0-scylla']`

The PR  also adds a new command ``make multiversionpreview`` that launches a webserver to quickly preview the multiversion build.

## How to test this PR

1. Run ``make multiversionpreview``.
2. Open http://0.0.0.0:5500 in a new browser tab.
3. You should see the page rendered.