### PR TITLE
Schema queries paging

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -348,6 +348,10 @@ public class Configuration {
       return this;
     }
 
+    public QueryOptions getQueryOptions() {
+      return queryOptions;
+    }
+
     /**
      * Builds the final object from this builder.
      *

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
@@ -70,6 +70,8 @@ public class QueryOptions {
   private volatile Cluster.Manager manager;
   private volatile boolean prepareOnAllHosts = true;
 
+  private volatile boolean schemaQueriesPaged = true;
+
   /**
    * Creates a new {@link QueryOptions} instance using the {@link #DEFAULT_CONSISTENCY_LEVEL},
    * {@link #DEFAULT_SERIAL_CONSISTENCY_LEVEL} and {@link #DEFAULT_FETCH_SIZE}.
@@ -322,6 +324,26 @@ public class QueryOptions {
   }
 
   /**
+   * Toggle schema queries paging.
+   *
+   * @param enabled whether paging is enabled in schema queries.
+   * @return this {@code QueryOptions} instance.
+   */
+  public QueryOptions setSchemaQueriesPaged(boolean enabled) {
+    this.schemaQueriesPaged = enabled;
+    return this;
+  }
+
+  /**
+   * Whether schema queries are using paging.
+   *
+   * @return the value.
+   */
+  public boolean isSchemaQueriesPaged() {
+    return schemaQueriesPaged;
+  }
+
+  /**
    * Sets the default window size in milliseconds used to debounce node list refresh requests.
    *
    * <p>When the control connection receives a new schema refresh request, it puts it on hold and
@@ -486,18 +508,19 @@ public class QueryOptions {
     QueryOptions other = (QueryOptions) that;
 
     return (this.consistency.equals(other.consistency)
-        && this.serialConsistency.equals(other.serialConsistency)
-        && this.fetchSize == other.fetchSize
-        && this.defaultIdempotence == other.defaultIdempotence
-        && this.metadataEnabled == other.metadataEnabled
-        && this.maxPendingRefreshNodeListRequests == other.maxPendingRefreshNodeListRequests
-        && this.maxPendingRefreshNodeRequests == other.maxPendingRefreshNodeRequests
-        && this.maxPendingRefreshSchemaRequests == other.maxPendingRefreshSchemaRequests
-        && this.refreshNodeListIntervalMillis == other.refreshNodeListIntervalMillis
-        && this.refreshNodeIntervalMillis == other.refreshNodeIntervalMillis
-        && this.refreshSchemaIntervalMillis == other.refreshSchemaIntervalMillis
-        && this.reprepareOnUp == other.reprepareOnUp
-        && this.prepareOnAllHosts == other.prepareOnAllHosts);
+            && this.serialConsistency.equals(other.serialConsistency)
+            && this.fetchSize == other.fetchSize
+            && this.defaultIdempotence == other.defaultIdempotence
+            && this.metadataEnabled == other.metadataEnabled
+            && this.maxPendingRefreshNodeListRequests == other.maxPendingRefreshNodeListRequests
+            && this.maxPendingRefreshNodeRequests == other.maxPendingRefreshNodeRequests
+            && this.maxPendingRefreshSchemaRequests == other.maxPendingRefreshSchemaRequests
+            && this.refreshNodeListIntervalMillis == other.refreshNodeListIntervalMillis
+            && this.refreshNodeIntervalMillis == other.refreshNodeIntervalMillis
+            && this.refreshSchemaIntervalMillis == other.refreshSchemaIntervalMillis
+            && this.reprepareOnUp == other.reprepareOnUp
+            && this.prepareOnAllHosts == other.prepareOnAllHosts)
+        && this.schemaQueriesPaged == other.schemaQueriesPaged;
   }
 
   @Override
@@ -515,7 +538,8 @@ public class QueryOptions {
         refreshNodeIntervalMillis,
         refreshSchemaIntervalMillis,
         reprepareOnUp,
-        prepareOnAllHosts);
+        prepareOnAllHosts,
+        schemaQueriesPaged);
   }
 
   public boolean isConsistencySet() {

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -1226,7 +1226,8 @@ abstract class SchemaParser {
         VersionNumber cassandraVersion)
         throws ConnectionException, BusyConnectionException, ExecutionException,
             InterruptedException {
-      if (targetType == null) {
+      if (targetType == null
+          && cluster.getConfiguration().getQueryOptions().isSchemaQueriesPaged()) {
         Map<String, KeyspaceMetadata> keyspaces =
             buildSchema(cluster, connection, cassandraVersion);
         Metadata metadata;

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -858,6 +858,8 @@ abstract class SchemaParser {
     private static final String VIEW_NAME = "view_name";
     private static final String COLUMN_NAME = "column_name";
     private static final String INDEX_NAME = "index_name";
+    private static final String FUNCTION_NAME = "function_name";
+    private static final String ARGUMENT_TYPES = "argument_types";
     private static final String LIMIT = " LIMIT 1000";
 
     private List<Row> fetchUDTs(
@@ -891,12 +893,44 @@ abstract class SchemaParser {
         KeyspaceMetadata keyspace, Connection connection, ProtocolVersion protocolVersion)
         throws ConnectionException, BusyConnectionException, InterruptedException,
             ExecutionException {
-      return queryAsync(
-              SELECT_FUNCTIONS + whereClause(KEYSPACE, keyspace.getName(), null, null),
-              connection,
-              protocolVersion)
-          .get()
-          .all();
+      String queryPrefix = SELECT_FUNCTIONS + whereClause(KEYSPACE, keyspace.getName(), null, null);
+      List<Row> result = new ArrayList<Row>();
+      List<Row> rs = queryAsync(queryPrefix + LIMIT, connection, protocolVersion).get().all();
+      while (!rs.isEmpty()) {
+        String lastSeenFunction = "'" + rs.get(rs.size() - 1).getString(FUNCTION_NAME) + "'";
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        boolean first = true;
+        for (String arg_type : rs.get(rs.size() - 1).getList(ARGUMENT_TYPES, String.class)) {
+          if (first) {
+            first = false;
+          } else {
+            sb.append(", ");
+          }
+          sb.append("'").append(arg_type).append("'");
+        }
+        sb.append("]");
+        String lastSeenArgs = sb.toString();
+        result.addAll(rs);
+        rs =
+            queryAsync(
+                    queryPrefix
+                        + " AND ("
+                        + FUNCTION_NAME
+                        + ", "
+                        + ARGUMENT_TYPES
+                        + ") > ("
+                        + lastSeenFunction
+                        + ", "
+                        + lastSeenArgs
+                        + ")"
+                        + LIMIT,
+                    connection,
+                    protocolVersion)
+                .get()
+                .all();
+      }
+      return result;
     }
 
     private void buildFunctions(


### PR DESCRIPTION
We need to add paging to schema queries because sometimes there are thousands or tens of thousands rows in schema tables.

Unfortunately, the driver is written in such a way that internal queries are using simplistic query mechanism that does not support paging.

To emulate paging `LIMIT` is used in this PR.