### PR TITLE
Use latest Cassandra 3.11 version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,19 +36,19 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
 
-      - name: Setup environment (Integration test on Cassandra 3.11)
+      - name: Setup environment (Integration test on Cassandra 3.11.11)
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip python-is-python3 python3-boto3
           sudo pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
 
-      - name: Run integration tests on Cassandra 3.11
-        run: mvn -B verify -Pshort -Dcassandra.version=3.11
+      - name: Run integration tests on Cassandra 3.11.11
+        run: mvn -B verify -Pshort -Dcassandra.version=3.11.11
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: ccm-logs-cassandra-3.11
+          name: ccm-logs-cassandra-3.11.11
           path: /tmp/*-0/ccm*/node*/logs/*
 
   run-scylla-integration-tests:


### PR DESCRIPTION
Use the latest Cassandra 3.11 version (3.11.11) in GitHub Actions workflow. Specifying only 3.11 would result in 3.11.0 being used (Cassandra release from 2017).

One of the tests (`TupleTest`) would sometimes fail under 3.11.0 (see PR #101). This test prepares the same exact query on two keyspaces. In Cassandra 3.11.0 those two prepared statements would get the same ID. In newer versions of Cassandra this problem is fixed (the ID is different for each keyspace) and it was never broken in Scylla, therefore no fixes are required in the driver.