### PR TITLE
docs: build for default branch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,6 +144,7 @@ html_style = ''
 # documentation.
 #
 html_theme_options = {
+    'branch_substring_removed': 'scylla-',
     'header_links': [
     ('Scylla Java Driver', 'https://java-driver.docs.scylladb.com/'),
     ('Scylla Cloud', 'https://docs.scylladb.com/scylla-cloud/'),
@@ -151,6 +152,7 @@ html_theme_options = {
     ('ScyllaDB Home', 'https://www.scylladb.com/')],
     'github_issues_repository': 'scylladb/java-driver',
     'show_sidebar_index': True,
+    'hide_version_dropdown': ['scylla-3.x'],
 }
 
 extlinks = {
@@ -198,7 +200,7 @@ redirects_file = "_utils/redirections.yaml"
 TAGS = []
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
 # Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['scylla-3.7.2.x', 'scylla-3.10.2.x']
+BRANCHES = ['scylla-3.x', 'scylla-3.7.2.x', 'scylla-3.10.2.x']
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
 # Must be listed in smv_tag_whitelist or smv_branch_whitelist.


### PR DESCRIPTION
Related issues https://github.com/scylladb/sphinx-scylladb-theme/issues/157

## Context

Adds the new option ``hide_version_dropdown``, which hides a list of tags and branch names from the multi-version dropdown.
It also removes the substring ``scylla-`` from the multi version dropdown.

## How to test this PR

1. Run ``make multiversionpreview``.

2. You should be able to preview http://0.0.0.0:5500/scylla-3.x/, but scylla-3.x should not appear as an option in the dropdown located at the right sidebar.

3. The banner at the top of the page should say:

"You are reading an unstable version of this documentation"