### PR TITLE
Add dynamic slug in api docs url

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 from datetime import date
-import yaml
 import re
 from docutils import nodes
 from sphinx.util import logging
@@ -75,7 +73,8 @@ def setup(app):
     app.add_transform(AutoStructify)
 
     # Replace DataStax links
-    replacements = {r'https://docs.datastax.com/en/drivers/java\/(.*?)\/': "https://java-driver.docs.scylladb.com/stable/api/"}
+    current_slug = os.getenv("SPHINX_MULTIVERSION_NAME", "stable")
+    replacements = {r'docs.datastax.com/en/drivers/java\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/api/"}
     app.add_config_value('replacements', replacements, True)
     app.connect('source-read', replace_relative_links)
 


### PR DESCRIPTION
@annastuchlik requested to edit this replacement:

> replacements = {r'https://docs.datastax.com/en/drivers/java\/(.*?)\/': "https://java-driver.docs.scylladb.com/stable/api/"}

To point to the javadoc version the user is reading and not to the latest stable version.