### PR TITLE
Add parsing of Scylla extensions metadata

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
@@ -317,6 +317,13 @@ public abstract class AbstractTableMetadata {
           .append("memtable_flush_period_in_ms = ")
           .append(options.getMemtableFlushPeriodInMs());
     }
+    for (Map.Entry<String, Map<String, String>> mapExtension :
+        options.getMapExtensions().entrySet()) {
+      and(sb, formatted)
+          .append(mapExtension.getKey())
+          .append(" = ")
+          .append(formatOptionMap(mapExtension.getValue()));
+    }
     sb.append(';');
     return sb;
   }

--- a/driver-core/src/main/java/com/datastax/driver/core/MapExtensionReader.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MapExtensionReader.java
@@ -1,0 +1,58 @@
+package com.datastax.driver.core;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MapExtensionReader {
+  private static final Logger logger = LoggerFactory.getLogger(MapExtensionReader.class);
+
+  private final ByteBuffer rawData;
+
+  public MapExtensionReader(ByteBuffer rawData) {
+    // Make a shallow copy, so that changing
+    // position of rawData in MapExtensionReader
+    // will not modify original rawData
+    // (but without the cost of copying the
+    // underlying data).
+    //
+    // Also read in LITTLE_ENDIAN.
+    this.rawData = Preconditions.checkNotNull(rawData).slice().order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  public Map<String, String> parse() {
+    ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+
+    int numElements = parseInt();
+    Preconditions.checkArgument(numElements >= 0);
+
+    for (int i = 0; i < numElements; i++) {
+      try {
+        String key = parseString();
+        String value = parseString();
+        builder.put(key, value);
+      } catch (UnsupportedEncodingException ex) {
+        logger.warn("Encoding exception while parsing extension map metadata", ex);
+      }
+    }
+
+    return builder.build();
+  }
+
+  private String parseString() throws UnsupportedEncodingException {
+    int length = parseInt();
+    byte[] rawString = new byte[length];
+    rawData.get(rawString);
+    return new String(rawString, "UTF-8");
+  }
+
+  private int parseInt() {
+    // Parse little-endian 32-bit integer.
+    return rawData.getInt();
+  }
+}


### PR DESCRIPTION
Add parsing of Scylla-specific extensions, which contain metadata represented as `Map<String, String>`. Those extensions are:

- Scylla CDC
- Scylla Encryption at Rest
- Scylla Alternator Tags

Add accessors of those extensions options, so for example `getScyllaCDCOptions()` returning information about CDC (TTL, whether pre/postimage is enabled) which was previously not easily accessible from client code, due to binary encoding of this data.

Extend appendOptions to also print extension information, so for example `WITH cdc = {...}` is now visible inside `TableMetadata::toString()` and can be copied as-is as a CQL query.