### PR TITLE
Lwt awareness

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/PreparedStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/PreparedStatement.java
@@ -118,6 +118,20 @@ public interface PreparedStatement {
   ColumnDefinitions getResultSetDefinitions();
 
   /**
+   * Informs if this is an LWT query.
+   *
+   * <p>Not guaranteed to return true for LWT queries (but guaranteed to return false for non-LWT
+   * ones). It can happen for several reasons, for example: using Cassandra instead of Scylla, using
+   * too old Scylla version, future changes in driver allowing channels to be created without
+   * sending OPTIONS request.
+   *
+   * <p>More information about LWT:
+   *
+   * @see <a href="https://docs.scylladb.com/using-scylla/lwt/">Docs about LWT</a>
+   */
+  boolean isLWT();
+
+  /**
    * Updates {@link #getResultMetadataId()} and {@link #getResultSetDefinitions()} atomically.
    *
    * <p>This is for internal use by the driver. Calling this manually with incorrect information can

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.api.core.cql;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -515,6 +521,20 @@ public interface Statement<SelfT extends Statement<SelfT>> extends Request {
   default SelfT setNowInSeconds(int nowInSeconds) {
     return (SelfT) this;
   }
+
+  /**
+   * Informs if this is a prepared LWT query.
+   *
+   * <p>Not guaranteed to return true for prepared LWT queries (but guaranteed to return false for
+   * non-LWT ones). It can happen for several reasons, for example: using Cassandra instead of
+   * Scylla, using too old Scylla version, future changes in driver allowing channels to be created
+   * without sending OPTIONS request.
+   *
+   * <p>More information about LWT:
+   *
+   * @see <a href="https://docs.scylladb.com/using-scylla/lwt/">Docs about LWT</a>
+   */
+  boolean isLWT();
 
   /**
    * Calculates the approximate size in bytes that the statement will have when encoded.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
 import com.datastax.oss.driver.internal.core.adminrequest.ThrottledAdminRequestHandler;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
+import com.datastax.oss.driver.internal.core.protocol.LwtInfo;
 import com.datastax.oss.driver.internal.core.protocol.ShardingInfo;
 import com.datastax.oss.driver.internal.core.protocol.ShardingInfo.ConnectionShardingInfo;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
@@ -60,6 +61,7 @@ public class DriverChannel {
       AttributeKey.newInstance("options");
   static final AttributeKey<ConnectionShardingInfo> SHARDING_INFO_KEY =
       AttributeKey.newInstance("sharding_info");
+  static final AttributeKey<LwtInfo> LWT_INFO_KEY = AttributeKey.newInstance("lwt_info");
 
   @SuppressWarnings("RedundantStringConstructorCall")
   static final Object GRACEFUL_CLOSE_MESSAGE = new String("GRACEFUL_CLOSE_MESSAGE");
@@ -152,6 +154,10 @@ public class DriverChannel {
     return channel.hasAttr(SHARDING_INFO_KEY)
         ? channel.attr(SHARDING_INFO_KEY).get().shardingInfo
         : null;
+  }
+
+  public LwtInfo getLwtInfo() {
+    return channel.attr(LWT_INFO_KEY).get();
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -71,6 +71,7 @@ import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.data.ValuesHelper;
 import com.datastax.oss.driver.internal.core.metadata.PartitionerFactory;
+import com.datastax.oss.driver.internal.core.protocol.LwtInfo;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.primitives.Ints;
@@ -363,7 +364,7 @@ public class Conversions {
   }
 
   public static DefaultPreparedStatement toPreparedStatement(
-      Prepared response, PrepareRequest request, InternalDriverContext context) {
+      Prepared response, PrepareRequest request, InternalDriverContext context, LwtInfo lwtInfo) {
     ColumnDefinitions variableDefinitions =
         toColumnDefinitions(response.variablesMetadata, context);
 
@@ -403,7 +404,7 @@ public class Conversions {
         request.areBoundStatementsTracing(),
         context.getCodecRegistry(),
         context.getProtocolVersion(),
-        false);
+        lwtInfo != null && lwtInfo.isLwt(response.variablesMetadata.flags));
   }
 
   public static ColumnDefinitions toColumnDefinitions(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -402,7 +402,8 @@ public class Conversions {
         request.getSerialConsistencyLevelForBoundStatements(),
         request.areBoundStatementsTracing(),
         context.getCodecRegistry(),
-        context.getProtocolVersion());
+        context.getProtocolVersion(),
+        false);
   }
 
   public static ColumnDefinitions toColumnDefinitions(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -232,13 +232,13 @@ public class CqlPrepareHandler implements Throttled {
     errorsSnapshot.add(new AbstractMap.SimpleEntry<>(node, error));
   }
 
-  private void setFinalResult(PrepareRequest request, Prepared response) {
+  private void setFinalResult(PrepareRequest request, Prepared response, DriverChannel channel) {
 
     // Whatever happens below, we're done with this stream id
     throttler.signalSuccess(this);
 
     DefaultPreparedStatement preparedStatement =
-        Conversions.toPreparedStatement(response, request, context);
+        Conversions.toPreparedStatement(response, request, context, channel.getLwtInfo());
 
     session
         .getRepreparePayloads()
@@ -375,7 +375,7 @@ public class CqlPrepareHandler implements Throttled {
         Message responseMessage = responseFrame.message;
         if (responseMessage instanceof Prepared) {
           LOG.trace("[{}] Got result, completing", logPrefix);
-          setFinalResult(request, (Prepared) responseMessage);
+          setFinalResult(request, (Prepared) responseMessage, channel);
         } else if (responseMessage instanceof Error) {
           LOG.trace("[{}] Got error response, processing", logPrefix);
           processErrorResponse((Error) responseMessage);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.core.cql;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -782,5 +788,10 @@ public class DefaultBatchStatement implements BatchStatement {
         timeout,
         node,
         newNowInSeconds);
+  }
+
+  @Override
+  public boolean isLWT() {
+    return false;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -770,4 +770,9 @@ public class DefaultBoundStatement implements BoundStatement {
         node,
         newNowInSeconds);
   }
+
+  @Override
+  public boolean isLWT() {
+    return this.getPreparedStatement().isLWT();
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
@@ -66,6 +66,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
   private final ConsistencyLevel serialConsistencyLevelForBoundStatements;
   private final Duration timeoutForBoundStatements;
   private final Partitioner partitioner;
+  private final boolean isLWT;
 
   public DefaultPreparedStatement(
       ByteBuffer id,
@@ -91,7 +92,8 @@ public class DefaultPreparedStatement implements PreparedStatement {
       ConsistencyLevel serialConsistencyLevelForBoundStatements,
       boolean areBoundStatementsTracing,
       CodecRegistry codecRegistry,
-      ProtocolVersion protocolVersion) {
+      ProtocolVersion protocolVersion,
+      boolean isLWT) {
     this.id = id;
     this.partitionKeyIndices = partitionKeyIndices;
     // It's important that we keep a reference to this object, so that it only gets evicted from
@@ -117,6 +119,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
 
     this.codecRegistry = codecRegistry;
     this.protocolVersion = protocolVersion;
+    this.isLWT = isLWT;
   }
 
   @NonNull
@@ -157,6 +160,11 @@ public class DefaultPreparedStatement implements PreparedStatement {
   @Override
   public ColumnDefinitions getResultSetDefinitions() {
     return resultMetadata.resultSetDefinitions;
+  }
+
+  @Override
+  public boolean isLWT() {
+    return isLWT;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultSimpleStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultSimpleStatement.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.oss.driver.internal.core.cql;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -739,6 +745,11 @@ public class DefaultSimpleStatement implements SimpleStatement {
         timeout,
         node,
         newNowInSeconds);
+  }
+
+  @Override
+  public boolean isLWT() {
+    return false;
   }
 
   public static Map<CqlIdentifier, Object> wrapKeys(Map<String, Object> namedValues) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/LwtInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/LwtInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.driver.internal.core.protocol;
+
+import java.util.List;
+import java.util.Map;
+
+public class LwtInfo {
+  private static final String SCYLLA_LWT_ADD_METADATA_MARK_KEY = "SCYLLA_LWT_ADD_METADATA_MARK";
+  private static final String LWT_OPTIMIZATION_META_BIT_MASK_KEY = "LWT_OPTIMIZATION_META_BIT_MASK";
+
+  private final int mask;
+
+  private LwtInfo(int m) {
+    mask = m;
+  }
+
+  public int getMask() {
+    return mask;
+  }
+
+  public boolean isLwt(int flags) {
+    return (flags & mask) == mask;
+  }
+
+  public static LwtInfo parseLwtInfo(Map<String, List<String>> supported) {
+    if (!supported.containsKey(SCYLLA_LWT_ADD_METADATA_MARK_KEY)) {
+      return null;
+    }
+    List<String> list = supported.get(SCYLLA_LWT_ADD_METADATA_MARK_KEY);
+    if (list == null || list.size() != 1) {
+      return null;
+    }
+    String val = list.get(0);
+    if (val == null || !val.startsWith(LWT_OPTIMIZATION_META_BIT_MASK_KEY + "=")) {
+      return null;
+    }
+    long mask;
+    try {
+      mask = Long.parseLong(val.substring((LWT_OPTIMIZATION_META_BIT_MASK_KEY + "=").length()));
+    } catch (Exception e) {
+      System.err.println(
+          "Error while parsing " + LWT_OPTIMIZATION_META_BIT_MASK_KEY + ": " + e.getMessage());
+      return null;
+    }
+    if (mask > Integer.MAX_VALUE) {
+      // Unfortunately server returns mask as unsigned int32 so we have to parse it as int64 and
+      // convert to proper signed int32
+      mask += Integer.MIN_VALUE;
+      mask += Integer.MIN_VALUE;
+    }
+
+    return new LwtInfo((int) mask);
+  }
+
+  public void addOption(Map<String, String> options) {
+    options.put(SCYLLA_LWT_ADD_METADATA_MARK_KEY, Integer.toString(mask));
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/tracker/RequestLogFormatterTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/tracker/RequestLogFormatterTest.java
@@ -291,6 +291,7 @@ public class RequestLogFormatterTest {
         null,
         false,
         context.getCodecRegistry(),
-        context.getProtocolVersion());
+        context.getProtocolVersion(),
+        false);
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.loadbalancing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.TokenMap;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+public class LWTLoadBalancingIT {
+  private static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(3).build();
+
+  private static final SessionRule<CqlSession> SESSION_RULE =
+      SessionRule.builder(CCM_RULE).withKeyspace(false).build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  @BeforeClass
+  public static void setup() {
+    CqlIdentifier keyspace = SessionUtils.uniqueKeyspaceId();
+    CqlSession session = SESSION_RULE.session();
+    session.execute(
+        "CREATE KEYSPACE "
+            + keyspace.asCql(false)
+            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
+    session.execute("USE " + keyspace.asCql(false));
+    session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+  }
+
+  @Test
+  public void should_use_only_one_node_when_lwt_detected() {
+    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT); // Functionality only available in Scylla
+    CqlSession session = SESSION_RULE.session();
+    int pk = 1234;
+    ByteBuffer routingKey = TypeCodecs.INT.encodePrimitive(pk, ProtocolVersion.DEFAULT);
+    TokenMap tokenMap = SESSION_RULE.session().getMetadata().getTokenMap().get();
+    Node owner = tokenMap.getReplicas(session.getKeyspace().get(), routingKey).iterator().next();
+    PreparedStatement statement =
+        SESSION_RULE
+            .session()
+            .prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS");
+    assertThat(statement.isLWT()).isTrue();
+    for (int i = 0; i < 30; i++) {
+      ResultSet result = session.execute(statement.bind(pk, i, 123));
+      assertThat(result.getExecutionInfo().getCoordinator()).isEqualTo(owner);
+    }
+  }
+
+  @Test
+  // Sanity check for the previous test - non-LWT queries should
+  // not always be sent to same node
+  public void should_not_use_only_one_node_when_non_lwt() {
+    CqlSession session = SESSION_RULE.session();
+    int pk = 1234;
+    PreparedStatement statement = session.prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?)");
+    assertThat(statement.isLWT()).isFalse();
+    Set<Node> coordinators = new HashSet<>();
+    for (int i = 0; i < 30; i++) {
+      ResultSet result = session.execute(statement.bind(pk, i, 123));
+      coordinators.add(result.getExecutionInfo().getCoordinator());
+    }
+
+    // Because keyspace RF == 3
+    assertThat(coordinators.size()).isEqualTo(3);
+  }
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraSkip.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraSkip.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a Class or Method that skips it for Cassandra. If the tests are run against
+ * Cassandra, the test is skipped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CassandraSkip {
+  /** @return The description returned if this requirement is not met. */
+  String description() default "Disabled for Cassandra.";
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -24,10 +24,7 @@ package com.datastax.oss.driver.api.testinfra.ccm;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.Version;
-import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
-import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
-import com.datastax.oss.driver.api.testinfra.DseRequirement;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.*;
 import java.util.Optional;
 import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
@@ -93,6 +90,21 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
             throw new AssumptionViolatedException(
                 String.format(
                     "Test skipped when running with Scylla.  Description: %s", description));
+          }
+        };
+      }
+    }
+
+    CassandraSkip cassandraSkip = description.getAnnotation(CassandraSkip.class);
+    if (cassandraSkip != null) {
+      if (!CcmBridge.SCYLLA_ENABLEMENT) {
+        return new Statement() {
+
+          @Override
+          public void evaluate() {
+            throw new AssumptionViolatedException(
+                String.format(
+                    "Test skipped when running with Cassandra.  Description: %s", description));
           }
         };
       }


### PR DESCRIPTION
PR based on https://github.com/scylladb/java-driver/pull/122, so should get merged after it.

Fixes #24 

PR is generally a port of commits mentioned in above issue, but modified to accommodate different architecture of driver 4.x, and also includes some integration tests.
