### PR TITLE
Fixes to merged 3.11.0 driver

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -866,11 +866,11 @@ public class Cluster implements Closeable {
      *
      * <p>By default, the driver will "auto-detect" which protocol version it can use when
      * connecting to the first node. More precisely, it will try first with {@link
-     * ProtocolVersion#NEWEST_SUPPORTED}, and if not supported fallback to the highest version
-     * supported by the first node it connects to. Please note that once the version is
-     * "auto-detected", it won't change: if the first node the driver connects to is a Cassandra 1.2
-     * node and auto-detection is used (the default), then the native protocol version 1 will be use
-     * for the lifetime of the Cluster instance.
+     * ProtocolVersion#DEFAULT}, and if not supported fallback to the highest version supported by
+     * the first node it connects to. Please note that once the version is "auto-detected", it won't
+     * change: if the first node the driver connects to is a Cassandra 1.2 node and auto-detection
+     * is used (the default), then the native protocol version 1 will be use for the lifetime of the
+     * Cluster instance.
      *
      * <p>By using {@link Builder#allowBetaProtocolVersion()}, it is possible to force driver to
      * connect to Cassandra node that supports the latest protocol beta version. Leaving this flag

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -133,6 +133,10 @@ public class Cluster implements Closeable {
   static final int NEW_NODE_DELAY_SECONDS =
       SystemProperties.getInt("com.datastax.driver.NEW_NODE_DELAY_SECONDS", 1);
 
+  // Used in integration tests to force the driver to negotiate the protocol
+  // version even if it was explicitly set.
+  @VisibleForTesting static boolean shouldAlwaysNegotiateProtocolVersion = false;
+
   // Some per-JVM number that allows to generate unique cluster names when
   // multiple Cluster instance are created in the same JVM.
   private static final AtomicInteger CLUSTER_ID = new AtomicInteger(0);
@@ -1887,7 +1891,9 @@ public class Cluster implements Closeable {
     }
 
     private void negotiateProtocolVersionAndConnect() {
-      boolean shouldNegotiate = (configuration.getProtocolOptions().initialProtocolVersion == null);
+      boolean shouldNegotiate =
+          (configuration.getProtocolOptions().initialProtocolVersion == null
+              || shouldAlwaysNegotiateProtocolVersion);
       while (true) {
         try {
           controlConnection.connect();

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -192,9 +192,7 @@ class Connection {
     this.requestedShardId = shardId;
 
     final ProtocolVersion protocolVersion =
-        factory.protocolVersion == null
-            ? ProtocolVersion.NEWEST_SUPPORTED
-            : factory.protocolVersion;
+        factory.protocolVersion == null ? ProtocolVersion.DEFAULT : factory.protocolVersion;
     final SettableFuture<Void> channelReadyFuture = SettableFuture.create();
 
     try {

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -301,7 +301,7 @@ class ControlConnection implements Connection.Owner {
     // If no protocol version was specified, set the default as soon as a connection succeeds (it's
     // needed to parse UDTs in refreshSchema)
     if (cluster.connectionFactory.protocolVersion == null)
-      cluster.connectionFactory.protocolVersion = ProtocolVersion.NEWEST_SUPPORTED;
+      cluster.connectionFactory.protocolVersion = ProtocolVersion.DEFAULT;
 
     try {
       logger.trace("[Control connection] Registering for events");

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
@@ -41,6 +41,12 @@ public enum ProtocolVersion {
   /** The most recent beta protocol version supported by the driver. */
   public static final ProtocolVersion NEWEST_BETA = V6;
 
+  /**
+   * The default protocol version used by the driver to connect to the cluster if no specific
+   * protocol version was set.
+   */
+  public static final ProtocolVersion DEFAULT = V4;
+
   private final VersionNumber minCassandraVersion;
 
   private final int asInt;

--- a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
@@ -94,7 +94,7 @@ public class NettyOptionsTest extends CCMTestsSupport {
     int expectedNumberOfCalls = TestUtils.numberOfLocalCoreConnections(cluster) * hosts + 1;
     // If the driver supports a more recent protocol version than C*, the negotiation at startup
     // will open an additional connection for each protocol version tried.
-    ProtocolVersion version = ProtocolVersion.NEWEST_SUPPORTED;
+    ProtocolVersion version = ProtocolVersion.DEFAULT;
     ProtocolVersion usedVersion = ccm().getProtocolVersion();
     while (version != usedVersion && version != null) {
       version = version.getLowerSupported();

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -532,8 +532,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
     PreparedStatement ps =
         session().prepare(String.format("INSERT INTO %s.foo (i) VALUES (?)", keyspace));
     BoundStatement bs = ps.bind(1);
-    assertThat(bs.getRoutingKey(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE))
-        .isNotNull();
+    assertThat(bs.getRoutingKey(protocolVersion, CodecRegistry.DEFAULT_INSTANCE)).isNotNull();
   }
 
   @Test(groups = "short")
@@ -548,8 +547,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
 
     PreparedStatement ps = session().prepare("INSERT INTO \"Test\".\"Foo\" (i) VALUES (?)");
     BoundStatement bs = ps.bind(1);
-    assertThat(bs.getRoutingKey(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE))
-        .isNotNull();
+    assertThat(bs.getRoutingKey(protocolVersion, CodecRegistry.DEFAULT_INSTANCE)).isNotNull();
   }
 
   @Test(groups = "short", expectedExceptions = InvalidQueryException.class)

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
@@ -93,6 +93,30 @@ public class ProtocolVersionRenegotiationTest extends CCMTestsSupport {
     assertThat(actualProtocolVersion(cluster)).isEqualTo(protocolVersion);
   }
 
+  @Test(groups = "short")
+  public void should_successfully_negotiate_down_from_newest_supported_version() {
+    // By default, the driver will connect with ProtocolVersion.DEFAULT (<=
+    // ProtocolVersion.NEWEST_SUPPORTED).
+    // This test verifies that the driver can connect starting with the
+    // newest supported version, potentially renegotiating the protocol
+    // version to a lower version.
+
+    // We will explicitly set a protocol version, so we need to force
+    // the driver to negotiate protocol version.
+    Cluster.shouldAlwaysNegotiateProtocolVersion = true;
+
+    try {
+      Cluster cluster = connectWithVersion(ProtocolVersion.NEWEST_SUPPORTED);
+      assertThat(actualProtocolVersion(cluster))
+          .isLessThanOrEqualTo(ProtocolVersion.NEWEST_SUPPORTED);
+    } catch (RuntimeException e) {
+      Cluster.shouldAlwaysNegotiateProtocolVersion = false;
+      throw e;
+    }
+
+    Cluster.shouldAlwaysNegotiateProtocolVersion = false;
+  }
+
   private UnsupportedProtocolVersionException connectWithUnsupportedVersion(
       ProtocolVersion version) {
     Cluster cluster =

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -24,7 +24,7 @@ import org.assertj.core.api.AbstractAssert;
 @SuppressWarnings("unused")
 public class TypeCodecAssert<T> extends AbstractAssert<TypeCodecAssert<T>, TypeCodec<T>> {
 
-  private ProtocolVersion version = ProtocolVersion.NEWEST_SUPPORTED;
+  private ProtocolVersion version = ProtocolVersion.DEFAULT;
 
   protected TypeCodecAssert(TypeCodec<T> actual) {
     super(actual, TypeCodecAssert.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -87,7 +87,7 @@ public class TokenAwarePolicyTest {
     when(cluster.getConfiguration()).thenReturn(configuration);
     when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
     when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
-    when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.NEWEST_SUPPORTED);
+    when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.DEFAULT);
     when(cluster.getMetadata()).thenReturn(metadata);
     when(metadata.getReplicas(Metadata.quote("keyspace"), null, routingKey))
         .thenReturn(Sets.newLinkedHashSet(host1, host2));
@@ -178,8 +178,7 @@ public class TokenAwarePolicyTest {
       // Encodes into murmur hash '4874351301193663061' which should be owned by node 6 with
       // replicas 7 and 8.
       ByteBuffer routingKey =
-          TypeCodec.varchar()
-              .serialize("This is some sample text", ProtocolVersion.NEWEST_SUPPORTED);
+          TypeCodec.varchar().serialize("This is some sample text", ProtocolVersion.DEFAULT);
 
       // then: The replicas resolved from the cluster metadata must match node 6 and its replicas.
       List<Host> replicas =
@@ -244,9 +243,7 @@ public class TokenAwarePolicyTest {
       // Encodes into murmur hash '4557949199137838892' which should be owned by node 3.
       ByteBuffer routingKey =
           TypeCodec.varchar()
-              .serialize(
-                  "should_choose_proper_host_based_on_routing_key",
-                  ProtocolVersion.NEWEST_SUPPORTED);
+              .serialize("should_choose_proper_host_based_on_routing_key", ProtocolVersion.DEFAULT);
       SimpleStatement statement =
           new SimpleStatement("select * from table where k=5")
               .setRoutingKey(routingKey)
@@ -307,7 +304,7 @@ public class TokenAwarePolicyTest {
           TypeCodec.varchar()
               .serialize(
                   "should_choose_host_in_local_dc_when_using_network_topology_strategy_and_dc_aware",
-                  ProtocolVersion.NEWEST_SUPPORTED);
+                  ProtocolVersion.DEFAULT);
       SimpleStatement statement =
           new SimpleStatement("select * from table where k=5")
               .setRoutingKey(routingKey)
@@ -358,7 +355,7 @@ public class TokenAwarePolicyTest {
           TypeCodec.varchar()
               .serialize(
                   "should_use_other_nodes_when_replicas_having_token_are_down",
-                  ProtocolVersion.NEWEST_SUPPORTED);
+                  ProtocolVersion.DEFAULT);
       SimpleStatement statement =
           new SimpleStatement("select * from table where k=5")
               .setRoutingKey(routingKey)
@@ -460,7 +457,7 @@ public class TokenAwarePolicyTest {
 
       // Derive a routing key for single routing key component, this should resolve to
       // '4891967783720036163'
-      ByteBuffer routingKey = TypeCodec.bigint().serialize(33L, ProtocolVersion.NEWEST_SUPPORTED);
+      ByteBuffer routingKey = TypeCodec.bigint().serialize(33L, ProtocolVersion.DEFAULT);
       bs.setRoutingKey(routingKey);
 
       QueryTracker queryTracker = new QueryTracker();
@@ -479,10 +476,9 @@ public class TokenAwarePolicyTest {
       // Derive a routing key for multiple routing key components, this should resolve to
       // '3735658072872431718'
       bs = preparedStatement.bind("a", "b");
-      ByteBuffer routingKeyK0Part =
-          TypeCodec.bigint().serialize(42L, ProtocolVersion.NEWEST_SUPPORTED);
+      ByteBuffer routingKeyK0Part = TypeCodec.bigint().serialize(42L, ProtocolVersion.DEFAULT);
       ByteBuffer routingKeyK1Part =
-          TypeCodec.varchar().serialize("hello_world", ProtocolVersion.NEWEST_SUPPORTED);
+          TypeCodec.varchar().serialize("hello_world", ProtocolVersion.DEFAULT);
       bs.setRoutingKey(routingKeyK0Part, routingKeyK1Part);
 
       queryTracker.query(session, 10, bs);


### PR DESCRIPTION
This PR consists of necessary changes to the 3.11.0 branch after merging from upstream.

**First commit** fixes protocol version downgrading. Previously, if an `OPTIONS` packet was sent with a wrong protocol version,
`onOptionsResponse` handler method would return a generic `TransportException` exception. This commit implements a similar approach to `onStartupResponse()` by throwing `UnsupportedProtocolVersion` when the exception is of that kind.

This fixes a problem with protocol version downgrading - before this change, the driver could not correctly downgrade the protocol version. By returning a properly typed Exception, the driver can correctly retry with a lower protocol version. The reason protocol version downgrading was broken in our fork and not in upstream is that we send `OPTIONS` packet before `STARTUP`, while upstream does it in reverse.

**Second commit** introduces `ProtocolVersion.DEFAULT` - a default protocol version to be used while connecting to a cluster. Previously `NEWEST_SUPPORTED` was used as a default, but 3.11.0 introduced support for protocol version V5, which is not supported in Scylla. Such default would cause the driver to always downgrade the version upon connecting. Therefore the new default (`ProtocolVersion.DEFAULT`) is set to `V4`.