### PR TITLE
Use paging for fetching schema tables from the cluster

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -753,6 +753,7 @@ public class Cluster implements Closeable {
     private boolean noCompact = false;
     private boolean isCloud = false;
     private boolean useAdvancedShardAwareness = true;
+    private boolean schemaQueriesPaged = true;
     private int localPortLow = ProtocolOptions.DEFAULT_LOCAL_PORT_LOW;
     private int localPortHigh = ProtocolOptions.DEFAULT_LOCAL_PORT_HIGH;
 
@@ -1496,6 +1497,19 @@ public class Cluster implements Closeable {
     }
 
     /**
+     * Disables paging in schema queries. By default, Queries that fetch schema from the cluster are
+     * paged. This option causes the least impact on the cluster latencies when a new client
+     * connects. Turning off paging may result in faster driver initialisation at the expense of
+     * higher cluster latencies.
+     *
+     * @return this builder.
+     */
+    public Builder withoutPagingInSchemaQueries() {
+      this.schemaQueriesPaged = false;
+      return this;
+    }
+
+    /**
      * Sets local port range for use by advanced shard awareness. Driver will use ports from this
      * range as local ports when connecting to cluster. If {@link #withoutAdvancedShardAwareness()}
      * was called, then setting this range does not affect anything.
@@ -1572,10 +1586,14 @@ public class Cluster implements Closeable {
 
       MetricsOptions metricsOptions = new MetricsOptions(metricsEnabled, jmxEnabled);
 
+      QueryOptions queryOptions = new QueryOptions();
+      queryOptions.setSchemaQueriesPaged(schemaQueriesPaged);
+
       return configurationBuilder
           .withProtocolOptions(protocolOptions)
           .withMetricsOptions(metricsOptions)
           .withPolicies(policiesBuilder.build())
+          .withQueryOptions(queryOptions)
           .build();
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
@@ -70,6 +70,8 @@ public class QueryOptions {
   private volatile Cluster.Manager manager;
   private volatile boolean prepareOnAllHosts = true;
 
+  private volatile boolean schemaQueriesPaged = true;
+
   /**
    * Creates a new {@link QueryOptions} instance using the {@link #DEFAULT_CONSISTENCY_LEVEL},
    * {@link #DEFAULT_SERIAL_CONSISTENCY_LEVEL} and {@link #DEFAULT_FETCH_SIZE}.
@@ -319,6 +321,26 @@ public class QueryOptions {
    */
   public boolean isMetadataEnabled() {
     return metadataEnabled;
+  }
+
+  /**
+   * Toggle schema queries paging.
+   *
+   * @param enabled whether paging is enabled in schema queries.
+   * @return this {@code QueryOptions} instance.
+   */
+  public QueryOptions setSchemaQueriesPaged(boolean enabled) {
+    this.schemaQueriesPaged = enabled;
+    return this;
+  }
+
+  /**
+   * Whether schema queries are using paging.
+   *
+   * @return the value.
+   */
+  public boolean isSchemaQueriesPaged() {
+    return schemaQueriesPaged;
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -855,6 +855,7 @@ abstract class SchemaParser {
     protected static final String SELECT_VIEWS = "SELECT * FROM system_schema.views";
 
     private static final String TABLE_NAME = "table_name";
+    private static final String VIEW_NAME = "view_name";
     private static final String LIMIT = " LIMIT 100";
 
     private List<Row> fetchUDTs(
@@ -1037,12 +1038,21 @@ abstract class SchemaParser {
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      return queryAsync(
-              SELECT_VIEWS + whereClause(KEYSPACE, keyspace.getName(), null, null),
-              connection,
-              protocolVersion)
-          .get()
-          .all();
+      String queryPrefix = SELECT_VIEWS + whereClause(KEYSPACE, keyspace.getName(), null, null);
+      List<Row> result = new ArrayList<Row>();
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        result.addAll(rs);
+        String lastSeen = "'" + result.get(result.size() - 1).getString(VIEW_NAME) + "'";
+        rs =
+            queryAsync(
+                    queryPrefix + " AND " + VIEW_NAME + " > " + lastSeen + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
+      }
+      return result;
     }
 
     private void buildTablesIndexesAndViews(

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -857,6 +857,7 @@ abstract class SchemaParser {
     private static final String TABLE_NAME = "table_name";
     private static final String VIEW_NAME = "view_name";
     private static final String COLUMN_NAME = "column_name";
+    private static final String INDEX_NAME = "index_name";
     private static final String LIMIT = " LIMIT 100";
 
     private List<Row> fetchUDTs(
@@ -1028,23 +1029,38 @@ abstract class SchemaParser {
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      ResultSet rs =
-          queryAsync(
-                  SELECT_INDEXES + whereClause(KEYSPACE, keyspace.getName(), null, null),
-                  connection,
-                  protocolVersion)
-              .get();
-      if (rs == null) return Collections.emptyMap();
-
+      String queryPrefix = SELECT_INDEXES + whereClause(KEYSPACE, keyspace.getName(), null, null);
       Map<String, List<Row>> result = Maps.newHashMap();
-      for (Row row : rs) {
-        String cfName = row.getString(TABLE_NAME);
-        List<Row> rowsByCf = result.get(cfName);
-        if (rowsByCf == null) {
-          rowsByCf = Lists.newArrayList();
-          result.put(cfName, rowsByCf);
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        String lastSeenTable = "'" + rs.get(rs.size() - 1).getString(TABLE_NAME) + "'";
+        String lastSeenIndex = "'" + rs.get(rs.size() - 1).getString(INDEX_NAME) + "'";
+        for (Row row : rs) {
+          String cfName = row.getString(TABLE_NAME);
+          List<Row> rowsByCf = result.get(cfName);
+          if (rowsByCf == null) {
+            rowsByCf = Lists.newArrayList();
+            result.put(cfName, rowsByCf);
+          }
+          rowsByCf.add(row);
         }
-        rowsByCf.add(row);
+        rs =
+            queryAsync(
+                    queryPrefix
+                        + " AND ("
+                        + TABLE_NAME
+                        + ", "
+                        + INDEX_NAME
+                        + ") > ("
+                        + lastSeenTable
+                        + ", "
+                        + lastSeenIndex
+                        + ")"
+                        + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
       }
       return result;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -861,18 +861,28 @@ abstract class SchemaParser {
     private static final String FUNCTION_NAME = "function_name";
     private static final String ARGUMENT_TYPES = "argument_types";
     private static final String AGGREGATE_NAME = "aggregate_name";
+    private static final String TYPE_NAME = "type_name";
     private static final String LIMIT = " LIMIT 100";
 
     private List<Row> fetchUDTs(
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      return queryAsync(
-              SELECT_USERTYPES + whereClause(KEYSPACE, keyspace.getName(), null, null),
-              connection,
-              protocolVersion)
-          .get()
-          .all();
+      String queryPrefix = SELECT_USERTYPES + whereClause(KEYSPACE, keyspace.getName(), null, null);
+      List<Row> result = new ArrayList<Row>();
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        result.addAll(rs);
+        String lastSeen = "'" + result.get(result.size() - 1).getString(TYPE_NAME) + "'";
+        rs =
+            queryAsync(
+                    queryPrefix + " AND " + TYPE_NAME + " > " + lastSeen + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
+      }
+      return result;
     }
 
     private void buildUDTs(

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -856,6 +856,7 @@ abstract class SchemaParser {
 
     private static final String TABLE_NAME = "table_name";
     private static final String VIEW_NAME = "view_name";
+    private static final String COLUMN_NAME = "column_name";
     private static final String LIMIT = " LIMIT 100";
 
     private List<Row> fetchUDTs(
@@ -945,24 +946,38 @@ abstract class SchemaParser {
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      ResultSet rs =
-          queryAsync(
-                  SELECT_COLUMNS + whereClause(KEYSPACE, keyspace.getName(), null, null),
-                  connection,
-                  protocolVersion)
-              .get();
-
-      if (rs == null) return Collections.emptyMap();
-
+      String queryPrefix = SELECT_COLUMNS + whereClause(KEYSPACE, keyspace.getName(), null, null);
       Map<String, Map<String, Row>> result = new HashMap<String, Map<String, Row>>();
-      for (Row row : rs) {
-        String cfName = row.getString(TABLE_NAME);
-        Map<String, Row> colsByCf = result.get(cfName);
-        if (colsByCf == null) {
-          colsByCf = new HashMap<String, Row>();
-          result.put(cfName, colsByCf);
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        String lastSeenTable = "'" + rs.get(rs.size() - 1).getString(TABLE_NAME) + "'";
+        String lastSeenColumn = "'" + rs.get(rs.size() - 1).getString(COLUMN_NAME) + "'";
+        for (Row row : rs) {
+          String cfName = row.getString(TABLE_NAME);
+          Map<String, Row> colsByCf = result.get(cfName);
+          if (colsByCf == null) {
+            colsByCf = new HashMap<String, Row>();
+            result.put(cfName, colsByCf);
+          }
+          colsByCf.put(row.getString(ColumnMetadata.COLUMN_NAME), row);
         }
-        colsByCf.put(row.getString(ColumnMetadata.COLUMN_NAME), row);
+        rs =
+            queryAsync(
+                    queryPrefix
+                        + " AND ("
+                        + TABLE_NAME
+                        + ", "
+                        + COLUMN_NAME
+                        + ") > ("
+                        + lastSeenTable
+                        + ", "
+                        + lastSeenColumn
+                        + ")"
+                        + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
       }
       return result;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -855,6 +855,7 @@ abstract class SchemaParser {
     protected static final String SELECT_VIEWS = "SELECT * FROM system_schema.views";
 
     private static final String TABLE_NAME = "table_name";
+    private static final String LIMIT = " LIMIT 100";
 
     private List<Row> fetchUDTs(
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
@@ -990,12 +991,21 @@ abstract class SchemaParser {
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      return queryAsync(
-              SELECT_TABLES + whereClause(KEYSPACE, keyspace.getName(), null, null),
-              connection,
-              protocolVersion)
-          .get()
-          .all();
+      String queryPrefix = SELECT_TABLES + whereClause(KEYSPACE, keyspace.getName(), null, null);
+      List<Row> result = new ArrayList<Row>();
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        result.addAll(rs);
+        String lastSeen = "'" + result.get(result.size() - 1).getString(TABLE_NAME) + "'";
+        rs =
+            queryAsync(
+                    queryPrefix + " AND " + TABLE_NAME + " > " + lastSeen + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
+      }
+      return result;
     }
 
     private Map<String, List<Row>> fetchIndexes(

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -1202,7 +1202,8 @@ abstract class SchemaParser {
         VersionNumber cassandraVersion)
         throws ConnectionException, BusyConnectionException, ExecutionException,
             InterruptedException {
-      if (targetType == null) {
+      if (targetType == null
+          && cluster.getConfiguration().getQueryOptions().isSchemaQueriesPaged()) {
         Map<String, KeyspaceMetadata> keyspaces =
             buildSchema(cluster, connection, cassandraVersion);
         Metadata metadata;


### PR DESCRIPTION
Those queries can sometimes return large number of rows
and non-paged can put unnecessary stress on the cluster.