### PR TITLE
docs: updated url

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -2,11 +2,10 @@
 
 # Copy contents
 mkdir gh-pages
-cp -r ./docs/_build/dirhtml/* gh-pages
+cp -r ./docs/_build/dirhtml/. gh-pages
 
 # Create gh-pages branch
 cd gh-pages
-touch .nojekyll
 git init
 git config --local user.email "action@scylladb.com"
 git config --local user.name "GitHub Action"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ def setup(app):
     app.add_transform(AutoStructify)
 
     # Replace DataStax links
-    replacements = {r'https://docs.datastax.com/en/drivers/java\/(.*?)\/': "https://scylladb.github.io/java-driver/latest/api/"}
+    replacements = {r'https://docs.datastax.com/en/drivers/java\/(.*?)\/': "https://java-driver.docs.scylladb.com/latest/api/"}
     app.add_config_value('replacements', replacements, True)
     app.connect('source-read', replace_relative_links)
 
@@ -145,7 +145,7 @@ html_style = ''
 #
 html_theme_options = {
     'header_links': [
-    ('Scylla Java Driver', 'https://scylladb.github.io/java-driver/'),
+    ('Scylla Java Driver', 'https://java-driver.docs.scylladb.com/'),
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
     ('Scylla University', 'https://university.scylladb.com/'),
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
@@ -174,7 +174,7 @@ html_sidebars = {'**': ['side-nav.html']}
 htmlhelp_basename = 'ScyllaDocumentationdoc'
 
 # URL which points to the root of the HTML documentation. 
-html_baseurl = 'https://scylladb.github.io/java-driver'
+html_baseurl = 'https://java-driver.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/88

Once this commit is merged, the docs will be published under the new domain name https://java-driver.docs.scylladb.com

## Frequently asked questions

> Should we change the links in the README/docs folder?

GitHub automatically handles the redirections. For example, https://scylladb.github.io/sphinx-scylladb-theme/stable/examples/index.html redirects to https://sphinx-theme.scylladb.com/stable/examples/index.html
Nevertheless, it would be great to change URLs progressively to avoid the 301 redirections.

> Do I need to add this new domain in the custom dns domain section on GitHub settings?

It is not necessary. We have already edited the DNS for this domain and the theme creates programmatically the required CNAME file. If everything goes well, GitHub should detect the new URL after this PR is merged.

> The DNS doesn't seem to have the right SSL certificates

GitHub handles the certificate provisioning but is not aware of the subdomain for this repo yet.  ``make multi-version`` will create a  new file "CNAME". This is published in `gh-pages` branch, therefore GitHub should create the missing cert.

## How to test this PR

1. Run ``make multiversion``.
2. You should see ``CNAME`` and ``.nojekyll`` files under the ``docs/_build/dirhtml`` folder.
3. The contents of the CNAME file should be ``java-driver.docs.scylladb.com``