### PR TITLE
Bump versions of libraries with known CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,9 @@
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <!-- guava 19.0 is the last to support java 6 and support both new/deprecated APIs (see GuavaCompatibility) -->
         <guava.version>19.0</guava.version>
-        <netty.version>4.0.56.Final</netty.version>
+        <netty.version>4.1.76.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
         <snappy.version>1.1.2.6</snappy.version>
@@ -63,7 +64,7 @@
         <hdr.version>2.1.10</hdr.version>
         <jackson.version>2.8.11</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
-        <jackson-databind.version>2.7.9.3</jackson-databind.version>
+        <jackson-databind.version>2.7.9.7</jackson-databind.version>
         <joda.version>2.9.9</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>


### PR DESCRIPTION
Bump versions of libraries that mvnrepository.com reports to have known vulnerabilities. We are not aware of any way those issues could be taken advantage of. The libraries were upgraded to the last version that supports Java 6.