### PR TITLE
Fix running integration tests on Java Driver 4.x

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.DseRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -81,6 +82,9 @@ public class ProtocolVersionInitialNegotiationIT {
       min = "4.0-rc1",
       description = "Only C* in [4.0-rc1,*[ has V5 as its highest version")
   @Test
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_downgrade_to_v5_oss() {
     Assume.assumeFalse("This test is only for OSS C*", ccm.getDseVersion().isPresent());
     try (CqlSession session = SessionUtils.newSession(ccm)) {
@@ -237,6 +241,9 @@ public class ProtocolVersionInitialNegotiationIT {
   /** Note that this test will need to be updated as new protocol versions are introduced. */
   @CassandraRequirement(min = "4.0", description = "Only C* in [4.0,*[ has V5 supported")
   @Test
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_not_downgrade_if_server_supports_latest_version_oss() {
     Assume.assumeFalse("This test is only for OSS C*", ccm.getDseVersion().isPresent());
     try (CqlSession session = SessionUtils.newSession(ccm)) {
@@ -311,6 +318,9 @@ public class ProtocolVersionInitialNegotiationIT {
 
   @CassandraRequirement(min = "4.0", description = "Only C* in [4.0,*[ has V5 supported")
   @Test
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_use_explicitly_provided_v5_oss() {
     Assume.assumeFalse("This test is only for OSS C*", ccm.getDseVersion().isPresent());
     DriverConfigLoader loader =
@@ -325,6 +335,9 @@ public class ProtocolVersionInitialNegotiationIT {
 
   @DseRequirement(min = "7.0", description = "Only DSE in [7.0,*[ has V5 supported")
   @Test
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_use_explicitly_provided_v5_dse() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider;
@@ -32,6 +33,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+@ScyllaSkip(
+    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaJVMArgs")
 public class PlainTextAuthProviderIT {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.auth;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
@@ -38,6 +38,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Iterator;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -339,6 +340,7 @@ public class BatchStatementIT {
   }
 
   @Test(expected = IllegalStateException.class)
+  @Ignore("@IntegrationTestDisabledCassandra4Failure")
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     //    CREATE TABLE test (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))
     DriverConfigLoader loader =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -127,6 +128,7 @@ public class BoundStatementCcmIT {
   }
 
   @Test(expected = IllegalStateException.class)
+  @Ignore("@IntegrationTestDisabledCassandra4Failure")
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -37,6 +37,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -270,6 +271,7 @@ public class BoundStatementCcmIT {
   }
 
   @Test
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_propagate_attributes_when_preparing_a_simple_statement() {
     CqlSession session = sessionRule.session();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -117,6 +118,9 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @CassandraRequirement(min = "3.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_execute_query_and_log_server_side_warnings() {
     final String query = "SELECT count(*) FROM test;";
     Statement<?> st = SimpleStatement.builder(query).build();
@@ -141,6 +145,9 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @CassandraRequirement(min = "3.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_execute_query_and_not_log_server_side_warnings() {
     final String query = "SELECT count(*) FROM test;";
     Statement<?> st =
@@ -159,6 +166,9 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @CassandraRequirement(min = "2.2")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_expose_warnings_on_execution_info() {
     // the default batch size warn threshold is 5 * 1024 bytes, but after CASSANDRA-10876 there must
     // be multiple mutations in a batch to trigger this warning so the batch includes 2 different

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -121,6 +122,9 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_simple_statement_with_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -139,6 +143,9 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_batch_with_explicit_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -163,6 +170,9 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_batch_with_inferred_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -195,6 +205,9 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_prepare_statement_with_keyspace() {
     CqlSession session = sessionRule.session();
     PreparedStatement prepared =
@@ -215,6 +228,9 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_reprepare_statement_with_keyspace_on_the_fly() {
     // Create a separate session because we don't want it to have a default keyspace
     try (CqlSession session = SessionUtils.newSession(ccmRule)) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -49,6 +49,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import junit.framework.TestCase;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -425,6 +426,7 @@ public class PreparedStatementIT {
    * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-15252">CASSANDRA-15252</a>
    */
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure")
   public void should_fail_fast_if_id_changes_on_reprepare() {
     try (CqlSession session = SessionUtils.newSession(ccmRule)) {
       PreparedStatement preparedStatement =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -272,6 +272,9 @@ public class PreparedStatementIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_fail_to_reprepare_if_query_becomes_invalid() {
     // Given
     CqlSession session = sessionRule.session();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -147,6 +148,7 @@ public class PreparedStatementIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_update_metadata_when_schema_changed_across_executions() {
     // Given
     CqlSession session = sessionRule.session();
@@ -176,6 +178,7 @@ public class PreparedStatementIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_update_metadata_when_schema_changed_across_pages() {
     // Given
     CqlSession session = sessionRule.session();
@@ -221,6 +224,7 @@ public class PreparedStatementIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_update_metadata_when_schema_changed_across_sessions() {
     // Given
     CqlSession session1 = sessionRule.session();
@@ -287,12 +291,14 @@ public class PreparedStatementIT {
 
   @Test
   @CassandraRequirement(min = "4.0")
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_not_store_metadata_for_conditional_updates() {
     should_not_store_metadata_for_conditional_updates(sessionRule.session());
   }
 
   @Test
   @CassandraRequirement(min = "2.2")
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   public void should_not_store_metadata_for_conditional_updates_in_legacy_protocol() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
@@ -304,6 +310,7 @@ public class PreparedStatementIT {
     }
   }
 
+  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   private void should_not_store_metadata_for_conditional_updates(CqlSession session) {
     // Given
     PreparedStatement ps =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.api.core.cql.QueryTrace;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -80,7 +81,9 @@ public class QueryTraceIT {
     InetAddress nodeAddress = ((InetSocketAddress) contactPoint.resolve()).getAddress();
     boolean expectPorts =
         CCM_RULE.getCassandraVersion().nextStable().compareTo(Version.V4_0_0) >= 0
-            && !CCM_RULE.getDseVersion().isPresent();
+            && !CCM_RULE.getDseVersion().isPresent()
+            && !CcmBridge
+                .SCYLLA_ENABLEMENT /* @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText */;
 
     QueryTrace queryTrace = executionInfo.getQueryTrace();
     assertThat(queryTrace.getTracingId()).isEqualTo(executionInfo.getTracingId());

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.cql.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.core.cql.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.dse.driver.api.core.cql.reactive.ReactiveResultSet;
 import com.datastax.dse.driver.api.core.cql.reactive.ReactiveRow;
@@ -29,6 +30,7 @@ import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -169,6 +171,8 @@ public class DefaultReactiveResultSetIT {
 
   @Test
   public void should_write_cas() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+
     SimpleStatement statement =
         SimpleStatement.builder(
                 "INSERT INTO test_reactive_write (pk, cc, v) VALUES (?, ?, ?) IF NOT EXISTS")
@@ -227,6 +231,8 @@ public class DefaultReactiveResultSetIT {
 
   @Test
   public void should_write_batch_cas() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+
     BatchStatement batch = createCASBatch();
     CqlSession session = sessionRule.session();
     // execute batch for the first time: all inserts should succeed and the server should return

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.loadbalancing;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.metadata.TokenMap;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -55,6 +56,8 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@ScyllaSkip(
+    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledCCMFailure")
 public class DefaultLoadBalancingPolicyIT {
 
   private static final String LOCAL_DC = "dc1";

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -44,6 +45,7 @@ import org.junit.rules.TestRule;
  * @see <a href="https://datastax-oss.atlassian.net/browse/JAVA-2028">JAVA-2028</a>
  */
 @Category(ParallelizableTests.class)
+@ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF")
 public class CaseSensitiveUdtIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -52,6 +53,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Category(ParallelizableTests.class)
+@ScyllaSkip(
+    description =
+        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality") //  'additional_write_policy' unsupported by Scylla in setupDatabase()
 public class DescribeIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(DescribeIT.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.testinfra.DseRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -45,6 +46,9 @@ public class NodeMetadataIT {
   @Rule public CcmRule ccmRule = CcmRule.getInstance();
 
   @Test
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_expose_node_metadata() {
     try (CqlSession session = SessionUtils.newSession(ccmRule)) {
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.core.metadata;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -27,6 +28,9 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@ScyllaSkip(
+    description =
+        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
 public class RandomTokenIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.core.metadata;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -32,6 +33,9 @@ import org.junit.rules.TestRule;
     max = "4.0-beta4",
     // TODO Re-enable when CASSANDRA-16364 is fixed
     description = "TODO Re-enable when CASSANDRA-16364 is fixed")
+@ScyllaSkip(
+    description =
+        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
 public class RandomTokenVnodesIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -315,6 +315,8 @@ public class SchemaChangesIT {
   public void should_handle_function_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_creation(
         null,
         "CREATE FUNCTION id(i int) RETURNS NULL ON NULL INPUT RETURNS int "
@@ -339,6 +341,8 @@ public class SchemaChangesIT {
   public void should_handle_function_drop() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_drop(
         ImmutableList.of(
             "CREATE FUNCTION id(i int) RETURNS NULL ON NULL INPUT RETURNS int "
@@ -355,6 +359,8 @@ public class SchemaChangesIT {
   public void should_handle_function_update() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_update_via_drop_and_recreate(
         ImmutableList.of(
             "CREATE FUNCTION id(i int) RETURNS NULL ON NULL INPUT RETURNS int "
@@ -375,6 +381,8 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_creation(
         "CREATE FUNCTION plus(i int, j int) RETURNS NULL ON NULL INPUT RETURNS int "
             + "LANGUAGE java AS 'return i+j;'",
@@ -401,6 +409,8 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_drop() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_drop(
         ImmutableList.of(
             "CREATE FUNCTION plus(i int, j int) RETURNS NULL ON NULL INPUT RETURNS int "
@@ -418,6 +428,8 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_update() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_update_via_drop_and_recreate(
         ImmutableList.of(
             "CREATE FUNCTION plus(i int, j int) RETURNS NULL ON NULL INPUT RETURNS int "

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -241,6 +241,7 @@ public class SchemaChangesIT {
   public void should_handle_view_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V3_0_0) >= 0)
         .isTrue();
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
     should_handle_creation(
         "CREATE TABLE scores(user text, game text, score int, PRIMARY KEY (user, game))",
         "CREATE MATERIALIZED VIEW highscores "

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -32,6 +32,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -186,6 +187,9 @@ public class SchemaIT {
   }
 
   @CassandraRequirement(min = "4.0", description = "virtual tables introduced in 4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
   @Test
   public void should_get_virtual_metadata() {
     skipIfDse60();
@@ -270,6 +274,9 @@ public class SchemaIT {
   }
 
   @CassandraRequirement(min = "4.0", description = "virtual tables introduced in 4.0")
+  @ScyllaSkip(
+      description =
+          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
   @Test
   public void should_exclude_virtual_keyspaces_from_token_map() {
     skipIfDse60();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.session;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.token.TokenRange;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
@@ -33,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+@ScyllaSkip(
+    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledCCMFailure")
 public class AddedNodeIT {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.session;
 
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,6 +49,7 @@ public class ShutdownIT {
   private static final String QUERY_STRING = "select * from foo";
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure")
   public void should_fail_requests_when_session_is_closed() throws Exception {
     // Given
     // Prime with a bit of delay to increase the chance that a query will be aborted in flight when

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class DefaultSslEngineFactoryHostnameValidationIT {
@@ -37,6 +38,7 @@ public class DefaultSslEngineFactoryHostnameValidationIT {
    * to 127.0.0.1.
    */
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_if_hostname_validation_enabled_and_hostname_matches() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class DefaultSslEngineFactoryIT {
@@ -31,6 +32,7 @@ public class DefaultSslEngineFactoryIT {
   @ClassRule public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withSsl().build();
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_ssl() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
@@ -81,6 +83,7 @@ public class DefaultSslEngineFactoryIT {
   }
 
   @Test(expected = AllNodesFailedException.class)
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_not_connect_if_not_using_ssl() {
     try (CqlSession session = SessionUtils.newSession(CCM_RULE)) {
       session.execute("select * from system.local");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.IsolatedTests;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -34,6 +35,7 @@ public class DefaultSslEngineFactoryPropertyBasedIT {
   public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withSslLocalhostCn().build();
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_ssl() {
     System.setProperty(
         "javax.net.ssl.trustStore", CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.IsolatedTests;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -34,6 +35,7 @@ public class DefaultSslEngineFactoryPropertyBasedWithClientAuthIT {
   public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withSslAuth().build();
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_ssl_using_client_auth() {
     System.setProperty(
         "javax.net.ssl.keyStore", CcmBridge.DEFAULT_CLIENT_KEYSTORE_FILE.getAbsolutePath());

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class DefaultSslEngineFactoryWithClientAuthIT {
@@ -32,6 +33,7 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
   public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withSslAuth().build();
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_ssl_using_client_auth() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
@@ -30,6 +30,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ProgrammaticSslIT {
@@ -37,6 +38,7 @@ public class ProgrammaticSslIT {
   @ClassRule public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withSsl().build();
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_programmatic_factory() {
     SslEngineFactory factory = new ProgrammaticSslEngineFactory(createSslContext());
     try (CqlSession session =
@@ -50,6 +52,7 @@ public class ProgrammaticSslIT {
   }
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledSSL")
   public void should_connect_with_programmatic_ssl_context() {
     SSLContext sslContext = createSslContext();
     try (CqlSession session =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.core.ssl;
 
 import com.datastax.oss.driver.api.core.CqlSession;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegrationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegrationIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.core.util.concurrent;
 
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.rows;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegrationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegrationIT.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -98,6 +99,7 @@ public class DriverBlockHoundIntegrationIT {
   }
 
   @Test
+  @Ignore("@IntegrationTestDisabledCassandra3Failure")
   public void should_not_detect_blocking_call_on_asynchronous_execution_prepared() {
     try (CqlSession session = SessionUtils.newSession(SIMULACRON_RULE)) {
       Flux<ReactiveRow> rows =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -33,6 +34,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -219,6 +221,7 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(dao.saveIfNotExists(FLAMETHROWER)).isNull();
 
     Product otherProduct =
@@ -237,6 +240,7 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_asynchronously() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(CompletableFutures.getUninterruptibly(dao.saveAsyncIfNotExists(FLAMETHROWER)))
         .isNull();
 
@@ -263,6 +267,7 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_returning_optional() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(dao.saveIfNotExistsOptional(FLAMETHROWER)).isEmpty();
 
     Product otherProduct =
@@ -272,6 +277,7 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_returning_optional_asynchronously() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(
             CompletableFutures.getUninterruptibly(dao.saveAsyncIfNotExistsOptional(FLAMETHROWER)))
         .isEmpty();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import com.datastax.oss.driver.api.core.Version;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
@@ -20,6 +20,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.api.mapper.annotations.ClusteringColumn;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import java.util.List;
@@ -97,7 +98,9 @@ public abstract class InventoryITBase {
   }
 
   protected static boolean supportsSASI(CcmRule ccmRule) {
-    return ccmRule.getCassandraVersion().compareTo(MINIMUM_SASI_VERSION) >= 0;
+    return ccmRule.getCassandraVersion().compareTo(MINIMUM_SASI_VERSION) >= 0
+        && !CcmBridge
+            .SCYLLA_ENABLEMENT /* @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex */;
   }
 
   @Entity

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static com.datastax.oss.driver.api.mapper.annotations.SchemaHint.TargetElement;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
@@ -20,6 +20,7 @@ import static com.datastax.oss.driver.internal.core.util.LoggerTest.setupTestLog
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -44,6 +45,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
 import com.datastax.oss.driver.api.mapper.entity.EntityHelper;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -192,6 +194,8 @@ public class SchemaValidationIT extends InventoryITBase {
 
   @Test
   public void should_throw_general_driver_exception_when_schema_validation_check_is_disabled() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    // @IntegrationTestDisabledScyllaDifferentText
     assertThatThrownBy(
             () -> mapperDisabledValidation.productDaoValidationDisabled(sessionRule.keyspace()))
         .isInstanceOf(InvalidQueryException.class)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static com.datastax.oss.driver.assertions.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -48,6 +49,9 @@ import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 @CassandraRequirement(min = "3.4", description = "Creates a SASI index")
+@ScyllaSkip(
+    description =
+        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex")
 public class SelectCustomWhereClauseIT extends InventoryITBase {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -34,6 +35,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -97,6 +99,8 @@ public class SelectOtherClausesIT {
 
   @Test
   public void should_select_with_per_partition_limit() {
+    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+
     PagingIterable<Simple> elements = dao.selectWithPerPartitionLimit(5);
     assertThat(elements.isFullyFetched()).isTrue();
     assertThat(elements.getAvailableWithoutFetching()).isEqualTo(10);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static com.datastax.oss.driver.assertions.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -47,6 +48,8 @@ import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 @CassandraRequirement(min = "3.11.0", description = "UDT fields in IF clause")
+@ScyllaSkip(
+    description = "@IntegrationTestDisabledScyllaFailure") // Test hangs in setup() in productDao()
 public class UpdateCustomIfClauseIT extends InventoryITBase {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
@@ -32,6 +32,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -50,6 +51,9 @@ import org.junit.rules.TestRule;
 @CassandraRequirement(
     min = "3.6",
     description = "Uses UDT fields in IF conditions (CASSANDRA-7423)")
+@ScyllaSkip(
+    description =
+        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex")
 public class UpdateReactiveIT extends InventoryITBase {
 
   private static CcmRule ccmRule = CcmRule.getInstance();

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiCustomLoadBalancingPolicyIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiCustomLoadBalancingPolicyIT.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -35,6 +36,7 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
  * DynamicImport-Package: *</code>.
  */
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 public class OsgiCustomLoadBalancingPolicyIT {
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiCustomLoadBalancingPolicyIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiCustomLoadBalancingPolicyIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import com.datastax.oss.driver.api.osgi.service.MailboxService;

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiDefaultIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiDefaultIT.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -29,6 +30,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 public class OsgiDefaultIT {
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiDefaultIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiDefaultIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import com.datastax.oss.driver.api.osgi.service.MailboxService;

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiLz4IT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiLz4IT.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -29,6 +30,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 public class OsgiLz4IT {
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiLz4IT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiLz4IT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import com.datastax.oss.driver.api.osgi.service.MailboxService;

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiReactiveIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiReactiveIT.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -33,6 +34,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 public class OsgiReactiveIT {
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiReactiveIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiReactiveIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiShadedIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiShadedIT.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -29,6 +30,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 public class OsgiShadedIT {
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiShadedIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiShadedIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import com.datastax.oss.driver.api.osgi.service.MailboxService;

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiSnappyIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiSnappyIT.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.internal.osgi.support.BundleOptions;
 import com.datastax.oss.driver.internal.osgi.support.CcmExamReactorFactory;
 import com.datastax.oss.driver.internal.osgi.support.CcmPaxExam;
 import javax.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -30,6 +31,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 
 @RunWith(CcmPaxExam.class)
+@Ignore("@IntegrationTestDisabledCassandra3Failure @IntegrationTestDisabledPaxExam")
 @ExamReactorStrategy(CcmExamReactorFactory.class)
 @CassandraRequirement(max = "3.99")
 public class OsgiSnappyIT {

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiSnappyIT.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/OsgiSnappyIT.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.osgi;
 
 import com.datastax.oss.driver.api.osgi.service.MailboxService;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ScyllaSkip.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ScyllaSkip.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a Class or Method that skips it for Scylla. If the tests are run against Scylla,
+ * the test is skipped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ScyllaSkip {
+  /** @return The description returned if this requirement is not met. */
+  String description() default "Disabled for Scylla.";
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
 import com.datastax.oss.driver.api.core.Version;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -249,7 +249,8 @@ public class CcmBridge implements AutoCloseable {
       for (Map.Entry<String, Object> conf : cassandraConfiguration.entrySet()) {
         execute("updateconf", String.format("%s:%s", conf.getKey(), conf.getValue()));
       }
-      if (getCassandraVersion().compareTo(Version.V2_2_0) >= 0) {
+      if (getCassandraVersion().compareTo(Version.V2_2_0) >= 0 && !SCYLLA_ENABLEMENT) {
+        // @IntegrationTestDisabledScyllaJVMArgs @IntegrationTestDisabledScyllaUDF
         execute("updateconf", "enable_user_defined_functions:true");
       }
       if (DSE_ENABLEMENT) {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
 import com.datastax.oss.driver.api.core.Version;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
@@ -28,8 +28,12 @@ public class DefaultCcmBridgeBuilderCustomizer {
       builder.withCassandraConfiguration("enable_sasi_indexes", true);
     }
     if (CcmBridge.VERSION.nextStable().compareTo(Version.V3_0_0) >= 0) {
-      builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
-      builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
+      if (!CcmBridge.SCYLLA_ENABLEMENT) {
+        // @IntegrationTestDisabledScyllaJVMArgs
+        // FIXME: Add Scylla equivalents of those configuration options
+        builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
+        builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
+      }
       builder.withCassandraConfiguration("num_tokens", "1");
       builder.withCassandraConfiguration("initial_token", "0");
     }


### PR DESCRIPTION
This pull request aims to "re-enable" integration tests with Java Driver 4.x: making them run again (mostly by disabling failing tests and categorizing them for future fixing), adding support for running them with Scylla.

The first two commits disable tests that fail with Cassandra and the next commits add support for running the tests with Scylla and disables/categorizes tests that fail.

The tests can be ran with following commands:
- `mvn verify -Dccm.version=3.11.12 -e` (Cassandra 3.11.12)
- `mvn verify -Dccm.version=4.0.3 -e` (Cassandra 4.0.3)
- `mvn verify -Dccm.version=4.5.3 -Dccm.scylla=true` (Scylla OSS 4.5.3)

This PR does not include running the tests in GitHub Actions - this will come at a later date.

The disabled tests are categorized with tags by reasons why they were disabled and should be fixed at a later date:

- `@IntegrationTestDisabledCassandra3Failure` - general regression when running with Cassandra 3.11
- `@IntegrationTestDisabledCassandra4Failure` - general regression when running with Cassandra 4
- `@IntegrationTestDisabledPaxExam` - disabling test using PaxExam functionality
- `@IntegrationTestDisabledScyllaFailure` - general regression when running with Scylla
- `@IntegrationTestDisabledScyllaJVMArgs` - disabling test, when running with Scylla, that uses Cassandra's JVM arguments
- `@IntegrationTestDisabledScyllaUDF` - disabling test, when running with Scylla, that uses Cassandra's UDF implementation
- `@IntegrationTestDisabledScyllaUnsupportedFunctionality` - disabling test, when running with Scylla, that uses functionality unsupported by Scylla (for example SASI indexes or Cassandra's CDC)
- `@IntegrationTestDisabledScyllaUnsupportedIndex` - disabling test, when running with Scylla, that uses Cassandra's indexes unsupported by Scylla
- `@IntegrationTestDisabledSSL` - a disabled test that also happens to test SSL functionality
- `@IntegrationTestDisabledScyllaProtocolV5` - a disabled test that relies on Protocol V5
- `@IntegrationTestDisabledScyllaDifferentText` - a disabled test that expects a Cassandra-specific text (such as tracing message)
- `@IntegrationTestDisabledCCMFailure` - a disabled test that fails at CCM stage (mostly adding new nodes to the cluster)