### PR TITLE
Fix connection error when compression turned on

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -351,11 +351,18 @@ class Connection {
               host.setLwtInfo(lwt);
             }
             return MoreFutures.VOID_SUCCESS;
+          case ERROR:
+            Responses.Error error = (Responses.Error) response;
+            throw new TransportException(
+                endPoint,
+                String.format(
+                    "Got ERROR response message from server to an OPTIONS message: %s",
+                    error.message));
           default:
             throw new TransportException(
                 endPoint,
                 String.format(
-                    "Unexpected %s response message from server to a OPTIONS message",
+                    "Unexpected %s response message from server to an OPTIONS message",
                     response.type));
         }
       }
@@ -1472,6 +1479,15 @@ class Connection {
             case SUPPORTED:
               logger.debug("{} heartbeat query succeeded", connection);
               break;
+            case ERROR:
+              Responses.Error error = (Responses.Error) response;
+              fail(
+                  connection,
+                  new ConnectionException(
+                      connection.endPoint,
+                      String.format(
+                          "Got ERROR response message from server to a heartbeat query: %s",
+                          error.message)));
             default:
               fail(
                   connection,

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -351,8 +351,12 @@ class Frame {
     @Override
     protected void encode(ChannelHandlerContext ctx, Frame frame, List<Object> out)
         throws Exception {
-      // Never compress STARTUP messages
-      if (frame.header.opcode == Message.Request.Type.STARTUP.opcode) {
+      // Never compress STARTUP and OPTIONS messages, because
+      // they could be sent before the server turned on support
+      // for compression (compression type is sent in a STARTUP message
+      // and we are sending OPTIONS message before a STARTUP message).
+      if (frame.header.opcode == Message.Request.Type.STARTUP.opcode
+          || frame.header.opcode == Message.Request.Type.OPTIONS.opcode) {
         out.add(frame);
       } else {
         frame.header.flags.add(Header.Flag.COMPRESSED);


### PR DESCRIPTION
Fix connection error when compression is turned on (issue https://github.com/scylladb/java-driver/issues/62) by turning off compression when sending `OPTIONS` messages to the server.

Commit 72858f0 changed the order of initial messages sent to the server when establishing a connection. Before, a `STARTUP` and then an `OPTIONS` message was sent. After that commit, an `OPTIONS` message is sent before a `STARTUP` message.

This order is allowed by CQL protocol specification, however a `STARTUP` message sets up compression on the server side (sending the compression type). But the `OPTIONS` request sent before `STARTUP` was sending the request compressed, so the server responded with `ERROR` (as it didn't know the compression type). This resulted in a failure to connect to the cluster.

Improve exception messages after receiving `ERROR` message - before it was lacking the response message (error cause), which made it difficult to determine the root cause of issue #62.

Fixes #62.