### PR TITLE
[v3] Implement advanced shard awareness

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -97,6 +97,8 @@ class HostConnectionPool implements Connection.Owner {
 
   private final AtomicReference<CloseFuture> closeFuture = new AtomicReference<CloseFuture>();
 
+  private long advShardAwarenessBlockedUntil = 0;
+
   private enum Phase {
     INITIALIZING,
     READY,
@@ -170,7 +172,16 @@ class HostConnectionPool implements Connection.Owner {
       return false;
     }
 
+    if (System.currentTimeMillis() < advShardAwarenessBlockedUntil) {
+      return false;
+    }
+
     return true;
+  }
+
+  public void tempBlockAdvShardAwareness(long millis) {
+    advShardAwarenessBlockedUntil =
+        Math.max(System.currentTimeMillis() + millis, advShardAwarenessBlockedUntil);
   }
 
   private final ConnectionTasksSharedState connectionTasksSharedState =

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -421,14 +421,12 @@ class HostConnectionPool implements Connection.Owner {
       if (host.convictionPolicy.canReconnectNow()) {
         if (connectionsPerShard == 0) {
           maybeSpawnNewConnection(shardId);
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         } else if (scheduledForCreation[shardId].compareAndSet(0, connectionsPerShard)) {
           for (int i = 0; i < connectionsPerShard; i++) {
             // We don't respect MAX_SIMULTANEOUS_CREATION here because it's  only to
             // protect against creating connection in excess of core too quickly
             manager.blockingExecutor().submit(new ConnectionTask(shardId));
           }
-          return enqueue(timeout, unit, maxQueueSize, shardId);
         }
       }
       // connections for this shard are still being initialized so pick connection for any shard

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -512,7 +512,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.add(MockRequest.send(pool));
 
       // Allow time for new connection to be spawned.
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
       assertPoolSize(pool, 2);
 
       // Borrow more and ensure the connection returned is a non-core connection.
@@ -563,7 +563,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.add(MockRequest.send(pool));
 
       // Reaching the threshold should have triggered the creation of an extra one
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
       assertPoolSize(pool, 2);
     } finally {
       MockRequest.completeAll(allRequests);
@@ -796,7 +796,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.addAll(requests);
       allRequests.add(MockRequest.send(pool));
 
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
       assertThat(pool.connections[0]).hasSize(2);
 
       // Grab the new non-core connection and replace it with a spy.
@@ -1199,7 +1199,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       Uninterruptibles.sleepUninterruptibly(reconnectInterval, TimeUnit.MILLISECONDS);
 
       // Reconnection mechanism should fill missing connections by now.
-      verify(factory, timeout(readTimeout).times(4)).open(any(HostConnectionPool.class), anyInt());
+      verify(factory, timeout(readTimeout).times(4))
+          .open(any(HostConnectionPool.class), anyInt(), anyInt());
       reset(factory);
       assertPoolSize(pool, 8);
     } finally {

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -27,6 +27,7 @@ import static com.datastax.driver.core.PoolingOptions.NEW_CONNECTION_THRESHOLD_L
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -511,7 +512,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.add(MockRequest.send(pool));
 
       // Allow time for new connection to be spawned.
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
       assertPoolSize(pool, 2);
 
       // Borrow more and ensure the connection returned is a non-core connection.
@@ -562,7 +563,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.add(MockRequest.send(pool));
 
       // Reaching the threshold should have triggered the creation of an extra one
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
       assertPoolSize(pool, 2);
     } finally {
       MockRequest.completeAll(allRequests);
@@ -795,7 +796,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       allRequests.addAll(requests);
       allRequests.add(MockRequest.send(pool));
 
-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
+      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt());
       assertThat(pool.connections[0]).hasSize(2);
 
       // Grab the new non-core connection and replace it with a spy.
@@ -1198,8 +1199,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       Uninterruptibles.sleepUninterruptibly(reconnectInterval, TimeUnit.MILLISECONDS);
 
       // Reconnection mechanism should fill missing connections by now.
-      verify(factory, timeout(readTimeout).times(4))
-          .open(any(HostConnectionPool.class));
+      verify(factory, timeout(readTimeout).times(4)).open(any(HostConnectionPool.class), anyInt());
       reset(factory);
       assertPoolSize(pool, 8);
     } finally {


### PR DESCRIPTION
This is continuation of #36. I addresed comments by @avelanarius - https://github.com/scylladb/java-driver/pull/36#issuecomment-903680419.

TODO:

- [x] When closing connection, free port in PortAllocator
- [x] In PortAllocator check if port is really free before returning it - I expect it should be faster (when many ports are busy) than opening Netty's channel multiple times.
- [x] Manual testing
- [x] There may be some unnecessary debug prints left, remove them.
- [x] When trying next local port, close previous channel.
- [x] Refactor initAsync changes - they are a bit ugly now.