### PR TITLE
Add shard awareness tests

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright ScyllaDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.driver.core.QueryTrace.Event;
+import com.datastax.driver.core.utils.ScyllaOnly;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+@ScyllaOnly
+@CCMConfig(
+    numberOfNodes = 3,
+    jvmArgs = {
+      /* 2-shard Scylla: */
+      "--smp",
+      "2"
+    })
+public class ShardAwarenessTest extends CCMTestsSupport {
+  private static final Logger logger = LoggerFactory.getLogger(ShardAwarenessTest.class);
+  private final boolean useAdvancedShardAwareness;
+
+  @Factory(dataProvider = "dataProvider")
+  public ShardAwarenessTest(boolean useAdvancedShardAwareness) {
+    this.useAdvancedShardAwareness = useAdvancedShardAwareness;
+  }
+
+  @DataProvider
+  public static Object[][] dataProvider() {
+    // Run the tests with advanced shard awareness
+    // and without it.
+    return new Object[][] {{false}, {true}};
+  }
+
+  @Override
+  public Cluster.Builder createClusterBuilder() {
+    Cluster.Builder builder = super.createClusterBuilder();
+    if (!useAdvancedShardAwareness) {
+      builder = builder.withoutAdvancedShardAwareness();
+    }
+    return builder;
+  }
+
+  private void verifyCorrectShardSingleRow(String pk, String ck, String v, String shard) {
+    PreparedStatement prepared =
+        session().prepare("SELECT pk, ck, v FROM shardawaretest.t WHERE pk=? AND ck=?");
+    ResultSet result = session().execute(prepared.bind(pk, ck).enableTracing());
+
+    Row row = result.one();
+    assertTrue(result.isExhausted());
+    assertThat(row).isNotNull();
+    assertThat(row.getString("pk")).isEqualTo(pk);
+    assertThat(row.getString("ck")).isEqualTo(ck);
+    assertThat(row.getString("v")).isEqualTo(v);
+
+    ExecutionInfo executionInfo = result.getExecutionInfo();
+
+    QueryTrace trace = executionInfo.getQueryTrace();
+    boolean anyLocal = false;
+    for (Event event : trace.getEvents()) {
+      logger.info(
+          "  {} - {} - [{}] - {}",
+          event.getSourceElapsedMicros(),
+          event.getSource(),
+          event.getThreadName(),
+          event.getDescription());
+      assertThat(event.getThreadName()).isEqualTo(shard);
+      if (event.getDescription().contains("querying locally")) {
+        anyLocal = true;
+      }
+    }
+    assertThat(anyLocal);
+  }
+
+  @Test(groups = "short")
+  public void correctShardInTracingTest() {
+    session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
+    session()
+        .execute(
+            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
+    session()
+        .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+
+    PreparedStatement populateStatement =
+        session().prepare("INSERT INTO shardawaretest.t (pk, ck, v) VALUES (?, ?, ?)");
+    session().execute(populateStatement.bind("a", "b", "c"));
+    session().execute(populateStatement.bind("e", "f", "g"));
+    session().execute(populateStatement.bind("100002", "f", "g"));
+
+    verifyCorrectShardSingleRow("a", "b", "c", "shard 0");
+    verifyCorrectShardSingleRow("e", "f", "g", "shard 0");
+    verifyCorrectShardSingleRow("100002", "f", "g", "shard 1");
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ShardingInfoTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardingInfoTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright ScyllaDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class ShardingInfoTest {
+
+  @Test(groups = "unit")
+  public void shardIdCalculationTest() {
+    // Verify that our Murmur hash calculates the correct shard for specific keys.
+    Token.Factory factory = Token.M3PToken.FACTORY;
+
+    Map<String, List<String>> params =
+        new HashMap<String, List<String>>() {
+          {
+            put("SCYLLA_SHARD", Collections.singletonList("1"));
+            put("SCYLLA_NR_SHARDS", Collections.singletonList("12"));
+            put(
+                "SCYLLA_PARTITIONER",
+                Collections.singletonList("org.apache.cassandra.dht.Murmur3Partitioner"));
+            put("SCYLLA_SHARDING_ALGORITHM", Collections.singletonList("biased-token-round-robin"));
+            put("SCYLLA_SHARDING_IGNORE_MSB", Collections.singletonList("12"));
+          }
+        };
+    ShardingInfo.ConnectionShardingInfo sharding = ShardingInfo.parseShardingInfo(params);
+    assertThat(sharding).isNotNull();
+    assertThat(sharding.shardId).isEqualTo(1);
+
+    Token token1 =
+        factory.hash(
+            ByteBuffer.wrap(
+                new byte[] {
+                  'a',
+                }));
+    assertThat(sharding.shardingInfo.shardId(token1)).isEqualTo(4);
+
+    Token token2 =
+        factory.hash(
+            ByteBuffer.wrap(
+                new byte[] {
+                  'b',
+                }));
+    assertThat(sharding.shardingInfo.shardId(token2)).isEqualTo(6);
+
+    Token token3 =
+        factory.hash(
+            ByteBuffer.wrap(
+                new byte[] {
+                  'c',
+                }));
+    assertThat(sharding.shardingInfo.shardId(token3)).isEqualTo(6);
+
+    Token token4 =
+        factory.hash(
+            ByteBuffer.wrap(
+                new byte[] {
+                  'e',
+                }));
+    assertThat(sharding.shardingInfo.shardId(token4)).isEqualTo(4);
+
+    Token token5 =
+        factory.hash(
+            ByteBuffer.wrap(
+                new byte[] {
+                  '1', '0', '0', '0', '0', '0',
+                }));
+    assertThat(sharding.shardingInfo.shardId(token5)).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
This PR is a fixed version of #53.

It adds two tests:
- ShardingInfoTest - an unit test checking `shardId` calculation
- ShardAwarenessTest - an integration test checking whether queries are sent to a correct shard (using information in tracing)

Compared to #53, there are some stylistic changes. Moreover, `CassandraSkip` was added to skip this integration test for Cassandra. Additionally, `--smp` configuration flag (expected to be of a certain value by the test) is now being set in `CcmBridge`.