### PR TITLE
Merge 4.14.1

### DIFF
--- a/.github/workflows/dep-lic-scan.yaml
+++ b/.github/workflows/dep-lic-scan.yaml
@@ -1,0 +1,23 @@
+name: Dependency and License Scan
+on:
+  push:
+    branches:
+      - '4.x'
+      - '3.x'
+    paths-ignore:
+      - 'manual/**'
+      - 'faq/**'
+      - 'upgrade_guide/**'
+      - 'changelog/**'
+jobs:
+  scan-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Fossa CLI
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash -s -- -b .
+      - name: Scan for dependencies and licenses
+        run: |
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,8 +356,8 @@ pipeline {
     // schedules only run against release branches (i.e. 3.x, 4.x, 4.5.x, etc.)
     parameterizedCron(branchPatternCron.matcher(env.BRANCH_NAME).matches() ? """
       # Every weeknight (Monday - Friday) around 2:00 AM
-      ### JDK8 tests against 2.1, 3.0, DSE 4.8, DSE 5.0, DSE 5.1, DSE-6.0, DSE 6.7 and DSE 6.8
-      H 2 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;CI_SCHEDULE_SERVER_VERSIONS=2.1 3.0 dse-4.8 dse-5.0 dse-5.1 dse-6.0 dse-6.7 dse-6.8;CI_SCHEDULE_JABBA_VERSION=1.8
+      ### JDK8 tests against 2.1, 3.0, DSE 4.8, DSE 5.0, DSE 5.1, DSE-6.0 and DSE 6.7
+      H 2 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;CI_SCHEDULE_SERVER_VERSIONS=2.1 3.0 dse-4.8 dse-5.0 dse-5.1 dse-6.0 dse-6.7;CI_SCHEDULE_JABBA_VERSION=1.8
       ### JDK11 tests against 3.11, 4.0 and DSE 6.8
       H 2 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;CI_SCHEDULE_SERVER_VERSIONS=3.11 4.0 dse-6.8;CI_SCHEDULE_JABBA_VERSION=openjdk@1.11
       # Every weekend (Sunday) around 12:00 PM noon

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *If you're reading this on github.com, please note that this is the readme for the development 
 version and that some features described here might not yet have been released. You can find the
 documentation for latest version through [DataStax Docs] or via the release tags, e.g. 
-[4.14.0](https://github.com/datastax/java-driver/tree/4.14.0).*
+[4.14.1](https://github.com/datastax/java-driver/tree/4.14.1).*
 
 A modern, feature-rich and highly tunable Java client library for [Apache Cassandra®] \(2.1+) and 
 [DataStax Enterprise] \(4.7+), and [DataStax Astra], using exclusively Cassandra's binary protocol

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *If you're reading this on github.com, please note that this is the readme for the development 
 version and that some features described here might not yet have been released. You can find the
 documentation for latest version through [DataStax Docs] or via the release tags, e.g. 
-[4.13.0](https://github.com/datastax/java-driver/tree/4.13.0).*
+[4.14.0](https://github.com/datastax/java-driver/tree/4.14.0).*
 
 A modern, feature-rich and highly tunable Java client library for [Apache Cassandra®] \(2.1+) and 
 [DataStax Enterprise] \(4.7+), and [DataStax Astra], using exclusively Cassandra's binary protocol
@@ -82,7 +82,7 @@ See the [upgrade guide](upgrade_guide/) for details.
 * [Changelog]
 * [FAQ]
 
-[API docs]: https://docs.datastax.com/en/drivers/java/4.13
+[API docs]: https://docs.datastax.com/en/drivers/java/4.14
 [JIRA]: https://datastax-oss.atlassian.net/browse/JAVA
 [Mailing list]: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
 [@dsJavaDriver]: https://twitter.com/dsJavaDriver

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
@@ -31,42 +31,42 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-processor</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-runtime</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-test-infra</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-micrometer</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-microprofile</artifactId>
-        <version>4.13.1-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
@@ -31,42 +31,42 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-processor</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-runtime</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-test-infra</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-micrometer</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-microprofile</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>4.13.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
@@ -31,42 +31,42 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-processor</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-runtime</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-test-infra</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-micrometer</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-microprofile</artifactId>
-        <version>4.13.0</version>
+        <version>4.13.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
@@ -31,42 +31,42 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-processor</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-runtime</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-test-infra</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-micrometer</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-microprofile</artifactId>
-        <version>4.14.1-SNAPSHOT</version>
+        <version>4.14.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
@@ -31,42 +31,42 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-processor</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-mapper-runtime</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-test-infra</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-micrometer</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-metrics-microprofile</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,12 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.14.1
+
+- [improvement] JAVA-3013: Upgrade dependencies to address CVEs and other security issues, 4.14.1 edition
+- [improvement] JAVA-3003: Update jnr-posix to address CVE-2014-4043
+- [improvement] JAVA-2977: Update Netty to resolve higher-priority CVEs
+
 ### 4.14.0
 
 - [bug] JAVA-2976: Support missing protocol v5 error codes CAS_WRITE_UNKNOWN, CDC_WRITE_FAILURE

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.14.0 (in progress)
+
+- [improvement] JAVA-2959: Don't throw NoNodeAvailableException when all connections busy
+
 ### 4.13.0
 
 - [improvement] JAVA-2940: Add GraalVM native image build configurations

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,8 +2,12 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
-### 4.14.0 (in progress)
+### 4.14.0
 
+- [bug] JAVA-2976: Support missing protocol v5 error codes CAS_WRITE_UNKNOWN, CDC_WRITE_FAILURE
+- [bug] JAVA-2987: BasicLoadBalancingPolicy remote computation assumes local DC is up and live
+- [bug] JAVA-2992: Include options into DefaultTableMetadata equals and hash methods
+- [improvement] JAVA-2982: Switch Esri geometry lib to an optional dependency
 - [improvement] JAVA-2959: Don't throw NoNodeAvailableException when all connections busy
 
 ### 4.13.0
@@ -596,6 +600,17 @@ changelog](https://docs.datastax.com/en/developer/java-driver-dse/latest/changel
 - [new feature] JAVA-1501: Reprepare on the fly when we get an UNPREPARED response
 - [bug] JAVA-1499: Wait for load balancing policy at cluster initialization
 - [new feature] JAVA-1495: Add prepared statements
+
+## 3.11.1
+- [bug] JAVA-2967: Support native transport peer information for DSE 6.8.
+- [bug] JAVA-2976: Support missing protocol v5 error codes CAS_WRITE_UNKNOWN, CDC_WRITE_FAILURE.
+
+## 3.11.0
+
+- [improvement] JAVA-2705: Remove protocol v5 beta status, add v6-beta.
+- [bug] JAVA-2923: Detect and use Guava's new HostAndPort.getHost method.
+- [bug] JAVA-2922: Switch to modern framing format inside a channel handler.
+- [bug] JAVA-2924: Consider protocol version unsupported when server requires USE_BETA flag for it.
 
 ### 3.10.2
 

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>HdrHistogram</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tinkerpop</groupId>
       <artifactId>gremlin-core</artifactId>
       <optional>true</optional>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-core-shaded</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-core-shaded</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-core-shaded</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -146,9 +146,6 @@
                   -->
                   <include>com.datastax.oss:java-driver-core</include>
                   <include>io.netty:*</include>
-                  <include>com.esri.geometry:*</include>
-                  <include>org.json:*</include>
-                  <include>org.codehaus.jackson:*</include>
                   <include>com.fasterxml.jackson.core:*</include>
                 </includes>
               </artifactSet>
@@ -160,18 +157,6 @@
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.esri</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.esri</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.json</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.json</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.codehaus.jackson</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.codehaus.jackson</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
@@ -190,24 +175,6 @@
                 </filter>
                 <filter>
                   <artifact>io.netty:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>com.esri.geometry:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.json:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.codehaus.jackson:*</artifact>
                   <excludes>
                     <exclude>META-INF/**</exclude>
                   </excludes>
@@ -311,6 +278,11 @@
                   <artifactId>jctools-core</artifactId>
                   <version>2.1.2</version>
                 </additionalDependency>
+                <additionalDependency>
+                  <groupId>com.esri.geometry</groupId>
+                  <artifactId>esri-geometry-api</artifactId>
+                  <version>1.2.1</version>
+                </additionalDependency>
               </additionalDependencies>
             </configuration>
           </execution>
@@ -340,7 +312,7 @@
                   <!--
                   1) Don't import packages shaded in the driver bundle. Note that shaded-guava lives
                   in its own bundle, so we must explicitly *not* mention it here.
-                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.esri.*, !com.datastax.oss.driver.shaded.json.*, !com.datastax.oss.driver.shaded.codehaus.jackson.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
+                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
                   <!--
                   2) Don't include the packages below because they contain annotations only and are
                   not required at runtime.
@@ -366,7 +338,7 @@
                 1) The driver's packages (API and internal);
                 2) All shaded packages, except Guava which resides in a separate bundle.
                 -->
-                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.esri.*, com.datastax.oss.driver.shaded.json.*, com.datastax.oss.driver.shaded.codehaus.jackson.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
+                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
               </instructions>
               <rebuildBundle>true</rebuildBundle>
             </configuration>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-core-shaded</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -331,7 +331,7 @@
                   <!--
                   5) Don't import packages imported by shaded classes, if they are not used by the
                   driver bundle.
-                  -->!com.google.protobuf.*, !com.jcraft.jzlib.*, !com.ning.compress.*, !lzma.sdk.*, !net.jpountz.xxhash.*, !org.bouncycastle.*, !org.conscrypt.*, !org.apache.commons.logging.*, !org.apache.log4j.*, !org.apache.logging.log4j.*, !org.eclipse.jetty.*, !org.jboss.marshalling.*, !sun.misc.*, !sun.security.*, !com.barchart.udt.*, !com.fasterxml.aalto.*, !com.sun.nio.sctp.*, !gnu.io.*, !org.xml.sax.*, !org.w3c.dom.*, *
+                  -->!com.google.protobuf.*, !com.jcraft.jzlib.*, !com.ning.compress.*, !lzma.sdk.*, !net.jpountz.xxhash.*, !org.bouncycastle.*, !org.conscrypt.*, !org.apache.commons.logging.*, !org.apache.log4j.*, !org.apache.logging.log4j.*, !org.eclipse.jetty.*, !org.jboss.marshalling.*, !sun.misc.*, !sun.security.*, !com.barchart.udt.*, !com.fasterxml.aalto.*, !com.sun.nio.sctp.*, !gnu.io.*, !org.xml.sax.*, !org.w3c.dom.*, !com.aayushatharva.brotli4j.*, !com.github.luben.zstd.*, *
                 </Import-Package>
                 <!--
                 Export:

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-core-shaded</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>com.esri.geometry</groupId>
       <artifactId>esri-geometry-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.tinkerpop</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-core</artifactId>
   <packaging>bundle</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-core</artifactId>
   <packaging>bundle</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-core</artifactId>
   <packaging>bundle</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-core</artifactId>
   <packaging>bundle</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-core</artifactId>
   <packaging>bundle</packaging>

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -5539,6 +5539,1284 @@
         "old": "missing-class org.apache.tinkerpop.gremlin.structure.VertexProperty",
         "new": "missing-class org.apache.tinkerpop.gremlin.structure.VertexProperty",
         "justification": "JAVA-2907: switched Tinkerpop dependency to optional"
+      },
+      {
+        "code": "java.class.nonFinalClassInheritsFromNewClass",
+        "old": "class com.fasterxml.jackson.core.JsonGenerationException",
+        "new": "class com.fasterxml.jackson.core.JsonGenerationException",
+        "superClass": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.serialVersionUIDChanged",
+        "old": "field com.fasterxml.jackson.core.JsonLocation.serialVersionUID",
+        "new": "field com.fasterxml.jackson.core.JsonLocation.serialVersionUID",
+        "oldSerialVersionUID": "1",
+        "newSerialVersionUID": "2",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.lang.StringBuilder com.fasterxml.jackson.core.JsonLocation::_appendSourceDesc(java.lang.StringBuilder)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.visibilityReduced",
+        "old": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String)",
+        "new": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String)",
+        "oldVisibility": "public",
+        "newVisibility": "protected",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.visibilityReduced",
+        "old": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String, com.fasterxml.jackson.core.JsonLocation)",
+        "new": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String, com.fasterxml.jackson.core.JsonLocation)",
+        "oldVisibility": "public",
+        "newVisibility": "protected",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.visibilityReduced",
+        "old": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String, java.lang.Throwable)",
+        "new": "method void com.fasterxml.jackson.core.exc.StreamReadException::<init>(com.fasterxml.jackson.core.JsonParser, java.lang.String, java.lang.Throwable)",
+        "oldVisibility": "public",
+        "newVisibility": "protected",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.nowFinal",
+        "old": "field com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer._intern",
+        "new": "field com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer._intern",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method void com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer::reportTooManyCollisions(int)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.abstractMethodAdded",
+        "new": "method java.util.List<com.fasterxml.jackson.databind.introspect.AnnotatedAndMetadata<com.fasterxml.jackson.databind.introspect.AnnotatedConstructor, com.fasterxml.jackson.annotation.JsonCreator.Mode>> com.fasterxml.jackson.databind.BeanDescription::getConstructorsWithMode()",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.abstractMethodAdded",
+        "new": "method java.util.List<com.fasterxml.jackson.databind.introspect.AnnotatedAndMetadata<com.fasterxml.jackson.databind.introspect.AnnotatedMethod, com.fasterxml.jackson.annotation.JsonCreator.Mode>> com.fasterxml.jackson.databind.BeanDescription::getFactoryMethodsWithMode()",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::_withMapperFeatures(===int===)",
+        "new": "parameter com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::_withMapperFeatures(===long===)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.finalMethodAddedToNonFinalClass",
+        "new": "method com.fasterxml.jackson.databind.util.TokenBuffer com.fasterxml.jackson.databind.DeserializationContext::bufferForInputBuffering()",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException",
+        "exception": "com.fasterxml.jackson.core.JacksonException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, T) throws java.io.IOException",
+        "new": "method T com.fasterxml.jackson.databind.JsonDeserializer<T>::deserialize(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, T) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException",
+        "exception": "com.fasterxml.jackson.core.JacksonException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method java.lang.Object com.fasterxml.jackson.databind.JsonDeserializer<T>::deserializeWithType(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.jsontype.TypeDeserializer) throws java.io.IOException",
+        "new": "method java.lang.Object com.fasterxml.jackson.databind.JsonDeserializer<T>::deserializeWithType(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.jsontype.TypeDeserializer) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException",
+        "exception": "com.fasterxml.jackson.core.JacksonException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method java.lang.Object com.fasterxml.jackson.databind.JsonDeserializer<T>::deserializeWithType(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.jsontype.TypeDeserializer, T) throws java.io.IOException",
+        "new": "method java.lang.Object com.fasterxml.jackson.databind.JsonDeserializer<T>::deserializeWithType(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.jsontype.TypeDeserializer, T) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException",
+        "exception": "com.fasterxml.jackson.core.JacksonException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.class.nonFinalClassInheritsFromNewClass",
+        "old": "class com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "class com.fasterxml.jackson.databind.JsonMappingException",
+        "superClass": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectMapper::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.JavaType) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectMapper::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.JavaType) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectMapper::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.JavaType) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectMapper::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext, com.fasterxml.jackson.databind.JavaType) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method com.fasterxml.jackson.core.JsonToken com.fasterxml.jackson.databind.ObjectMapper::_initForReading(com.fasterxml.jackson.core.JsonParser) throws java.io.IOException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T extends com.fasterxml.jackson.core.TreeNode> T com.fasterxml.jackson.databind.ObjectMapper::readTree(com.fasterxml.jackson.core.JsonParser) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method <T extends com.fasterxml.jackson.core.TreeNode> T com.fasterxml.jackson.databind.ObjectMapper::readTree(com.fasterxml.jackson.core.JsonParser) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method com.fasterxml.jackson.databind.JsonNode com.fasterxml.jackson.databind.ObjectMapper::readTree(java.io.File) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method com.fasterxml.jackson.databind.JsonNode com.fasterxml.jackson.databind.ObjectMapper::readTree(java.io.File) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], int, int, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(byte[], java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.File, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.InputStream, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.io.Reader, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonParseException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method <T> T com.fasterxml.jackson.databind.ObjectMapper::readValue(java.net.URL, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamReadException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.ResolvedType) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.core.type.TypeReference<T>) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, com.fasterxml.jackson.databind.JavaType) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method <T> com.fasterxml.jackson.databind.MappingIterator<T> com.fasterxml.jackson.databind.ObjectMapper::readValues(com.fasterxml.jackson.core.JsonParser, java.lang.Class<T>) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeTree(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.core.TreeNode) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeTree(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.core.TreeNode) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeTree(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.JsonNode) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeTree(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.JsonNode) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findRootDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findTreeDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findTreeDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findTreeDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<java.lang.Object> com.fasterxml.jackson.databind.ObjectReader::_findTreeDeserializer(com.fasterxml.jackson.databind.DeserializationContext) throws com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUndetectableSource(java.lang.Object) throws com.fasterxml.jackson.core.JsonParseException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUndetectableSource(java.lang.Object) throws com.fasterxml.jackson.core.exc.StreamReadException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamReadException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUndetectableSource(java.lang.Object) throws com.fasterxml.jackson.core.JsonParseException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUndetectableSource(java.lang.Object) throws com.fasterxml.jackson.core.exc.StreamReadException",
+        "exception": "com.fasterxml.jackson.core.JsonParseException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUnkownFormat(com.fasterxml.jackson.databind.deser.DataFormatReaders, com.fasterxml.jackson.databind.deser.DataFormatReaders.Match) throws com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUnkownFormat(com.fasterxml.jackson.databind.deser.DataFormatReaders, com.fasterxml.jackson.databind.deser.DataFormatReaders.Match) throws java.io.IOException",
+        "exception": "java.io.IOException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUnkownFormat(com.fasterxml.jackson.databind.deser.DataFormatReaders, com.fasterxml.jackson.databind.deser.DataFormatReaders.Match) throws com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectReader::_reportUnkownFormat(com.fasterxml.jackson.databind.deser.DataFormatReaders, com.fasterxml.jackson.databind.deser.DataFormatReaders.Match) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.DataOutput, java.lang.Object) throws java.io.IOException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.DataOutput, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.DataOutput, java.lang.Object) throws java.io.IOException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.DataOutput, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.File, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.OutputStream, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.exc.StreamWriteException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException, com.fasterxml.jackson.databind.JsonMappingException",
+        "new": "method void com.fasterxml.jackson.databind.ObjectWriter::writeValue(java.io.Writer, java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.exc.StreamWriteException, com.fasterxml.jackson.databind.DatabindException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.serialVersionUIDUnchanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationConfig.serialVersionUID",
+        "new": "field com.fasterxml.jackson.databind.SerializationConfig.serialVersionUID",
+        "serialVersionUID": "1",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::_withMapperFeatures(===int===)",
+        "new": "parameter com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::_withMapperFeatures(===long===)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.EAGER_SERIALIZER_FETCH",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.EAGER_SERIALIZER_FETCH",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_EMPTY_JSON_ARRAYS",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_EMPTY_JSON_ARRAYS",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_INDEX",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_INDEX",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUM_KEYS_USING_INDEX",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUM_KEYS_USING_INDEX",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_NULL_MAP_VALUES",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_NULL_MAP_VALUES",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.enumConstantOrderChanged",
+        "old": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED",
+        "new": "field com.fasterxml.jackson.databind.SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.finalMethodAddedToNonFinalClass",
+        "new": "method com.fasterxml.jackson.databind.util.TokenBuffer com.fasterxml.jackson.databind.SerializerProvider::bufferForValueConversion()",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.lang.Class<?> com.fasterxml.jackson.databind.SerializerProvider::getSerializationView()",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.typeChanged",
+        "old": "field com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>._mapperFeatures",
+        "new": "field com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>._mapperFeatures",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.field.serialVersionUIDUnchanged",
+        "old": "field com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>.serialVersionUID",
+        "new": "field com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>.serialVersionUID",
+        "serialVersionUID": "2",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter void com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>::<init>(com.fasterxml.jackson.databind.cfg.BaseSettings, ===int===)",
+        "new": "parameter void com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>::<init>(com.fasterxml.jackson.databind.cfg.BaseSettings, ===long===)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter void com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>::<init>(com.fasterxml.jackson.databind.cfg.MapperConfig<T>, ===int===)",
+        "new": "parameter void com.fasterxml.jackson.databind.cfg.MapperConfig<T extends com.fasterxml.jackson.databind.cfg.MapperConfig<T>>::<init>(com.fasterxml.jackson.databind.cfg.MapperConfig<T>, ===long===)",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::_fixAccess(java.util.Collection<com.fasterxml.jackson.databind.deser.SettableBeanProperty>)",
+        "new": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::_fixAccess(java.util.Collection<com.fasterxml.jackson.databind.deser.SettableBeanProperty>) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::addBackReferenceProperty(java.lang.String, com.fasterxml.jackson.databind.deser.SettableBeanProperty)",
+        "new": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::addBackReferenceProperty(java.lang.String, com.fasterxml.jackson.databind.deser.SettableBeanProperty) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::addInjectable(com.fasterxml.jackson.databind.PropertyName, com.fasterxml.jackson.databind.JavaType, com.fasterxml.jackson.databind.util.Annotations, com.fasterxml.jackson.databind.introspect.AnnotatedMember, java.lang.Object)",
+        "new": "method void com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::addInjectable(com.fasterxml.jackson.databind.PropertyName, com.fasterxml.jackson.databind.JavaType, com.fasterxml.jackson.databind.util.Annotations, com.fasterxml.jackson.databind.introspect.AnnotatedMember, java.lang.Object) throws com.fasterxml.jackson.databind.JsonMappingException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedAdded",
+        "old": "method com.fasterxml.jackson.databind.JsonDeserializer<?> com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::build()",
+        "new": "method com.fasterxml.jackson.databind.JsonDeserializer<?> com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder::build() throws com.fasterxml.jackson.databind.JsonMappingException",
+        "exception": "com.fasterxml.jackson.databind.JsonMappingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.class.nonFinalClassInheritsFromNewClass",
+        "old": "class com.fasterxml.jackson.databind.deser.UnresolvedForwardReference",
+        "new": "class com.fasterxml.jackson.databind.deser.UnresolvedForwardReference",
+        "superClass": "com.fasterxml.jackson.databind.DatabindException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.deser.impl.PropertyValue::assign(java.lang.Object) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.deser.impl.PropertyValue::assign(java.lang.Object) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.node.BinaryNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.node.BinaryNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.node.BaseJsonNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException @ com.fasterxml.jackson.databind.node.NumericNode",
+        "new": "method void com.fasterxml.jackson.databind.node.BaseJsonNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException @ com.fasterxml.jackson.databind.node.NumericNode",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.node.BaseJsonNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException @ com.fasterxml.jackson.databind.node.ValueNode",
+        "new": "method void com.fasterxml.jackson.databind.node.BaseJsonNode::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException @ com.fasterxml.jackson.databind.node.ValueNode",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.ser.std.BeanSerializerBase::serializeFieldsFiltered(java.lang.Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException, com.fasterxml.jackson.core.JsonGenerationException",
+        "new": "method void com.fasterxml.jackson.databind.ser.std.BeanSerializerBase::serializeFieldsFiltered(java.lang.Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonGenerationException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
+      },
+      {
+        "code": "java.method.exception.checkedRemoved",
+        "old": "method void com.fasterxml.jackson.databind.type.TypeBase::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException, com.fasterxml.jackson.core.JsonProcessingException",
+        "new": "method void com.fasterxml.jackson.databind.type.TypeBase::serialize(com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider) throws java.io.IOException",
+        "exception": "com.fasterxml.jackson.core.JsonProcessingException",
+        "justification": "Upgrade deps around JAVA-2977 to address outstanding CVEs"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/DseGraphTraversal.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/DseGraphTraversal.java
@@ -34,16 +34,6 @@ class DseGraphTraversal<S, E> extends AbstractRemoteTraversal<S, E> {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public org.apache.tinkerpop.gremlin.process.remote.traversal.RemoteTraversalSideEffects
-      getSideEffects() {
-    // This was deprecated as part of TINKERPOP-2265
-    // and is no longer being promoted as a feature.
-    // return null but do not throw "NotSupportedException"
-    return null;
-  }
-
-  @Override
   public boolean hasNext() {
     return graphNodeIterator.hasNext();
   }

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -24,6 +24,7 @@ import com.datastax.dse.driver.internal.core.graph.binary.GraphBinaryModule;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -253,6 +254,8 @@ public class GraphRequestHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/NodeUnavailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/NodeUnavailableException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * Indicates that a {@link Node} was selected in a query plan, but it had no connection available.
+ *
+ * <p>A common reason to encounter this error is when the configured number of connections per node
+ * and requests per connection is not high enough to absorb the overall request rate. This can be
+ * mitigated by tuning the following options:
+ *
+ * <ul>
+ *   <li>{@code advanced.connection.pool.local.size};
+ *   <li>{@code advanced.connection.pool.remote.size};
+ *   <li>{@code advanced.connection.max-requests-per-connection}.
+ * </ul>
+ *
+ * See {@code reference.conf} for more details.
+ *
+ * <p>Another possibility is when you are trying to direct a request {@linkplain
+ * com.datastax.oss.driver.api.core.cql.Statement#setNode(Node) to a particular node}, but that node
+ * has no connections available.
+ */
+public class NodeUnavailableException extends DriverException {
+
+  private final Node node;
+
+  public NodeUnavailableException(Node node) {
+    super("No connection was available to " + node, null, null, true);
+    this.node = Objects.requireNonNull(node);
+  }
+
+  @NonNull
+  public Node getNode() {
+    return node;
+  }
+
+  @Override
+  @NonNull
+  public DriverException copy() {
+    return new NodeUnavailableException(node);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
@@ -25,7 +25,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * requests.
  *
  * <p>This might happen under heavy load. The driver will automatically try the next node in the
- * query plan. Therefore the only way that the client can observe this exception is as part of a
+ * query plan. Therefore, the only way that the client can observe this exception is as part of a
  * {@link AllNodesFailedException}.
  */
 public class BusyConnectionException extends DriverException {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.servererrors;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.session.Request;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The result of a CAS operation is in an unknown state.
+ *
+ * <p>This exception is processed by {@link RetryPolicy#onErrorResponseVerdict(Request,
+ * CoordinatorException, int)} , which will decide if it is rethrown directly to the client or if
+ * the request should be retried. If all other tried nodes also fail, this exception will appear in
+ * the {@link AllNodesFailedException} thrown to the client.
+ */
+public class CASWriteUnknownException extends QueryConsistencyException {
+
+  public CASWriteUnknownException(
+      @NonNull Node coordinator,
+      @NonNull ConsistencyLevel consistencyLevel,
+      int received,
+      int blockFor) {
+    this(
+        coordinator,
+        String.format(
+            "CAS operation result is unknown - proposal was not accepted by a quorum. (%d / %d)",
+            received, blockFor),
+        consistencyLevel,
+        received,
+        blockFor,
+        null,
+        false);
+  }
+
+  private CASWriteUnknownException(
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @NonNull ConsistencyLevel consistencyLevel,
+      int received,
+      int blockFor,
+      ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
+  }
+
+  @NonNull
+  @Override
+  public DriverException copy() {
+    return new CASWriteUnknownException(
+        getCoordinator(),
+        getMessage(),
+        getConsistencyLevel(),
+        getReceived(),
+        getBlockFor(),
+        getExecutionInfo(),
+        true);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CDCWriteFailureException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CDCWriteFailureException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.servererrors;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.session.Request;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * An attempt was made to write to a commitlog segment which doesn't support CDC mutations.
+ *
+ * <p>This exception is processed by {@link RetryPolicy#onErrorResponseVerdict(Request,
+ * CoordinatorException, int)}, which will decide if it is rethrown directly to the client or if the
+ * request should be retried. If all other tried nodes also fail, this exception will appear in the
+ * {@link AllNodesFailedException} thrown to the client.
+ */
+public class CDCWriteFailureException extends QueryExecutionException {
+
+  public CDCWriteFailureException(@NonNull Node coordinator) {
+    super(coordinator, "Commitlog does not support CDC mutations", null, false);
+  }
+
+  public CDCWriteFailureException(@NonNull Node coordinator, @NonNull String message) {
+    super(coordinator, "Commitlog does not support CDC mutations", null, false);
+  }
+
+  private CDCWriteFailureException(
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
+  }
+
+  @NonNull
+  @Override
+  public DriverException copy() {
+    return new CDCWriteFailureException(getCoordinator(), getMessage(), getExecutionInfo(), true);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
@@ -45,7 +45,8 @@ public class ReadTimeoutException extends QueryConsistencyException {
     this(
         coordinator,
         String.format(
-            "Cassandra timeout during read query at consistency %s (%s)",
+            "Cassandra timeout during read query at consistency %s (%s). "
+                + "In case this was generated during read repair, the consistency level is not representative of the actual consistency.",
             consistencyLevel, formatDetails(received, blockFor, dataPresent)),
         consistencyLevel,
         received,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
@@ -47,7 +47,7 @@ import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Handles the lifecyle of an admin request (such as a node refresh or schema refresh query). */
+/** Handles the lifecycle of an admin request (such as a node refresh or schema refresh query). */
 @ThreadSafe
 public class AdminRequestHandler<ResultT> implements ResponseCallback {
   private static final Logger LOG = LoggerFactory.getLogger(AdminRequestHandler.class);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
@@ -34,7 +34,7 @@ class StreamIdGenerator {
   private final int maxAvailableIds;
   // unset = available, set = borrowed (note that this is the opposite of the 3.x implementation)
   private final BitSet ids;
-  private AtomicInteger availableIds;
+  private final AtomicInteger availableIds;
 
   StreamIdGenerator(int maxAvailableIds) {
     this.maxAvailableIds = maxAvailableIds;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -40,6 +40,8 @@ import com.datastax.oss.driver.api.core.metadata.schema.RelationMetadata;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.datastax.oss.driver.api.core.servererrors.BootstrappingException;
+import com.datastax.oss.driver.api.core.servererrors.CASWriteUnknownException;
+import com.datastax.oss.driver.api.core.servererrors.CDCWriteFailureException;
 import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
 import com.datastax.oss.driver.api.core.servererrors.FunctionFailureException;
 import com.datastax.oss.driver.api.core.servererrors.InvalidConfigurationInQueryException;
@@ -75,6 +77,7 @@ import com.datastax.oss.protocol.internal.request.query.QueryOptions;
 import com.datastax.oss.protocol.internal.response.Error;
 import com.datastax.oss.protocol.internal.response.Result;
 import com.datastax.oss.protocol.internal.response.error.AlreadyExists;
+import com.datastax.oss.protocol.internal.response.error.CASWriteUnknown;
 import com.datastax.oss.protocol.internal.response.error.ReadFailure;
 import com.datastax.oss.protocol.internal.response.error.ReadTimeout;
 import com.datastax.oss.protocol.internal.response.error.Unavailable;
@@ -505,6 +508,15 @@ public class Conversions {
             context.getWriteTypeRegistry().fromName(writeFailure.writeType),
             writeFailure.numFailures,
             writeFailure.reasonMap);
+      case ProtocolConstants.ErrorCode.CDC_WRITE_FAILURE:
+        return new CDCWriteFailureException(node, errorMessage.message);
+      case ProtocolConstants.ErrorCode.CAS_WRITE_UNKNOWN:
+        CASWriteUnknown casFailure = (CASWriteUnknown) errorMessage;
+        return new CASWriteUnknownException(
+            node,
+            context.getConsistencyLevelRegistry().codeToLevel(casFailure.consistencyLevel),
+            casFailure.received,
+            casFailure.blockFor);
       case ProtocolConstants.ErrorCode.SYNTAX_ERROR:
         return new SyntaxError(node, errorMessage.message);
       case ProtocolConstants.ErrorCode.UNAUTHORIZED:

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.core.cql;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -188,6 +189,8 @@ public class CqlPrepareHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -251,6 +252,8 @@ public class CqlRequestHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -323,9 +323,8 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
 
           @Override
           protected Object[] computeNodes() {
-            Set<String> dcs = liveNodes.dcs();
             Object[] remoteNodes =
-                dcs.stream()
+                liveNodes.dcs().stream()
                     .filter(Predicates.not(Predicates.equalTo(localDc)))
                     .flatMap(dc -> liveNodes.dc(dc).stream().limit(maxNodesPerRemoteDc))
                     .toArray();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -42,6 +42,7 @@ import com.datastax.oss.driver.internal.core.util.collection.CompositeQueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.LazyQueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
+import com.datastax.oss.driver.shaded.guava.common.base.Predicates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
@@ -322,30 +323,19 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
 
           @Override
           protected Object[] computeNodes() {
-            Object[] dcs = liveNodes.dcs().toArray();
-            if (dcs.length <= 1) {
-              return EMPTY_NODES;
-            }
-            Object[] remoteNodes = new Object[(dcs.length - 1) * maxNodesPerRemoteDc];
-            int remoteNodesLength = 0;
-            for (Object dc : dcs) {
-              if (!dc.equals(localDc)) {
-                Object[] remoteNodesInDc = liveNodes.dc((String) dc).toArray();
-                for (int i = 0; i < maxNodesPerRemoteDc && i < remoteNodesInDc.length; i++) {
-                  remoteNodes[remoteNodesLength++] = remoteNodesInDc[i];
-                }
-              }
-            }
+            Set<String> dcs = liveNodes.dcs();
+            Object[] remoteNodes =
+                dcs.stream()
+                    .filter(Predicates.not(Predicates.equalTo(localDc)))
+                    .flatMap(dc -> liveNodes.dc(dc).stream().limit(maxNodesPerRemoteDc))
+                    .toArray();
+
+            int remoteNodesLength = remoteNodes.length;
             if (remoteNodesLength == 0) {
               return EMPTY_NODES;
             }
             shuffleHead(remoteNodes, remoteNodesLength);
-            if (remoteNodes.length == remoteNodesLength) {
-              return remoteNodes;
-            }
-            Object[] trimmedRemoteNodes = new Object[remoteNodesLength];
-            System.arraycopy(remoteNodes, 0, trimmedRemoteNodes, 0, remoteNodesLength);
-            return trimmedRemoteNodes;
+            return remoteNodes;
           }
         };
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultTableMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultTableMetadata.java
@@ -142,7 +142,8 @@ public class DefaultTableMetadata implements TableMetadata, Serializable {
           && Objects.equals(this.partitionKey, that.getPartitionKey())
           && Objects.equals(this.clusteringColumns, that.getClusteringColumns())
           && Objects.equals(this.columns, that.getColumns())
-          && Objects.equals(this.indexes, that.getIndexes());
+          && Objects.equals(this.indexes, that.getIndexes())
+          && Objects.equals(this.options, that.getOptions());
     } else {
       return false;
     }
@@ -159,7 +160,8 @@ public class DefaultTableMetadata implements TableMetadata, Serializable {
         partitionKey,
         clusteringColumns,
         columns,
-        indexes);
+        indexes,
+        options);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -143,7 +143,6 @@ public class ChannelPool implements AsyncAutoCloseable {
    *     request path, and we want to avoid complex check-then-act semantics; therefore this might
    *     race and return a channel that is already closed, or {@code null}. In those cases, it is up
    *     to the caller to fail fast and move to the next node.
-   *     <p>There is no need to return the channel.
    */
   public DriverChannel next() {
     return channels.next();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ProtocolUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ProtocolUtils.java
@@ -95,6 +95,10 @@ public class ProtocolUtils {
         return "FUNCTION_FAILURE";
       case ProtocolConstants.ErrorCode.WRITE_FAILURE:
         return "WRITE_FAILURE";
+      case ProtocolConstants.ErrorCode.CDC_WRITE_FAILURE:
+        return "CDC_WRITE_FAILURE";
+      case ProtocolConstants.ErrorCode.CAS_WRITE_UNKNOWN:
+        return "CAS_WRITE_UNKNOWN";
       case ProtocolConstants.ErrorCode.SYNTAX_ERROR:
         return "SYNTAX_ERROR";
       case ProtocolConstants.ErrorCode.UNAUTHORIZED:

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
@@ -125,7 +125,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     factoryHelper.waitForCalls(node, 2);
 
-    // Pool should have shrinked back to 2. We keep the most recent channels so 1 and 2 get closed.
+    // Pool should have shrunk back to 2. We keep the most recent channels so 1 and 2 get closed.
     inOrder.verify(eventBus, VERIFY_TIMEOUT.times(2)).fire(ChannelEvent.channelOpened(node));
     inOrder.verify(eventBus, VERIFY_TIMEOUT.times(2)).fire(ChannelEvent.channelClosed(node));
     inOrder.verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.reconnectionStopped(node));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
@@ -50,7 +50,7 @@ import org.mockito.verification.VerificationWithTimeout;
 abstract class ChannelPoolTestBase {
 
   /** How long we wait when verifying mocks for async invocations */
-  protected static final VerificationWithTimeout VERIFY_TIMEOUT = timeout(500);
+  protected static final VerificationWithTimeout VERIFY_TIMEOUT = timeout(2000);
 
   @Mock protected InternalDriverContext context;
   @Mock private DriverConfig config;

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-distribution</artifactId>
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-distribution</artifactId>
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-distribution</artifactId>
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-distribution</artifactId>
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-distribution</artifactId>
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>java-driver-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-examples</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - examples.</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>java-driver-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-examples</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - examples.</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>java-driver-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-examples</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - examples.</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>java-driver-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-examples</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - examples.</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>java-driver-parent</artifactId>
     <groupId>com.datastax.oss</groupId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-examples</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - examples.</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-integration-tests</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-integration-tests</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -211,6 +211,11 @@
       <artifactId>blockhound-junit-platform</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-integration-tests</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-integration-tests</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-integration-tests</artifactId>
   <packaging>jar</packaging>

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousPagingITBase.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousPagingITBase.java
@@ -16,6 +16,7 @@
 package com.datastax.dse.driver.api.core.cql.continuous;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.codahale.metrics.Timer;
 import com.datastax.dse.driver.api.core.config.DseDriverOption;
@@ -30,6 +31,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.tngtech.java.junit.dataprovider.DataProvider;
+import java.time.Duration;
 import java.util.UUID;
 
 public abstract class ContinuousPagingITBase {
@@ -111,15 +113,33 @@ public abstract class ContinuousPagingITBase {
         .as("assert metrics.getNodeMetric(node, DefaultNodeMetric.CQL_MESSAGES) present")
         .isPresent();
     Timer messages = (Timer) metrics.getNodeMetric(node, DefaultNodeMetric.CQL_MESSAGES).get();
-    assertThat(messages.getCount()).as("assert messages.getCount() >= 0").isGreaterThan(0);
-    assertThat(messages.getMeanRate()).as("assert messages.getMeanRate() >= 0").isGreaterThan(0);
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              assertThat(messages.getCount())
+                  .as("assert messages.getCount() >= 0")
+                  .isGreaterThan(0);
+              assertThat(messages.getMeanRate())
+                  .as("assert messages.getMeanRate() >= 0")
+                  .isGreaterThan(0);
+            });
     assertThat(metrics.getSessionMetric(DseSessionMetric.CONTINUOUS_CQL_REQUESTS))
         .as("assert metrics.getSessionMetric(DseSessionMetric.CONTINUOUS_CQL_REQUESTS) present")
         .isPresent();
     Timer requests =
         (Timer) metrics.getSessionMetric(DseSessionMetric.CONTINUOUS_CQL_REQUESTS).get();
-    assertThat(requests.getCount()).as("assert requests.getCount() >= 0").isGreaterThan(0);
-    assertThat(requests.getMeanRate()).as("assert requests.getMeanRate() >= 0").isGreaterThan(0);
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              assertThat(requests.getCount())
+                  .as("assert requests.getCount() >= 0")
+                  .isGreaterThan(0);
+              assertThat(requests.getMeanRate())
+                  .as("assert requests.getMeanRate() >= 0")
+                  .isGreaterThan(0);
+            });
   }
 
   public static class Options {

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/graph/remote/ClassicGraphTraversalRemoteIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/graph/remote/ClassicGraphTraversalRemoteIT.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.dse.driver.api.core.graph.remote;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
 import com.datastax.dse.driver.api.core.graph.DseGraph;
 import com.datastax.dse.driver.api.core.graph.GraphTestSupport;
 import com.datastax.dse.driver.api.core.graph.SampleGraphScripts;
@@ -24,9 +26,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.testinfra.DseRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
-import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -70,14 +70,12 @@ public class ClassicGraphTraversalRemoteIT extends GraphTraversalRemoteITBase {
 
   @Override
   protected GraphTraversalSource graphTraversalSource() {
-    return AnonymousTraversalSource.traversal()
-        .withRemote(DseGraph.remoteConnectionBuilder(session()).build());
+    return traversal().withRemote(DseGraph.remoteConnectionBuilder(session()).build());
   }
 
   @Override
   protected SocialTraversalSource socialTraversalSource() {
-    return EmptyGraph.instance()
-        .traversal(SocialTraversalSource.class)
+    return traversal(SocialTraversalSource.class)
         .withRemote(DseGraph.remoteConnectionBuilder(session()).build());
   }
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/graph/remote/CoreGraphTraversalRemoteIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/graph/remote/CoreGraphTraversalRemoteIT.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.dse.driver.api.core.graph.remote;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+
 import com.datastax.dse.driver.api.core.graph.DseGraph;
 import com.datastax.dse.driver.api.core.graph.GraphTestSupport;
 import com.datastax.dse.driver.api.core.graph.SampleGraphScripts;
@@ -24,9 +26,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.testinfra.DseRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
-import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -60,15 +60,14 @@ public class CoreGraphTraversalRemoteIT extends GraphTraversalRemoteITBase {
 
   @Override
   protected GraphTraversalSource graphTraversalSource() {
-    return AnonymousTraversalSource.traversal()
+    return traversal()
         .withRemote(DseGraph.remoteConnectionBuilder(session()).build())
         .with("allow-filtering");
   }
 
   @Override
   protected SocialTraversalSource socialTraversalSource() {
-    return EmptyGraph.instance()
-        .traversal(SocialTraversalSource.class)
+    return traversal(SocialTraversalSource.class)
         .withRemote(DseGraph.remoteConnectionBuilder(session()).build())
         .with("allow-filtering");
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ByteOrderedTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ByteOrderedTokenIT.java
@@ -36,7 +36,14 @@ import org.junit.rules.TestRule;
 public class ByteOrderedTokenIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =
-      CustomCcmRule.builder().withNodes(3).withCreateOption("-p ByteOrderedPartitioner").build();
+      CustomCcmRule.builder()
+          .withNodes(3)
+          .withCreateOption("-p ByteOrderedPartitioner")
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
+          .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =
       SessionRule.builder(CCM_RULE)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ByteOrderedTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ByteOrderedTokenVnodesIT.java
@@ -40,6 +40,10 @@ public class ByteOrderedTokenVnodesIT extends TokenITBase {
           .withNodes(3)
           .withCreateOption("-p ByteOrderedPartitioner")
           .withCreateOption("--vnodes")
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
           .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenIT.java
@@ -29,7 +29,14 @@ import org.junit.rules.TestRule;
 
 public class Murmur3TokenIT extends TokenITBase {
 
-  private static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(3).build();
+  private static final CustomCcmRule CCM_RULE =
+      CustomCcmRule.builder()
+          .withNodes(3)
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
+          .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =
       SessionRule.builder(CCM_RULE)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenVnodesIT.java
@@ -35,7 +35,14 @@ import org.junit.rules.TestRule;
 public class Murmur3TokenVnodesIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =
-      CustomCcmRule.builder().withNodes(3).withCreateOption("--vnodes").build();
+      CustomCcmRule.builder()
+          .withNodes(3)
+          .withCreateOption("--vnodes")
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
+          .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =
       SessionRule.builder(CCM_RULE)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
@@ -30,7 +30,14 @@ import org.junit.rules.TestRule;
 public class RandomTokenIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =
-      CustomCcmRule.builder().withNodes(3).withCreateOption("-p RandomPartitioner").build();
+      CustomCcmRule.builder()
+          .withNodes(3)
+          .withCreateOption("-p RandomPartitioner")
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
+          .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =
       SessionRule.builder(CCM_RULE)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
@@ -39,6 +39,10 @@ public class RandomTokenVnodesIT extends TokenITBase {
           .withNodes(3)
           .withCreateOption("-p RandomPartitioner")
           .withCreateOption("--vnodes")
+          .withCassandraConfiguration("range_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("read_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("write_request_timeout_in_ms", 45_000)
+          .withCassandraConfiguration("request_timeout_in_ms", 45_000)
           .build();
 
   private static final SessionRule<CqlSession> SESSION_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
@@ -120,7 +120,7 @@ public class ShutdownIT {
     }
     TimeUnit.MILLISECONDS.sleep(100);
     session.forceCloseAsync();
-    assertThat(gotSessionClosedError.await(1, TimeUnit.SECONDS))
+    assertThat(gotSessionClosedError.await(10, TimeUnit.SECONDS))
         .as("Expected to get the 'Session is closed' error shortly after shutting down")
         .isTrue();
     requestExecutor.shutdownNow();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
@@ -118,7 +118,7 @@ public class ShutdownIT {
             }
           });
     }
-    TimeUnit.MILLISECONDS.sleep(100);
+    TimeUnit.MILLISECONDS.sleep(1000);
     session.forceCloseAsync();
     assertThat(gotSessionClosedError.await(10, TimeUnit.SECONDS))
         .as("Expected to get the 'Session is closed' error shortly after shutting down")

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
@@ -214,7 +214,7 @@ public class RequestLoggerIT {
     sessionRuleRequest.session().execute(QUERY);
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     assertThat(loggingEventCaptor.getValue().getFormattedMessage())
         .contains("Success", "[0 values]", QUERY)
         .matches(WITH_PER_REQUEST_PREFIX);
@@ -229,7 +229,7 @@ public class RequestLoggerIT {
     sessionRuleDefaults.session().execute(QUERY);
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     assertThat(loggingEventCaptor.getValue().getFormattedMessage())
         .contains("Success", "[0 values]", QUERY)
         .matches(WITH_PER_REQUEST_PREFIX);
@@ -249,7 +249,7 @@ public class RequestLoggerIT {
     }
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     ILoggingEvent log = loggingEventCaptor.getValue();
     assertThat(log.getFormattedMessage())
         .contains("Error", "[0 values]", QUERY)
@@ -272,7 +272,7 @@ public class RequestLoggerIT {
     }
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     ILoggingEvent log = loggingEventCaptor.getValue();
     assertThat(log.getFormattedMessage())
         .contains("Error", "[0 values]", QUERY, ServerError.class.getName())
@@ -295,7 +295,7 @@ public class RequestLoggerIT {
     }
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     ILoggingEvent log = loggingEventCaptor.getValue();
     assertThat(log.getFormattedMessage())
         .contains("Error", "[0 values]", QUERY, ServerError.class.getName())
@@ -314,7 +314,7 @@ public class RequestLoggerIT {
         .execute(SimpleStatement.builder(QUERY).setExecutionProfileName("low-threshold").build());
 
     // Then
-    verify(appender, timeout(500)).doAppend(loggingEventCaptor.capture());
+    verify(appender, timeout(5000)).doAppend(loggingEventCaptor.capture());
     assertThat(loggingEventCaptor.getValue().getFormattedMessage())
         .contains("Slow", "[0 values]", QUERY)
         .matches(WITH_PER_REQUEST_PREFIX);
@@ -359,7 +359,7 @@ public class RequestLoggerIT {
         .execute(SimpleStatement.builder(QUERY).setExecutionProfileName("sorting-lbp").build());
 
     // Then
-    verify(appender, new Timeout(500, VerificationModeFactory.times(3)))
+    verify(appender, new Timeout(5000, VerificationModeFactory.times(3)))
         .doAppend(loggingEventCaptor.capture());
     List<ILoggingEvent> events = loggingEventCaptor.getAllValues();
     assertThat(events.get(0).getFormattedMessage())
@@ -392,7 +392,7 @@ public class RequestLoggerIT {
     sessionRuleNode.session().execute(QUERY);
 
     // Then
-    verify(appender, new Timeout(500, VerificationModeFactory.times(2)))
+    verify(appender, new Timeout(5000, VerificationModeFactory.times(2)))
         .doAppend(loggingEventCaptor.capture());
     List<ILoggingEvent> events = loggingEventCaptor.getAllValues();
     assertThat(events.get(0).getFormattedMessage())

--- a/manual/case_sensitivity/README.md
+++ b/manual/case_sensitivity/README.md
@@ -106,11 +106,11 @@ For "consuming" methods, string overloads are also provided for convenience, for
 * in other cases, the string is always assumed to be in CQL form, and converted on the fly with
   `CqlIdentifier.fromCql`. 
 
-[CqlIdentifier]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlIdentifier.html
-[Row]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
-[UdtValue]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/UdtValue.html
-[BoundStatement]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[AccessibleByName]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/AccessibleByName.html
+[CqlIdentifier]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlIdentifier.html
+[Row]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
+[UdtValue]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/UdtValue.html
+[BoundStatement]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[AccessibleByName]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/AccessibleByName.html
 
 ### Good practices
 

--- a/manual/cloud/README.md
+++ b/manual/cloud/README.md
@@ -7,14 +7,13 @@ driver is configured in an application and that you will need to obtain a *secur
 ### Prerequisites
 
 1. [Download][Download Maven] and [install][Install Maven] Maven.
-2. Create an Astra database on [GCP][Create an Astra database - GCP] or
-   [AWS][Create an Astra database - AWS]; alternatively, have a team member provide access to their
-   Astra database (instructions for [GCP][Access an Astra database - GCP] and
-   [AWS][Access an Astra database - AWS]) to obtain database connection details.
+2. Create an Astra database on [AWS/Azure/GCP][Create an Astra database - AWS/Azure/GCP];
+   alternatively, have a team member provide access to their
+   Astra database (instructions for [AWS/Azure/GCP][Access an Astra database - AWS/Azure/GCP] to
+   obtain database connection details.
 3. Download the secure connect bundle (instructions for 
-   [GCP][Download the secure connect bundle - GCP] and 
-   [AWS][Download the secure connect bundle - AWS]), that contains connection information such as
-   contact points and certificates.
+   [AWS/Azure/GCP][Download the secure connect bundle - AWS/Azure/GCP], that contains connection
+   information such as contact points and certificates.
 
 ### Procedure
 
@@ -125,11 +124,8 @@ public class Main {
 
 [Download Maven]: https://maven.apache.org/download.cgi
 [Install Maven]: https://maven.apache.org/install.html
-[Create an Astra database - GCP]: https://docs.datastax.com/en/astra/gcp/doc/dscloud/astra/dscloudGettingStarted.html#dscloudCreateCluster
-[Create an Astra database - AWS]: https://docs.datastax.com/en/astra/aws/doc/dscloud/astra/dscloudGettingStarted.html#dscloudCreateCluster
-[Access an Astra database - GCP]: https://docs.datastax.com/en/astra/gcp/doc/dscloud/astra/dscloudShareClusterDetails.html
-[Access an Astra database - AWS]: https://docs.datastax.com/en/astra/aws/doc/dscloud/astra/dscloudShareClusterDetails.html
-[Download the secure connect bundle - GCP]: https://docs.datastax.com/en/astra/gcp/doc/dscloud/astra/dscloudObtainingCredentials.html
-[Download the secure connect bundle - AWS]: https://docs.datastax.com/en/astra/aws/doc/dscloud/astra/dscloudObtainingCredentials.html
+[Create an Astra database - AWS/Azure/GCP]: https://docs.datastax.com/en/astra/docs/creating-your-astra-database.html
+[Access an Astra database - AWS/Azure/GCP]: https://docs.datastax.com/en/astra/docs/obtaining-database-credentials.html#_sharing_your_secure_connect_bundle
+[Download the secure connect bundle - AWS/Azure/GCP]: https://docs.datastax.com/en/astra/docs/obtaining-database-credentials.html
 [minimal project structure]: ../core/integration/#minimal-project-structure
 [driver documentation]: ../core/configuration/

--- a/manual/core/README.md
+++ b/manual/core/README.md
@@ -314,18 +314,18 @@ for (ColumnDefinitions.Definition definition : row.getColumnDefinitions()) {
 }
 ```
 
-[CqlSession]:                           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html
-[CqlSession#builder()]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html#builder--
-[ResultSet]:                            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[Row]:                                  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
-[CqlIdentifier]:                        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlIdentifier.html
-[AccessibleByName]:                     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/AccessibleByName.html
-[GenericType]:                          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
-[CqlDuration]:                          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/CqlDuration.html
-[TupleValue]:                           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/TupleValue.html
-[UdtValue]:                             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/UdtValue.html
-[SessionBuilder.addContactPoint()]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoint-java.net.InetSocketAddress-
-[SessionBuilder.addContactPoints()]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoints-java.util.Collection-
-[SessionBuilder.withLocalDatacenter()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withLocalDatacenter-java.lang.String-
+[CqlSession]:                           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html
+[CqlSession#builder()]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html#builder--
+[ResultSet]:                            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[Row]:                                  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
+[CqlIdentifier]:                        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlIdentifier.html
+[AccessibleByName]:                     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/AccessibleByName.html
+[GenericType]:                          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
+[CqlDuration]:                          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/CqlDuration.html
+[TupleValue]:                           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/TupleValue.html
+[UdtValue]:                             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/UdtValue.html
+[SessionBuilder.addContactPoint()]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoint-java.net.InetSocketAddress-
+[SessionBuilder.addContactPoints()]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoints-java.util.Collection-
+[SessionBuilder.withLocalDatacenter()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withLocalDatacenter-java.lang.String-
 
 [CASSANDRA-10145]: https://issues.apache.org/jira/browse/CASSANDRA-10145

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -124,7 +124,7 @@ Cassandra node:
 domain name of the target instance. Then it performs a forward DNS lookup of the domain name; the EC2 DNS does the
 private/public switch automatically based on location).
 
-[AddressTranslator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/addresstranslation/AddressTranslator.html
+[AddressTranslator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/addresstranslation/AddressTranslator.html
 
 [cassandra.yaml]:        https://docs.datastax.com/en/cassandra/3.x/cassandra/configuration/configCassandra_yaml.html
 [rpc_address]:           https://docs.datastax.com/en/cassandra/3.x/cassandra/configuration/configCassandra_yaml.html?scroll=configCassandra_yaml__rpc_address

--- a/manual/core/async/README.md
+++ b/manual/core/async/README.md
@@ -207,4 +207,4 @@ documentation for more details and an example.
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 
-[AsyncResultSet]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[AsyncResultSet]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html

--- a/manual/core/authentication/README.md
+++ b/manual/core/authentication/README.md
@@ -227,13 +227,13 @@ session.execute(statement);
 
 [SASL]: https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer
 
-[AuthProvider]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/auth/AuthProvider.html
-[DriverContext]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/context/DriverContext.html
-[PlainTextAuthProviderBase]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.html
-[ProgrammaticPlainTextAuthProvider]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/auth/ProgrammaticPlainTextAuthProvider.html
-[DseGssApiAuthProviderBase]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBase.html
-[ProgrammaticDseGssApiAuthProvider]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/auth/ProgrammaticDseGssApiAuthProvider.html
-[ProxyAuthentication.executeAs]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/auth/ProxyAuthentication.html#executeAs-java.lang.String-StatementT-
-[SessionBuilder.withAuthCredentials]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withAuthCredentials-java.lang.String-java.lang.String-
-[SessionBuilder.withAuthProvider]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withAuthProvider-com.datastax.oss.driver.api.core.auth.AuthProvider-
+[AuthProvider]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/auth/AuthProvider.html
+[DriverContext]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/context/DriverContext.html
+[PlainTextAuthProviderBase]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.html
+[ProgrammaticPlainTextAuthProvider]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/auth/ProgrammaticPlainTextAuthProvider.html
+[DseGssApiAuthProviderBase]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBase.html
+[ProgrammaticDseGssApiAuthProvider]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/auth/ProgrammaticDseGssApiAuthProvider.html
+[ProxyAuthentication.executeAs]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/auth/ProxyAuthentication.html#executeAs-java.lang.String-StatementT-
+[SessionBuilder.withAuthCredentials]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withAuthCredentials-java.lang.String-java.lang.String-
+[SessionBuilder.withAuthProvider]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withAuthProvider-com.datastax.oss.driver.api.core.auth.AuthProvider-
 [reference.conf]: ../configuration/reference/

--- a/manual/core/bom/README.md
+++ b/manual/core/bom/README.md
@@ -13,7 +13,7 @@ To import the driver's BOM, add the following section in your application's own 
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-bom</artifactId>
-        <version>4.13.0</version>
+        <version>4.14.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -65,7 +65,7 @@ good idea to extract a property to keep it in sync with the BOM:
 ```xml
 <project>
   <properties>
-    <java-driver.version>4.13.0</java-driver.version>
+    <java-driver.version>4.14.0</java-driver.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/manual/core/bom/README.md
+++ b/manual/core/bom/README.md
@@ -13,7 +13,7 @@ To import the driver's BOM, add the following section in your application's own 
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-bom</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -65,7 +65,7 @@ good idea to extract a property to keep it in sync with the BOM:
 ```xml
 <project>
   <properties>
-    <java-driver.version>4.14.0</java-driver.version>
+    <java-driver.version>4.14.1</java-driver.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/manual/core/configuration/README.md
+++ b/manual/core/configuration/README.md
@@ -520,16 +520,16 @@ config.getDefaultProfile().getString(MyCustomOption.ADMIN_EMAIL);
 config.getDefaultProfile().getInt(MyCustomOption.AWESOMENESS_FACTOR);
 ```
 
-[DriverConfig]:                           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfig.html
-[DriverExecutionProfile]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverExecutionProfile.html
-[DriverContext]:                          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/context/DriverContext.html
-[DriverOption]:                           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverOption.html
-[DefaultDriverOption]:                    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DefaultDriverOption.html
-[DriverConfigLoader]:                     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html
-[DriverConfigLoader.fromClasspath]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromClasspath-java.lang.String-
-[DriverConfigLoader.fromFile]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromFile-java.io.File-
-[DriverConfigLoader.fromUrl]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromUrl-java.net.URL-
-[DriverConfigLoader.programmaticBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#programmaticBuilder--
+[DriverConfig]:                           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfig.html
+[DriverExecutionProfile]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverExecutionProfile.html
+[DriverContext]:                          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/context/DriverContext.html
+[DriverOption]:                           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverOption.html
+[DefaultDriverOption]:                    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DefaultDriverOption.html
+[DriverConfigLoader]:                     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html
+[DriverConfigLoader.fromClasspath]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromClasspath-java.lang.String-
+[DriverConfigLoader.fromFile]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromFile-java.io.File-
+[DriverConfigLoader.fromUrl]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromUrl-java.net.URL-
+[DriverConfigLoader.programmaticBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#programmaticBuilder--
 
 [Typesafe Config]: https://github.com/typesafehub/config
 [config standard behavior]: https://github.com/typesafehub/config#standard-behavior

--- a/manual/core/control_connection/README.md
+++ b/manual/core/control_connection/README.md
@@ -23,4 +23,4 @@ There are a few options to fine tune the control connection behavior in the
 `advanced.control-connection` and `advanced.metadata` sections; see the [metadata](../metadata/)
 pages and the [reference configuration](../configuration/reference/) for all the details.
 
-[Node.getOpenConnections]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getOpenConnections--
+[Node.getOpenConnections]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getOpenConnections--

--- a/manual/core/custom_codecs/README.md
+++ b/manual/core/custom_codecs/README.md
@@ -660,13 +660,13 @@ private static String formatRow(Row row) {
 }
 ```
 
-[CodecRegistry]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html
-[GenericType]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
-[TypeCodec]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html
-[format()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html#format-JavaTypeT-
-[parse()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html#parse-java.lang.String-
-[MappingCodec]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/MappingCodec.html
-[SessionBuilder.addTypeCodecs]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addTypeCodecs-com.datastax.oss.driver.api.core.type.codec.TypeCodec...-
+[CodecRegistry]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html
+[GenericType]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
+[TypeCodec]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html
+[format()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html#format-JavaTypeT-
+[parse()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodec.html#parse-java.lang.String-
+[MappingCodec]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/MappingCodec.html
+[SessionBuilder.addTypeCodecs]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addTypeCodecs-com.datastax.oss.driver.api.core.type.codec.TypeCodec...-
 
 [Enums]: https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html
 [Enum.name()]: https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html#name--
@@ -680,36 +680,36 @@ private static String formatRow(Row row) {
 [java.time.LocalDateTime]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html
 [java.time.ZoneId]: https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html
 
-[ExtraTypeCodecs]:                           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html
-[ExtraTypeCodecs.BLOB_TO_ARRAY]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BLOB_TO_ARRAY
-[ExtraTypeCodecs.BOOLEAN_LIST_TO_ARRAY]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BOOLEAN_LIST_TO_ARRAY
-[ExtraTypeCodecs.BYTE_LIST_TO_ARRAY]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BYTE_LIST_TO_ARRAY
-[ExtraTypeCodecs.SHORT_LIST_TO_ARRAY]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#SHORT_LIST_TO_ARRAY
-[ExtraTypeCodecs.INT_LIST_TO_ARRAY]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#INT_LIST_TO_ARRAY
-[ExtraTypeCodecs.LONG_LIST_TO_ARRAY]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LONG_LIST_TO_ARRAY
-[ExtraTypeCodecs.FLOAT_LIST_TO_ARRAY]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#FLOAT_LIST_TO_ARRAY
-[ExtraTypeCodecs.DOUBLE_LIST_TO_ARRAY]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#DOUBLE_LIST_TO_ARRAY
-[ExtraTypeCodecs.listToArrayOf(TypeCodec)]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#listToArrayOf-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
-[ExtraTypeCodecs.TIMESTAMP_UTC]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_UTC
-[ExtraTypeCodecs.timestampAt(ZoneId)]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#timestampAt-java.time.ZoneId-
-[ExtraTypeCodecs.TIMESTAMP_MILLIS_SYSTEM]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_MILLIS_SYSTEM
-[ExtraTypeCodecs.TIMESTAMP_MILLIS_UTC]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_MILLIS_UTC
-[ExtraTypeCodecs.timestampMillisAt(ZoneId)]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#timestampMillisAt-java.time.ZoneId-
-[ExtraTypeCodecs.ZONED_TIMESTAMP_SYSTEM]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_SYSTEM
-[ExtraTypeCodecs.ZONED_TIMESTAMP_UTC]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_UTC
-[ExtraTypeCodecs.zonedTimestampAt(ZoneId)]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#zonedTimestampAt-java.time.ZoneId-
-[ExtraTypeCodecs.LOCAL_TIMESTAMP_SYSTEM]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LOCAL_TIMESTAMP_SYSTEM
-[ExtraTypeCodecs.LOCAL_TIMESTAMP_UTC]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LOCAL_TIMESTAMP_UTC
-[ExtraTypeCodecs.localTimestampAt(ZoneId)]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#localTimestampAt-java.time.ZoneId-
-[ExtraTypeCodecs.ZONED_TIMESTAMP_PERSISTED]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_PERSISTED
-[ExtraTypeCodecs.optionalOf(TypeCodec)]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#optionalOf-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
-[ExtraTypeCodecs.enumNamesOf(Class)]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#enumNamesOf-java.lang.Class-
-[ExtraTypeCodecs.enumOrdinalsOf(Class)]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#enumOrdinalsOf-java.lang.Class-
-[ExtraTypeCodecs.json(Class)]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#json-java.lang.Class-
-[ExtraTypeCodecs.json(Class, ObjectMapper)]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#json-java.lang.Class-com.fasterxml.jackson.databind.ObjectMapper-
+[ExtraTypeCodecs]:                           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html
+[ExtraTypeCodecs.BLOB_TO_ARRAY]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BLOB_TO_ARRAY
+[ExtraTypeCodecs.BOOLEAN_LIST_TO_ARRAY]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BOOLEAN_LIST_TO_ARRAY
+[ExtraTypeCodecs.BYTE_LIST_TO_ARRAY]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BYTE_LIST_TO_ARRAY
+[ExtraTypeCodecs.SHORT_LIST_TO_ARRAY]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#SHORT_LIST_TO_ARRAY
+[ExtraTypeCodecs.INT_LIST_TO_ARRAY]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#INT_LIST_TO_ARRAY
+[ExtraTypeCodecs.LONG_LIST_TO_ARRAY]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LONG_LIST_TO_ARRAY
+[ExtraTypeCodecs.FLOAT_LIST_TO_ARRAY]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#FLOAT_LIST_TO_ARRAY
+[ExtraTypeCodecs.DOUBLE_LIST_TO_ARRAY]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#DOUBLE_LIST_TO_ARRAY
+[ExtraTypeCodecs.listToArrayOf(TypeCodec)]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#listToArrayOf-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
+[ExtraTypeCodecs.TIMESTAMP_UTC]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_UTC
+[ExtraTypeCodecs.timestampAt(ZoneId)]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#timestampAt-java.time.ZoneId-
+[ExtraTypeCodecs.TIMESTAMP_MILLIS_SYSTEM]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_MILLIS_SYSTEM
+[ExtraTypeCodecs.TIMESTAMP_MILLIS_UTC]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#TIMESTAMP_MILLIS_UTC
+[ExtraTypeCodecs.timestampMillisAt(ZoneId)]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#timestampMillisAt-java.time.ZoneId-
+[ExtraTypeCodecs.ZONED_TIMESTAMP_SYSTEM]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_SYSTEM
+[ExtraTypeCodecs.ZONED_TIMESTAMP_UTC]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_UTC
+[ExtraTypeCodecs.zonedTimestampAt(ZoneId)]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#zonedTimestampAt-java.time.ZoneId-
+[ExtraTypeCodecs.LOCAL_TIMESTAMP_SYSTEM]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LOCAL_TIMESTAMP_SYSTEM
+[ExtraTypeCodecs.LOCAL_TIMESTAMP_UTC]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#LOCAL_TIMESTAMP_UTC
+[ExtraTypeCodecs.localTimestampAt(ZoneId)]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#localTimestampAt-java.time.ZoneId-
+[ExtraTypeCodecs.ZONED_TIMESTAMP_PERSISTED]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#ZONED_TIMESTAMP_PERSISTED
+[ExtraTypeCodecs.optionalOf(TypeCodec)]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#optionalOf-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
+[ExtraTypeCodecs.enumNamesOf(Class)]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#enumNamesOf-java.lang.Class-
+[ExtraTypeCodecs.enumOrdinalsOf(Class)]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#enumOrdinalsOf-java.lang.Class-
+[ExtraTypeCodecs.json(Class)]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#json-java.lang.Class-
+[ExtraTypeCodecs.json(Class, ObjectMapper)]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#json-java.lang.Class-com.fasterxml.jackson.databind.ObjectMapper-
 
-[TypeCodecs.BLOB]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#BLOB
-[TypeCodecs.TIMESTAMP]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#TIMESTAMP
+[TypeCodecs.BLOB]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#BLOB
+[TypeCodecs.TIMESTAMP]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#TIMESTAMP
 
 
 [ObjectMapper]: http://fasterxml.github.io/jackson-databind/javadoc/2.10/com/fasterxml/jackson/databind/ObjectMapper.html

--- a/manual/core/detachable_types/README.md
+++ b/manual/core/detachable_types/README.md
@@ -137,13 +137,13 @@ Even then, the defaults used by detached objects might be good enough for you:
 Otherwise, just make sure you reattach objects any time you deserialize them or create them from
 scratch.
 
-[CodecRegistry]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html
-[CodecRegistry#DEFAULT]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html#DEFAULT
-[DataType]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/DataType.html
-[Detachable]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/detach/Detachable.html
-[Session]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html
-[ColumnDefinition]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ColumnDefinition.html
-[Row]:                   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
+[CodecRegistry]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html
+[CodecRegistry#DEFAULT]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html#DEFAULT
+[DataType]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/DataType.html
+[Detachable]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/detach/Detachable.html
+[Session]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html
+[ColumnDefinition]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ColumnDefinition.html
+[Row]:                   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
 
 [Java serialization]: https://docs.oracle.com/javase/tutorial/jndi/objects/serial.html
 [protocol specifications]: https://github.com/datastax/native-protocol/tree/1.x/src/main/resources

--- a/manual/core/dse/geotypes/README.md
+++ b/manual/core/dse/geotypes/README.md
@@ -166,9 +166,9 @@ All geospatial types interoperate with three standard formats:
 
 [ESRI]: https://github.com/Esri/geometry-api-java
 
-[LineString]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/data/geometry/LineString.html
-[Point]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/data/geometry/Point.html
-[Polygon]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/data/geometry/Polygon.html
+[LineString]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/data/geometry/LineString.html
+[Point]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/data/geometry/Point.html
+[Polygon]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/data/geometry/Polygon.html
 
 [Well-known text]: https://en.wikipedia.org/wiki/Well-known_text
 [Well-known binary]: https://en.wikipedia.org/wiki/Well-known_text#Well-known_binary

--- a/manual/core/dse/graph/README.md
+++ b/manual/core/dse/graph/README.md
@@ -74,8 +74,8 @@ fluent API returns Apache TinkerPop™ types directly.
 
 [Apache TinkerPop™]: http://tinkerpop.apache.org/
 
-[CqlSession]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html
-[GraphSession]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/GraphSession.html
+[CqlSession]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html
+[GraphSession]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/GraphSession.html
 
 [DSE developer guide]: https://docs.datastax.com/en/dse/6.0/dse-dev/datastax_enterprise/graph/graphTOC.html
 [Gremlin]: https://docs.datastax.com/en/dse/6.0/dse-dev/datastax_enterprise/graph/dseGraphAbout.html#dseGraphAbout__what-is-cql

--- a/manual/core/dse/graph/fluent/README.md
+++ b/manual/core/dse/graph/fluent/README.md
@@ -109,8 +109,8 @@ All the DSE predicates are available on the driver side:
             .values("name");
     ```
 
-[Search]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/predicates/Search.html
-[Geo]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/predicates/Geo.html
+[Search]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/predicates/Search.html
+[Geo]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/predicates/Geo.html
 
 [Apache TinkerPop™]: http://tinkerpop.apache.org/
 [TinkerPop DSL]: http://tinkerpop.apache.org/docs/current/reference/#dsl

--- a/manual/core/dse/graph/fluent/explicit/README.md
+++ b/manual/core/dse/graph/fluent/explicit/README.md
@@ -105,9 +105,9 @@ added in a future version.
 
 See also the [parent page](../) for topics common to all fluent traversals. 
 
-[FluentGraphStatement]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html
-[FluentGraphStatement.newInstance]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html#newInstance-org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal-
-[FluentGraphStatement.builder]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html#builder-org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal-
-[BatchGraphStatement]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html
-[BatchGraphStatement.newInstance]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html#newInstance--
-[BatchGraphStatement.builder]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html#builder--
+[FluentGraphStatement]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html
+[FluentGraphStatement.newInstance]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html#newInstance-org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal-
+[FluentGraphStatement.builder]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/FluentGraphStatement.html#builder-org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal-
+[BatchGraphStatement]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html
+[BatchGraphStatement.newInstance]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html#newInstance--
+[BatchGraphStatement.builder]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/BatchGraphStatement.html#builder--

--- a/manual/core/dse/graph/results/README.md
+++ b/manual/core/dse/graph/results/README.md
@@ -137,8 +137,8 @@ If a type doesn't have a corresponding `asXxx()` method, use the variant that ta
 UUID uuid = graphNode.as(UUID.class);
 ```
 
-[GraphNode]:           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/GraphNode.html
-[GraphResultSet]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/GraphResultSet.html
-[AsyncGraphResultSet]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/AsyncGraphResultSet.html
+[GraphNode]:           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/GraphNode.html
+[GraphResultSet]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/GraphResultSet.html
+[AsyncGraphResultSet]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/AsyncGraphResultSet.html
 
 [DSE data types]: https://docs.datastax.com/en/dse/6.0/dse-dev/datastax_enterprise/graph/reference/refDSEGraphDataTypes.html

--- a/manual/core/dse/graph/script/README.md
+++ b/manual/core/dse/graph/script/README.md
@@ -101,6 +101,6 @@ Note however that some types of queries can only be performed through the script
 * configuration;
 * DSE graph schema queries.
 
-[ScriptGraphStatement]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html
-[ScriptGraphStatement.newInstance]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html#newInstance-java.lang.String-
-[ScriptGraphStatement.builder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html#builder-java.lang.String-
+[ScriptGraphStatement]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html
+[ScriptGraphStatement.newInstance]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html#newInstance-java.lang.String-
+[ScriptGraphStatement.builder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/graph/ScriptGraphStatement.html#builder-java.lang.String-

--- a/manual/core/graalvm/README.md
+++ b/manual/core/graalvm/README.md
@@ -1,9 +1,9 @@
-## Using the driver in GraalVM native images
+## GraalVM native images
 
 ### Quick overview
 
-* [GraalVM Native images](https://www.graalvm.org/reference-manual/native-image/) using the driver 
-  can be built with no additional configuration starting with driver 4.13.0.
+* [GraalVM native images](https://www.graalvm.org/reference-manual/native-image/) can be built with 
+  no additional configuration starting with driver 4.13.0.
 * But extra configurations are required in a few cases:
   * When using [reactive programming](../reactive);
   * When using [Jackson](../integration#Jackson);
@@ -132,7 +132,7 @@ following configurations must be added:
 
 ### Using the Jackson JSON library
 
-[Jackson](https://github.com/FasterXML/jackson) is used in [a few places](../integration#Jackson) in 
+[Jackson](https://github.com/FasterXML/jackson) is used in [a few places](../integration#jackson) in 
 the driver, but is an optional dependency; if you intend to use Jackson, the following 
 configurations must be added:
 
@@ -223,7 +223,7 @@ configuration is required:
 
 ### Native calls
 
-The driver performs a few [native calls](../integration#Native-libraries) using 
+The driver performs a few [native calls](../integration#native-libraries) using 
 [JNR](https://github.com/jnr).
 
 Starting with driver 4.7.0, native calls are also possible in a GraalVM native image, without any

--- a/manual/core/idempotence/README.md
+++ b/manual/core/idempotence/README.md
@@ -60,5 +60,5 @@ assert bs.isIdempotent();
 The query builder tries to infer idempotence automatically; refer to
 [its manual](../../query_builder/idempotence/) for more details.
 
-[Statement.setIdempotent]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Statement.html#setIdempotent-java.lang.Boolean-
-[StatementBuilder.setIdempotence]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/StatementBuilder.html#setIdempotence-java.lang.Boolean-
+[Statement.setIdempotent]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Statement.html#setIdempotent-java.lang.Boolean-
+[StatementBuilder.setIdempotence]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/StatementBuilder.html#setIdempotence-java.lang.Boolean-

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -562,6 +562,7 @@ Here are the recommended TinkerPop versions for each driver version:
 
 <table>
 <tr><th>Driver version</th><th>TinkerPop version</th></tr>
+<tr><td>4.14.0</td><td>3.4.10</td></tr>
 <tr><td>4.13.0</td><td>3.4.10</td></tr>
 <tr><td>4.12.0</td><td>3.4.10</td></tr>
 <tr><td>4.11.0</td><td>3.4.10</td></tr>
@@ -662,6 +663,6 @@ The remaining core driver dependencies are the only ones that are truly mandator
 [guava]: https://github.com/google/guava/issues/2721
 [annotation processing]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#sthref65
 
-[Session.getMetrics]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#getMetrics--
-[SessionBuilder.addContactPoint]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoint-java.net.InetSocketAddress-
-[Uuids]:                          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/uuid/Uuids.html
+[Session.getMetrics]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#getMetrics--
+[SessionBuilder.addContactPoint]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addContactPoint-java.net.InetSocketAddress-
+[Uuids]:                          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/uuid/Uuids.html

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -562,6 +562,7 @@ Here are the recommended TinkerPop versions for each driver version:
 
 <table>
 <tr><th>Driver version</th><th>TinkerPop version</th></tr>
+<tr><td>4.14.1</td><td>3.5.3</td></tr>
 <tr><td>4.14.0</td><td>3.4.10</td></tr>
 <tr><td>4.13.0</td><td>3.4.10</td></tr>
 <tr><td>4.12.0</td><td>3.4.10</td></tr>

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -479,8 +479,9 @@ don't use any of the above features, you can safely exclude the dependency:
 Our [geospatial types](../dse/geotypes/) implementation is based on the [Esri Geometry
 API](https://github.com/Esri/geometry-api-java).
 
-Esri is declared as a required dependency, but the driver can operate normally without it. If you
-don't use geospatial types anywhere in your application, you can exclude the dependency:
+For driver versions >= 4.4.0 and < 4.14.0 Esri is declared as a required dependency,
+although the driver can operate normally without it. If you don't use geospatial types
+anywhere in your application you can exclude the dependency:
 
 ```xml
 <dependency>
@@ -495,6 +496,22 @@ don't use geospatial types anywhere in your application, you can exclude the dep
   </exclusions>
 </dependency>
 ```
+
+Starting with driver 4.14.0 Esri has been changed to an optional dependency.  You no longer have to
+explicitly exclude the dependency if it's not used, but if you do wish to make use of the Esri
+library you must now explicitly specify it as a dependency :
+
+```xml
+<dependency>
+  <groupId>com.esri.geometry</groupId>
+  <artifactId>esri-geometry-api</artifactId>
+  <version>${esri.version}</version>
+</dependency>
+```
+
+In the dependency specification above you should use any 1.2.x version of Esri (we recommend
+1.2.1).  These versions are older than the current 2.x versions of the library but they are
+guaranteed to be fully compatible with DSE.
 
 #### TinkerPop
 

--- a/manual/core/load_balancing/README.md
+++ b/manual/core/load_balancing/README.md
@@ -426,12 +426,12 @@ Then it uses the "closest" distance for any given node. For example:
 * policy1 changes its suggestion to IGNORED. node1 is set to REMOTE;
 * policy1 changes its suggestion to REMOTE. node1 stays at REMOTE.
 
-[DriverContext]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/context/DriverContext.html
-[LoadBalancingPolicy]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/loadbalancing/LoadBalancingPolicy.html
+[DriverContext]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/context/DriverContext.html
+[LoadBalancingPolicy]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/loadbalancing/LoadBalancingPolicy.html
 [BasicLoadBalancingPolicy]: https://github.com/datastax/java-driver/blob/4.x/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
-[getRoutingKeyspace()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKeyspace--
-[getRoutingToken()]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Request.html#getRoutingToken--
-[getRoutingKey()]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKey--
-[NodeDistanceEvaluator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/loadbalancing/NodeDistanceEvaluator.html
+[getRoutingKeyspace()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKeyspace--
+[getRoutingToken()]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Request.html#getRoutingToken--
+[getRoutingKey()]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKey--
+[NodeDistanceEvaluator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/loadbalancing/NodeDistanceEvaluator.html
 [`nodetool status`]: https://docs.datastax.com/en/dse/6.7/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html 
 [cqlsh]: https://docs.datastax.com/en/dse/6.7/cql/cql/cql_using/startCqlshStandalone.html

--- a/manual/core/metadata/README.md
+++ b/manual/core/metadata/README.md
@@ -56,6 +56,6 @@ new keyspace in the schema metadata before the token metadata was updated.
 Schema and node state events are debounced. This allows you to control how often the metadata gets
 refreshed. See the [Performance](../performance/#debouncing) page for more details.
 
-[Session#getMetadata]:                          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#getMetadata--
-[Metadata]:                                     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Metadata.html
-[Node]:                                         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html
+[Session#getMetadata]:                          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#getMetadata--
+[Metadata]:                                     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Metadata.html
+[Node]:                                         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html

--- a/manual/core/metadata/node/README.md
+++ b/manual/core/metadata/node/README.md
@@ -129,17 +129,17 @@ beyond the scope of this document; if you're interested, study the `TopologyMoni
 the source code.
 
 
-[Metadata#getNodes]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Metadata.html#getNodes--
-[Node]:                      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html
-[Node#getState()]:           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getState--
-[Node#getDatacenter()]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getDatacenter--
-[Node#getRack()]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getRack--
-[Node#getDistance()]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getDistance--
-[Node#getExtras()]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getExtras--
-[Node#getOpenConnections()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#getOpenConnections--
-[Node#isReconnecting()]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Node.html#isReconnecting--
-[NodeState]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/NodeState.html
-[NodeStateListener]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/NodeStateListener.html
-[NodeStateListenerBase]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/NodeStateListenerBase.html
-[SessionBuilder.addNodeStateListener]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addNodeStateListener-com.datastax.oss.driver.api.core.metadata.NodeStateListener-
-[DseNodeProperties]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/metadata/DseNodeProperties.html
+[Metadata#getNodes]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Metadata.html#getNodes--
+[Node]:                      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html
+[Node#getState()]:           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getState--
+[Node#getDatacenter()]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getDatacenter--
+[Node#getRack()]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getRack--
+[Node#getDistance()]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getDistance--
+[Node#getExtras()]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getExtras--
+[Node#getOpenConnections()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#getOpenConnections--
+[Node#isReconnecting()]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Node.html#isReconnecting--
+[NodeState]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/NodeState.html
+[NodeStateListener]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/NodeStateListener.html
+[NodeStateListenerBase]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/NodeStateListenerBase.html
+[SessionBuilder.addNodeStateListener]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addNodeStateListener-com.datastax.oss.driver.api.core.metadata.NodeStateListener-
+[DseNodeProperties]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/metadata/DseNodeProperties.html

--- a/manual/core/metadata/schema/README.md
+++ b/manual/core/metadata/schema/README.md
@@ -321,16 +321,16 @@ unavailable for the excluded keyspaces.
 If you issue schema-altering requests from the driver (e.g. `session.execute("CREATE TABLE ..")`),
 take a look at the [Performance](../../performance/#schema-updates) page for a few tips.
 
-[Metadata#getKeyspaces]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Metadata.html#getKeyspaces--
-[SchemaChangeListener]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListener.html
-[SchemaChangeListenerBase]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListenerBase.html
-[Session#setSchemaMetadataEnabled]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#setSchemaMetadataEnabled-java.lang.Boolean-
-[Session#checkSchemaAgreementAsync]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#checkSchemaAgreementAsync--
-[SessionBuilder#addSchemaChangeListener]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addSchemaChangeListener-com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener-
-[ExecutionInfo#isSchemaInAgreement]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#isSchemaInAgreement--
-[com.datastax.dse.driver.api.core.metadata.schema]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/metadata/schema/package-frame.html
-[DseFunctionMetadata]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/metadata/schema/DseFunctionMetadata.html
-[DseAggregateMetadata]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadata.html
+[Metadata#getKeyspaces]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Metadata.html#getKeyspaces--
+[SchemaChangeListener]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListener.html
+[SchemaChangeListenerBase]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListenerBase.html
+[Session#setSchemaMetadataEnabled]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#setSchemaMetadataEnabled-java.lang.Boolean-
+[Session#checkSchemaAgreementAsync]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#checkSchemaAgreementAsync--
+[SessionBuilder#addSchemaChangeListener]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addSchemaChangeListener-com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener-
+[ExecutionInfo#isSchemaInAgreement]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#isSchemaInAgreement--
+[com.datastax.dse.driver.api.core.metadata.schema]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/metadata/schema/package-frame.html
+[DseFunctionMetadata]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/metadata/schema/DseFunctionMetadata.html
+[DseAggregateMetadata]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadata.html
 
 [JAVA-750]: https://datastax-oss.atlassian.net/browse/JAVA-750
 [java.util.regex.Pattern]: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html

--- a/manual/core/metadata/token/README.md
+++ b/manual/core/metadata/token/README.md
@@ -169,5 +169,5 @@ on [schema metadata](../schema/). If schema metadata is disabled or filtered, to
 also be unavailable for the excluded keyspaces.
 
 
-[Metadata#getTokenMap]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/Metadata.html#getTokenMap--
-[TokenMap]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/TokenMap.html
+[Metadata#getTokenMap]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/Metadata.html#getTokenMap--
+[TokenMap]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/TokenMap.html

--- a/manual/core/native_protocol/README.md
+++ b/manual/core/native_protocol/README.md
@@ -135,6 +135,6 @@ If you want to see the details of mixed cluster negotiation, enable `DEBUG` leve
 [protocol spec]: https://github.com/datastax/native-protocol/tree/1.x/src/main/resources
 [driver3]: https://docs.datastax.com/en/developer/java-driver/3.10/manual/native_protocol/
 
-[ExecutionInfo.getWarnings]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getWarnings--
-[Request.getCustomPayload]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Request.html#getCustomPayload--
-[AttachmentPoint.getProtocolVersion]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/detach/AttachmentPoint.html#getProtocolVersion--
+[ExecutionInfo.getWarnings]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getWarnings--
+[Request.getCustomPayload]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Request.html#getCustomPayload--
+[AttachmentPoint.getProtocolVersion]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/detach/AttachmentPoint.html#getProtocolVersion--

--- a/manual/core/non_blocking/README.md
+++ b/manual/core/non_blocking/README.md
@@ -49,22 +49,22 @@ For example, calling any synchronous method declared in [`SyncCqlSession`], such
 will block until the result is available. These methods should never be used in non-blocking 
 applications.
 
-[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
-[`execute`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html#execute-com.datastax.oss.driver.api.core.cql.Statement-
+[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
+[`execute`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html#execute-com.datastax.oss.driver.api.core.cql.Statement-
 
 However, the asynchronous methods declared in [`AsyncCqlSession`], such as [`executeAsync`], are all 
 safe for use in non-blocking applications; the statement execution and asynchronous result delivery 
 is guaranteed to never block. 
 
-[`AsyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncCqlSession.html
-[`executeAsync`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncCqlSession.html#executeAsync-com.datastax.oss.driver.api.core.cql.Statement-
+[`AsyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncCqlSession.html
+[`executeAsync`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncCqlSession.html#executeAsync-com.datastax.oss.driver.api.core.cql.Statement-
 
 The same applies to the methods declared in [`ReactiveSession`] such as [`executeReactive`]: the 
 returned publisher will never block when subscribed to, until the final results are delivered to 
 the subscriber.
 
-[`ReactiveSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html
-[`executeReactive`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html#executeReactive-com.datastax.oss.driver.api.core.cql.Statement-
+[`ReactiveSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html
+[`executeReactive`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html#executeReactive-com.datastax.oss.driver.api.core.cql.Statement-
 
 There is one exception though: continuous paging queries (a feature specific to DSE) have a special
 execution model which uses internal locks for coordination. Although such locks are only held for 
@@ -77,10 +77,10 @@ reactive APIs like [`executeContinuouslyAsync`] and [`executeContinuouslyReactiv
 though, continuous paging is extremely efficient and can safely be used in most non-blocking 
 contexts, unless they require strict lock-freedom.
 
-[`ContinuousSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.html
-[`ContinuousReactiveSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.html
-[`executeContinuouslyAsync`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.html#executeContinuouslyAsync-com.datastax.oss.driver.api.core.cql.Statement-
-[`executeContinuouslyReactive`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.html#executeContinuouslyReactive-com.datastax.oss.driver.api.core.cql.Statement-
+[`ContinuousSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.html
+[`ContinuousReactiveSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.html
+[`executeContinuouslyAsync`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.html#executeContinuouslyAsync-com.datastax.oss.driver.api.core.cql.Statement-
+[`executeContinuouslyReactive`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.html#executeContinuouslyReactive-com.datastax.oss.driver.api.core.cql.Statement-
 
 #### Driver lock-free guarantees per session lifecycle phases
 
@@ -110,8 +110,8 @@ Similarly, a call to [`SessionBuilder.build()`] should be considered blocking as
 calling thread and wait until the method returns. For this reason, calls to `SessionBuilder.build()` 
 should be avoided in non-blocking applications.
 
-[`SessionBuilder.buildAsync()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#buildAsync--
-[`SessionBuilder.build()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#build--
+[`SessionBuilder.buildAsync()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#buildAsync--
+[`SessionBuilder.build()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#build--
 
 Once the session is initialized, however, the driver is guaranteed to be non-blocking during the
 session's lifecycle, and under normal operation, unless otherwise noted elsewhere in this document.
@@ -121,8 +121,8 @@ during that phase. Therefore, calls to any method declared in [`AsyncAutoCloseab
 asynchronous ones like [`closeAsync()`], should also be preferably deferred until the application is 
 shut down and lock-freedom enforcement is disabled.
 
-[`AsyncAutoCloseable`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AsyncAutoCloseable.html
-[`closeAsync()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AsyncAutoCloseable.html#closeAsync--
+[`AsyncAutoCloseable`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AsyncAutoCloseable.html
+[`closeAsync()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AsyncAutoCloseable.html#closeAsync--
 
 #### Driver lock-free guarantees for specific components
 
@@ -131,7 +131,7 @@ Certain driver components are not implemented in lock-free algorithms.
 For example, [`SafeInitNodeStateListener`] is implemented with internal locks for coordination. It 
 should not be used if strict lock-freedom is enforced.
 
-[`SafeInitNodeStateListener`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListener.html
+[`SafeInitNodeStateListener`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListener.html
 
 The same is valid for both built-in [request throttlers]:
 
@@ -143,7 +143,7 @@ use locks internally, and depending on how many requests are being executed in p
 contention on these locks can be high: in short, if your application enforces strict lock-freedom, 
 then these components should not be used.
 
-[request throttlers]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/throttling/RequestThrottler.html
+[request throttlers]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/throttling/RequestThrottler.html
 
 Other components may be lock-free, *except* for their first invocation. This is the case of the 
 following items:
@@ -151,8 +151,8 @@ following items:
 * All built-in implementations of [`TimestampGenerator`], upon instantiation;
 * The utility method [`Uuids.timeBased()`].
 
-[`TimestampGenerator`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/time/TimestampGenerator.html
-[`Uuids.timeBased()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/uuid/Uuids.html#timeBased--
+[`TimestampGenerator`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/time/TimestampGenerator.html
+[`Uuids.timeBased()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/uuid/Uuids.html#timeBased--
 
 Both components need to access native libraries when they get initialized and this may involve 
 hitting the local filesystem, thus causing the initialization to become a blocking call.
@@ -172,7 +172,7 @@ One component, the codec registry, can block when its [`register`] method is cal
 therefore advised that codecs should be registered during application startup exclusively. See the
 [custom codecs](../custom_codecs) section for more details about registering codecs.
 
-[`register`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/registry/MutableCodecRegistry.html#register-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
+[`register`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/registry/MutableCodecRegistry.html#register-com.datastax.oss.driver.api.core.type.codec.TypeCodec-
 
 Finally, a few internal components also use locks, but only during session initialization; once the 
 session is ready, they are either discarded, or don't use locks anymore for the rest of the 
@@ -213,7 +213,7 @@ lock-freedom enforcement tools could report calls to that method, but it was imp
 these calls. Thanks to [JAVA-2449], released with driver 4.10.0, `Uuids.random()` became a
 non-blocking call and random UUIDs can now be safely generated in non-blocking applications.
 
-[`Uuids.random()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/uuid/Uuids.html#random--
+[`Uuids.random()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/uuid/Uuids.html#random--
 [JAVA-2449]: https://datastax-oss.atlassian.net/browse/JAVA-2449
 
 #### Driver lock-free guarantees when reloading the configuration
@@ -228,8 +228,8 @@ detectors. If that is the case, it is advised to disable hot-reloading by settin
 `datastax-java-driver.basic.config-reload-interval` option to 0. See the manual page on 
 [configuration](../configuration) for more information.
 
-[`DriverConfigLoader`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html
-[hot-reloading]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#supportsReloading--
+[`DriverConfigLoader`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html
+[hot-reloading]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#supportsReloading--
 
 #### Driver lock-free guarantees when connecting to DSE
 

--- a/manual/core/non_blocking/README.md
+++ b/manual/core/non_blocking/README.md
@@ -29,7 +29,7 @@ primitives such as atomic variables and CAS (compare-and-swap) instructions.
 
 A further distinction is generally established between "lock-free" and "wait-free" algorithms: the 
 former ones allow progress of the overall system, while the latter ones allow each thread to make 
-progress at any time. This distinction is however rather theoretical and is outside of the scope of 
+progress at any time. This distinction is however rather theoretical and is outside the scope of 
 this document.
 
 [lock-free]: https://www.baeldung.com/lock-free-programming

--- a/manual/core/paging/README.md
+++ b/manual/core/paging/README.md
@@ -253,12 +253,12 @@ protocol page size and the logical page size to the same value.
 The [driver examples] include two complete web service implementations demonstrating forward-only
 and offset paging.
 
-[ResultSet]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[AsyncResultSet]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[AsyncPagingIterable.hasMorePages]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AsyncPagingIterable.html#hasMorePages--
-[AsyncPagingIterable.fetchNextPage]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AsyncPagingIterable.html#fetchNextPage--
-[OffsetPager]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/paging/OffsetPager.html
-[PagingState]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/PagingState.html
+[ResultSet]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[AsyncResultSet]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[AsyncPagingIterable.hasMorePages]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AsyncPagingIterable.html#hasMorePages--
+[AsyncPagingIterable.fetchNextPage]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AsyncPagingIterable.html#fetchNextPage--
+[OffsetPager]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/paging/OffsetPager.html
+[PagingState]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/PagingState.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 

--- a/manual/core/performance/README.md
+++ b/manual/core/performance/README.md
@@ -345,8 +345,8 @@ possible to reuse the same event loop group for I/O, admin tasks, and even your 
 (the driver's internal code is fully asynchronous so it will never block any thread). The timer is
 the only one that will have to stay on a separate thread.
 
-[AccessibleByName]:                    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/AccessibleByName.html
-[CqlIdentifier]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlIdentifier.html
-[CqlSession.prepare(SimpleStatement)]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html#prepare-com.datastax.oss.driver.api.core.cql.SimpleStatement-
-[GenericType]:                         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
-[Statement.setNode()]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Statement.html#setNode-com.datastax.oss.driver.api.core.metadata.Node-
+[AccessibleByName]:                    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/AccessibleByName.html
+[CqlIdentifier]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlIdentifier.html
+[CqlSession.prepare(SimpleStatement)]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html#prepare-com.datastax.oss.driver.api.core.cql.SimpleStatement-
+[GenericType]:                         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
+[Statement.setNode()]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Statement.html#setNode-com.datastax.oss.driver.api.core.metadata.Node-

--- a/manual/core/pooling/README.md
+++ b/manual/core/pooling/README.md
@@ -170,5 +170,5 @@ you experience the issue, here's what to look out for:
 Try adding more connections per node. Thanks to the driver's hot-reload mechanism, you can do that
 at runtime and see the effects immediately.
 
-[CqlSession]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html
+[CqlSession]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html
 [CASSANDRA-8086]: https://issues.apache.org/jira/browse/CASSANDRA-8086

--- a/manual/core/query_timestamps/README.md
+++ b/manual/core/query_timestamps/README.md
@@ -187,9 +187,9 @@ Here is the order of precedence of all the methods described so far:
 3. otherwise, if the timestamp generator assigned a timestamp, use it;
 4. otherwise, let the server assign the timestamp.
 
-[TimestampGenerator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/time/TimestampGenerator.html
+[TimestampGenerator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/time/TimestampGenerator.html
 
 [gettimeofday]: http://man7.org/linux/man-pages/man2/settimeofday.2.html
 [JNR]: https://github.com/jnr/jnr-posix
 [Lightweight transactions]: https://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useInsertLWT.html
-[Statement.setQueryTimestamp()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Statement.html#setQueryTimestamp-long-
+[Statement.setQueryTimestamp()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Statement.html#setQueryTimestamp-long-

--- a/manual/core/reactive/README.md
+++ b/manual/core/reactive/README.md
@@ -367,18 +367,18 @@ Note that the driver already has a [built-in retry mechanism] that can transpare
 queries; the above example should be seen as a demonstration of application-level retries, when a
 more fine-grained control of what should be retried, and how, is required.
 
-[CqlSession]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html
-[ReactiveSession]:                  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html
-[ResultSet]:                        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[ReactiveResultSet]:                https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
-[ReactiveRow]:                      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html
-[Row]:                              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
-[getColumnDefinitions]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#getColumnDefinitions--
-[getExecutionInfos]:                https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#getExecutionInfos--
-[wasApplied]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#wasApplied--
-[ReactiveRow.getColumnDefinitions]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#getColumnDefinitions--
-[ReactiveRow.getExecutionInfo]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#getExecutionInfo--
-[ReactiveRow.wasApplied]:           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#wasApplied--
+[CqlSession]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html
+[ReactiveSession]:                  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveSession.html
+[ResultSet]:                        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[ReactiveResultSet]:                https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[ReactiveRow]:                      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html
+[Row]:                              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
+[getColumnDefinitions]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#getColumnDefinitions--
+[getExecutionInfos]:                https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#getExecutionInfos--
+[wasApplied]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html#wasApplied--
+[ReactiveRow.getColumnDefinitions]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#getColumnDefinitions--
+[ReactiveRow.getExecutionInfo]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#getExecutionInfo--
+[ReactiveRow.wasApplied]:           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveRow.html#wasApplied--
 
 [built-in retry mechanism]: ../retries/
 [request throttling]: ../throttling/

--- a/manual/core/reconnection/README.md
+++ b/manual/core/reconnection/README.md
@@ -84,7 +84,7 @@ Note that the session is not accessible until it is fully ready: the `CqlSession
 call &mdash; or the future returned by `buildAsync()` &mdash; will not complete until the connection
 was established.
 
-[ConstantReconnectionPolicy]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.html
-[DriverContext]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/context/DriverContext.html
-[ExponentialReconnectionPolicy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.html
-[ReconnectionPolicy]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/connection/ReconnectionPolicy.html
+[ConstantReconnectionPolicy]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.html
+[DriverContext]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/context/DriverContext.html
+[ExponentialReconnectionPolicy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.html
+[ReconnectionPolicy]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/connection/ReconnectionPolicy.html

--- a/manual/core/request_tracker/README.md
+++ b/manual/core/request_tracker/README.md
@@ -123,5 +123,5 @@ all FROM users WHERE user_id=? [v0=42]
 com.datastax.oss.driver.api.core.servererrors.InvalidQueryException: Undefined column name all
 ```
 
-[RequestTracker]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/tracker/RequestTracker.html
-[SessionBuilder.addRequestTracker]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addRequestTracker-com.datastax.oss.driver.api.core.tracker.RequestTracker-
+[RequestTracker]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/tracker/RequestTracker.html
+[SessionBuilder.addRequestTracker]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addRequestTracker-com.datastax.oss.driver.api.core.tracker.RequestTracker-

--- a/manual/core/retries/README.md
+++ b/manual/core/retries/README.md
@@ -231,21 +231,21 @@ configuration).
 Each request uses its declared profile's policy. If it doesn't declare any profile, or if the
 profile doesn't have a dedicated policy, then the default profile's policy is used.
 
-[AllNodesFailedException]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AllNodesFailedException.html
-[ClosedConnectionException]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.html
-[DriverTimeoutException]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/DriverTimeoutException.html
-[FunctionFailureException]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/FunctionFailureException.html
-[HeartbeatException]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/connection/HeartbeatException.html
-[ProtocolError]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/ProtocolError.html
-[OverloadedException]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/OverloadedException.html
-[QueryValidationException]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/QueryValidationException.html
-[ReadFailureException]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.html
-[ReadTimeoutException]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.html
-[RetryDecision]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/retry/RetryDecision.html
-[RetryPolicy]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/retry/RetryPolicy.html
-[RetryVerdict]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/retry/RetryVerdict.html
-[ServerError]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/ServerError.html
-[TruncateException]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/TruncateException.html
-[UnavailableException]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/UnavailableException.html
-[WriteFailureException]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.html
-[WriteTimeoutException]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.html
+[AllNodesFailedException]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AllNodesFailedException.html
+[ClosedConnectionException]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.html
+[DriverTimeoutException]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/DriverTimeoutException.html
+[FunctionFailureException]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/FunctionFailureException.html
+[HeartbeatException]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/connection/HeartbeatException.html
+[ProtocolError]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/ProtocolError.html
+[OverloadedException]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/OverloadedException.html
+[QueryValidationException]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/QueryValidationException.html
+[ReadFailureException]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.html
+[ReadTimeoutException]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.html
+[RetryDecision]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/retry/RetryDecision.html
+[RetryPolicy]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/retry/RetryPolicy.html
+[RetryVerdict]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/retry/RetryVerdict.html
+[ServerError]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/ServerError.html
+[TruncateException]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/TruncateException.html
+[UnavailableException]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/UnavailableException.html
+[WriteFailureException]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.html
+[WriteTimeoutException]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.html

--- a/manual/core/speculative_execution/README.md
+++ b/manual/core/speculative_execution/README.md
@@ -250,4 +250,4 @@ profiles have the same configuration).
 Each request uses its declared profile's policy. If it doesn't declare any profile, or if the
 profile doesn't have a dedicated policy, then the default profile's policy is used.
 
-[SpeculativeExecutionPolicy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionPolicy.html
+[SpeculativeExecutionPolicy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionPolicy.html

--- a/manual/core/ssl/README.md
+++ b/manual/core/ssl/README.md
@@ -204,6 +204,6 @@ the box, but with a bit of custom development it is fairly easy to add. See
 [dsClientToNode]: https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/secureSSLClientToNode.html
 [pickle]: http://thelastpickle.com/blog/2015/09/30/hardening-cassandra-step-by-step-part-1-server-to-server.html
 [JSSE system properties]: http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization
-[SessionBuilder.withSslEngineFactory]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withSslEngineFactory-com.datastax.oss.driver.api.core.ssl.SslEngineFactory-
-[SessionBuilder.withSslContext]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withSslContext-javax.net.ssl.SSLContext-
-[ProgrammaticSslEngineFactory]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/ssl/ProgrammaticSslEngineFactory.html
+[SessionBuilder.withSslEngineFactory]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withSslEngineFactory-com.datastax.oss.driver.api.core.ssl.SslEngineFactory-
+[SessionBuilder.withSslContext]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withSslContext-javax.net.ssl.SSLContext-
+[ProgrammaticSslEngineFactory]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/ssl/ProgrammaticSslEngineFactory.html

--- a/manual/core/statements/README.md
+++ b/manual/core/statements/README.md
@@ -59,7 +59,7 @@ the [configuration](../configuration/). Namely, these are: idempotent flag, quer
 consistency levels and page size. We recommended the configuration approach whenever possible (you
 can create execution profiles to capture common combinations of those options).
 
-[Statement]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Statement.html
-[StatementBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/StatementBuilder.html
-[execute]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#execute-com.datastax.oss.driver.api.core.cql.Statement-
-[executeAsync]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Session.html#executeAsync-com.datastax.oss.driver.api.core.cql.Statement-
+[Statement]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Statement.html
+[StatementBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/StatementBuilder.html
+[execute]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#execute-com.datastax.oss.driver.api.core.cql.Statement-
+[executeAsync]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Session.html#executeAsync-com.datastax.oss.driver.api.core.cql.Statement-

--- a/manual/core/statements/batch/README.md
+++ b/manual/core/statements/batch/README.md
@@ -61,8 +61,8 @@ In addition, simple statements with named parameters are currently not supported
 due to a [protocol limitation][CASSANDRA-10246] that will be fixed in a future version). If you try
 to execute such a batch, an `IllegalArgumentException` is thrown.
 
-[BatchStatement]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BatchStatement.html
-[BatchStatement.newInstance()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BatchStatement.html#newInstance-com.datastax.oss.driver.api.core.cql.BatchType-
-[BatchStatement.builder()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BatchStatement.html#builder-com.datastax.oss.driver.api.core.cql.BatchType-
+[BatchStatement]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BatchStatement.html
+[BatchStatement.newInstance()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BatchStatement.html#newInstance-com.datastax.oss.driver.api.core.cql.BatchType-
+[BatchStatement.builder()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BatchStatement.html#builder-com.datastax.oss.driver.api.core.cql.BatchType-
 [batch_dse]: http://docs.datastax.com/en/dse/6.7/cql/cql/cql_using/useBatch.html
 [CASSANDRA-10246]: https://issues.apache.org/jira/browse/CASSANDRA-10246

--- a/manual/core/statements/per_query_keyspace/README.md
+++ b/manual/core/statements/per_query_keyspace/README.md
@@ -124,6 +124,6 @@ SimpleStatement statement =
 At some point in the future, when Cassandra 4 becomes prevalent and using a per-query keyspace is
 the norm, we'll probably deprecate `setRoutingKeyspace()`.
 
-[token-aware routing]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKey--
+[token-aware routing]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/Request.html#getRoutingKey--
 
 [CASSANDRA-10145]: https://issues.apache.org/jira/browse/CASSANDRA-10145

--- a/manual/core/statements/prepared/README.md
+++ b/manual/core/statements/prepared/README.md
@@ -330,10 +330,10 @@ With Cassandra 4 and [native protocol](../../native_protocol/) v5, this issue is
 new version with the response; the driver updates its local cache transparently, and the client can
 observe the new columns in the result set.
 
-[BoundStatement]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[Session.prepare]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlSession.html#prepare-com.datastax.oss.driver.api.core.cql.SimpleStatement-
+[BoundStatement]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[Session.prepare]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlSession.html#prepare-com.datastax.oss.driver.api.core.cql.SimpleStatement-
 [CASSANDRA-10786]: https://issues.apache.org/jira/browse/CASSANDRA-10786
 [CASSANDRA-10813]: https://issues.apache.org/jira/browse/CASSANDRA-10813
 [guava eviction]: https://github.com/google/guava/wiki/CachesExplained#reference-based-eviction
-[PreparedStatement.bind]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/PreparedStatement.html#bind-java.lang.Object...-
-[PreparedStatement.boundStatementBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/PreparedStatement.html#boundStatementBuilder-java.lang.Object...-
+[PreparedStatement.bind]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/PreparedStatement.html#bind-java.lang.Object...-
+[PreparedStatement.boundStatementBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/PreparedStatement.html#boundStatementBuilder-java.lang.Object...-

--- a/manual/core/statements/simple/README.md
+++ b/manual/core/statements/simple/README.md
@@ -182,6 +182,6 @@ session.execute(
 Or you could also use [prepared statements](../prepared/), which don't have this limitation since
 parameter types are known in advance. 
 
-[SimpleStatement]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SimpleStatement.html
-[SimpleStatement.newInstance()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SimpleStatement.html#newInstance-java.lang.String-
-[SimpleStatement.builder()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SimpleStatement.html#builder-java.lang.String-
+[SimpleStatement]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SimpleStatement.html
+[SimpleStatement.newInstance()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SimpleStatement.html#newInstance-java.lang.String-
+[SimpleStatement.builder()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SimpleStatement.html#builder-java.lang.String-

--- a/manual/core/temporal_types/README.md
+++ b/manual/core/temporal_types/README.md
@@ -146,7 +146,7 @@ System.out.println(dateTime.minus(CqlDuration.from("1h15s15ns")));
 // prints "2018-10-03T22:59:44.999999985-07:00[America/Los_Angeles]"
 ```
 
-[CqlDuration]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/CqlDuration.html
-[TypeCodecs.ZONED_TIMESTAMP_SYSTEM]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#ZONED_TIMESTAMP_SYSTEM
-[TypeCodecs.ZONED_TIMESTAMP_UTC]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#ZONED_TIMESTAMP_UTC
-[TypeCodecs.zonedTimestampAt()]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#zonedTimestampAt-java.time.ZoneId-
+[CqlDuration]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/CqlDuration.html
+[TypeCodecs.ZONED_TIMESTAMP_SYSTEM]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#ZONED_TIMESTAMP_SYSTEM
+[TypeCodecs.ZONED_TIMESTAMP_UTC]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#ZONED_TIMESTAMP_UTC
+[TypeCodecs.zonedTimestampAt()]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.html#zonedTimestampAt-java.time.ZoneId-

--- a/manual/core/throttling/README.md
+++ b/manual/core/throttling/README.md
@@ -145,6 +145,6 @@ datastax-java-driver {
 If you enable `throttling.delay`, make sure to also check the associated extra options to correctly
 size the underlying histograms (`metrics.session.throttling.delay.*`).
 
-[RequestThrottlingException]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/RequestThrottlingException.html
-[AllNodesFailedException]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/AllNodesFailedException.html
-[BusyConnectionException]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/connection/BusyConnectionException.html
+[RequestThrottlingException]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/RequestThrottlingException.html
+[AllNodesFailedException]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/AllNodesFailedException.html
+[BusyConnectionException]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/connection/BusyConnectionException.html

--- a/manual/core/tracing/README.md
+++ b/manual/core/tracing/README.md
@@ -113,9 +113,9 @@ for (TraceEvent event : trace.getEvents()) {
 If you call `getQueryTrace()` for a statement that didn't have tracing enabled, an exception is
 thrown.
 
-[ExecutionInfo]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html
-[QueryTrace]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/QueryTrace.html
-[Statement.setTracing()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Statement.html#setTracing-boolean-
-[StatementBuilder.setTracing()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/StatementBuilder.html#setTracing--
-[ExecutionInfo.getTracingId()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getTracingId--
-[ExecutionInfo.getQueryTrace()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getQueryTrace--
+[ExecutionInfo]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html
+[QueryTrace]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/QueryTrace.html
+[Statement.setTracing()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Statement.html#setTracing-boolean-
+[StatementBuilder.setTracing()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/StatementBuilder.html#setTracing--
+[ExecutionInfo.getTracingId()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getTracingId--
+[ExecutionInfo.getQueryTrace()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getQueryTrace--

--- a/manual/core/tuples/README.md
+++ b/manual/core/tuples/README.md
@@ -139,5 +139,5 @@ BoundStatement bs =
 
 [cql_doc]: https://docs.datastax.com/en/cql/3.3/cql/cql_reference/tupleType.html
 
-[TupleType]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/TupleType.html
-[TupleValue]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/TupleValue.html
+[TupleType]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/TupleType.html
+[TupleValue]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/TupleValue.html

--- a/manual/core/udts/README.md
+++ b/manual/core/udts/README.md
@@ -135,5 +135,5 @@ session.execute(bs);
 
 [cql_doc]: https://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlRefUDType.html
 
-[UdtValue]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/UdtValue.html
-[UserDefinedType]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/UserDefinedType.html
+[UdtValue]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/UdtValue.html
+[UserDefinedType]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/UserDefinedType.html

--- a/manual/developer/common/concurrency/README.md
+++ b/manual/developer/common/concurrency/README.md
@@ -101,8 +101,8 @@ public interface ExecutionInfo {
 
 When a public API method is blocking, this is generally clearly stated in its javadocs. 
 
-[`ExecutionInfo.getQueryTrace()`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getQueryTrace--
-[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
+[`ExecutionInfo.getQueryTrace()`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getQueryTrace--
+[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
 
 `BlockingOperation` is a utility to check that those methods aren't called on I/O threads, which
 could introduce deadlocks.

--- a/manual/mapper/config/kotlin/README.md
+++ b/manual/mapper/config/kotlin/README.md
@@ -106,4 +106,4 @@ before compilation:
 [build.gradle]: https://github.com/DataStax-Examples/object-mapper-jvm/blob/master/kotlin/build.gradle
 [UserDao.kt]: https://github.com/DataStax-Examples/object-mapper-jvm/blob/master/kotlin/src/main/kotlin/com/datastax/examples/mapper/killrvideo/user/UserDao.kt
 
-[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html
+[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html

--- a/manual/mapper/config/record/README.md
+++ b/manual/mapper/config/record/README.md
@@ -27,7 +27,7 @@ You need to build with Java 14, and pass the `--enable-preview` flag to both the
 runtime JVM. See [pom.xml] in the example.
 
 
-[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html
+[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html
 
 [DataStax-Examples/object-mapper-jvm/record]: https://github.com/DataStax-Examples/object-mapper-jvm/tree/master/record
 [pom.xml]: https://github.com/DataStax-Examples/object-mapper-jvm/blob/master/record/pom.xml

--- a/manual/mapper/config/scala/README.md
+++ b/manual/mapper/config/scala/README.md
@@ -54,4 +54,4 @@ mapper builder.
 [DataStax-Examples/object-mapper-jvm/scala]: https://github.com/DataStax-Examples/object-mapper-jvm/tree/master/scala
 [build.sbt]: https://github.com/DataStax-Examples/object-mapper-jvm/blob/master/scala/build.sbt
 
-[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html
+[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html

--- a/manual/mapper/daos/README.md
+++ b/manual/mapper/daos/README.md
@@ -148,8 +148,8 @@ In this case, any annotations declared in `Dao1` would be chosen over `Dao2`.
 
 To control how the hierarchy is scanned, annotate interfaces with [@HierarchyScanStrategy].
 
-[@Dao]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Dao.html
-[@DaoFactory]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DaoFactory.html
-[@DefaultNullSavingStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DefaultNullSavingStrategy.html
-[@HierarchyScanStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/HierarchyScanStrategy.html
+[@Dao]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Dao.html
+[@DaoFactory]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DaoFactory.html
+[@DefaultNullSavingStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DefaultNullSavingStrategy.html
+[@HierarchyScanStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/HierarchyScanStrategy.html
 [Entity Inheritance]: ../entities/#inheritance

--- a/manual/mapper/daos/custom_types/README.md
+++ b/manual/mapper/daos/custom_types/README.md
@@ -236,8 +236,8 @@ flag:
 With this configuration, if a DAO method declares a non built-in return type, it will be surfaced as
 a compiler error.
 
-[EntityHelper]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/entity/EntityHelper.html
-[GenericType]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
-[MapperContext]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/MapperContext.html
-[MapperResultProducer]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/result/MapperResultProducer.html
-[MapperResultProducerService]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/result/MapperResultProducerService.html
+[EntityHelper]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/entity/EntityHelper.html
+[GenericType]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/reflect/GenericType.html
+[MapperContext]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/MapperContext.html
+[MapperResultProducer]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/result/MapperResultProducer.html
+[MapperResultProducerService]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/result/MapperResultProducerService.html

--- a/manual/mapper/daos/delete/README.md
+++ b/manual/mapper/daos/delete/README.md
@@ -151,15 +151,15 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the [naming strategy](../../entities/#naming-strategy)).
 
-[default keyspace]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[AsyncResultSet]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[@ClusteringColumn]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
-[@Delete]:                https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Delete.html
-[@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
-[ResultSet]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[ResultSet#wasApplied()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
-[BoundStatement]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[ReactiveResultSet]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[default keyspace]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[AsyncResultSet]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[@ClusteringColumn]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@Delete]:                https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Delete.html
+[@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[ResultSet]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[ResultSet#wasApplied()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
+[BoundStatement]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[ReactiveResultSet]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
 
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html

--- a/manual/mapper/daos/getentity/README.md
+++ b/manual/mapper/daos/getentity/README.md
@@ -130,15 +130,15 @@ If the return type doesn't match the parameter type (for example [PagingIterable
 [AsyncResultSet]), the mapper processor will issue a compile-time error.
 
 
-[@GetEntity]:                https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/GetEntity.html
-[AsyncResultSet]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[GettableByName]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/GettableByName.html
-[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
-[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html
-[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
-[ResultSet]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[Row]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
-[UdtValue]:                  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/UdtValue.html
+[@GetEntity]:                https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/GetEntity.html
+[AsyncResultSet]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[GettableByName]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/GettableByName.html
+[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
+[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html
+[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
+[ResultSet]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[Row]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
+[UdtValue]:                  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/UdtValue.html
 
 [Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
 

--- a/manual/mapper/daos/increment/README.md
+++ b/manual/mapper/daos/increment/README.md
@@ -75,12 +75,12 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the naming convention).
 
-[@Increment]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Increment.html
-[ReactiveResultSet]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
-[default keyspace]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@ClusteringColumn]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
-[@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
-[@CqlName]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
+[@Increment]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Increment.html
+[ReactiveResultSet]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[default keyspace]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@ClusteringColumn]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@CqlName]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
 
 [CompletionStage]:   https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/insert/README.md
+++ b/manual/mapper/daos/insert/README.md
@@ -108,13 +108,13 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the [naming strategy](../../entities/#naming-strategy)).
 
-[default keyspace]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@Insert]:                      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Insert.html
-[ResultSet]:                    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[ResultSet#wasApplied()]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
-[ResultSet#getExecutionInfo()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html#getExecutionInfo--
-[BoundStatement]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[ReactiveResultSet]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[default keyspace]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@Insert]:                      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Insert.html
+[ResultSet]:                    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[ResultSet#wasApplied()]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
+[ResultSet#getExecutionInfo()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html#getExecutionInfo--
+[BoundStatement]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[ReactiveResultSet]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/null_saving/README.md
+++ b/manual/mapper/daos/null_saving/README.md
@@ -93,10 +93,10 @@ public interface UserDao extends InventoryDao {
 }
 ```
 
-[@DefaultNullSavingStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DefaultNullSavingStrategy.html
-[BoundStatement]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[MapperException]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/MapperException.html
-[DO_NOT_SET]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/entity/saving/NullSavingStrategy.html#DO_NOT_SET
-[SET_TO_NULL]:                https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/entity/saving/NullSavingStrategy.html#SET_TO_NULL
+[@DefaultNullSavingStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DefaultNullSavingStrategy.html
+[BoundStatement]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[MapperException]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/MapperException.html
+[DO_NOT_SET]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/entity/saving/NullSavingStrategy.html#DO_NOT_SET
+[SET_TO_NULL]:                https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/entity/saving/NullSavingStrategy.html#SET_TO_NULL
       
 [CASSANDRA-7304]: https://issues.apache.org/jira/browse/CASSANDRA-7304

--- a/manual/mapper/daos/query/README.md
+++ b/manual/mapper/daos/query/README.md
@@ -113,18 +113,18 @@ Then:
   query succeeds or not depends on whether the session that the mapper was built with has a [default
   keyspace].
 
-[default keyspace]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@Query]:                    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Query.html
-[AsyncResultSet]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[ResultSet]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[ResultSet#wasApplied()]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
-[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
-[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html
-[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
-[Row]:                       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/Row.html
-[BoundStatement]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[ReactiveResultSet]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
-[MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
+[default keyspace]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@Query]:                    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Query.html
+[AsyncResultSet]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[ResultSet]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[ResultSet#wasApplied()]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
+[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
+[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html
+[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
+[Row]:                       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/Row.html
+[BoundStatement]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[ReactiveResultSet]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/queryprovider/README.md
+++ b/manual/mapper/daos/queryprovider/README.md
@@ -137,11 +137,11 @@ Here is the full implementation:
      the desired [PagingIterable<SensorReading>][PagingIterable].
 
 
-[@QueryProvider]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html
-[providerClass]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#providerClass--
-[entityHelpers]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#entityHelpers--
-[providerMethod]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#providerMethod--
-[MapperContext]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/MapperContext.html
-[EntityHelper]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/EntityHelper.html
-[ResultSet]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[PagingIterable]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html
+[@QueryProvider]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html
+[providerClass]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#providerClass--
+[entityHelpers]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#entityHelpers--
+[providerMethod]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#providerMethod--
+[MapperContext]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/MapperContext.html
+[EntityHelper]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/EntityHelper.html
+[ResultSet]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[PagingIterable]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html

--- a/manual/mapper/daos/select/README.md
+++ b/manual/mapper/daos/select/README.md
@@ -160,20 +160,20 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the [naming strategy](../../entities/#naming-strategy)).
 
-[default keyspace]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@ClusteringColumn]:         https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
-[@PartitionKey]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
-[@Select]:                   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html
-[allowFiltering()]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#allowFiltering--
-[customWhereClause()]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#customWhereClause--
-[groupBy()]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#groupBy--
-[limit()]:                   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#limit--
-[orderBy()]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#orderBy--
-[perPartitionLimit()]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html#perPartitionLimit--
-[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
-[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html
-[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
-[MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
+[default keyspace]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@ClusteringColumn]:         https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@PartitionKey]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@Select]:                   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html
+[allowFiltering()]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#allowFiltering--
+[customWhereClause()]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#customWhereClause--
+[groupBy()]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#groupBy--
+[limit()]:                   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#limit--
+[orderBy()]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#orderBy--
+[perPartitionLimit()]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html#perPartitionLimit--
+[MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
+[PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html
+[PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
+[MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/setentity/README.md
+++ b/manual/mapper/daos/setentity/README.md
@@ -112,8 +112,8 @@ BoundStatement bind(Product product, BoundStatement statement);
 If you use a void method with [BoundStatement], the mapper processor will issue a compile-time
 warning.
 
-[@SetEntity]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/SetEntity.html
-[BoundStatement]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[BoundStatementBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.html
-[SettableByName]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/SettableByName.html
-[UdtValue]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/data/UdtValue.html
+[@SetEntity]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/SetEntity.html
+[BoundStatement]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[BoundStatementBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.html
+[SettableByName]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/SettableByName.html
+[UdtValue]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/data/UdtValue.html

--- a/manual/mapper/daos/statement_attributes/README.md
+++ b/manual/mapper/daos/statement_attributes/README.md
@@ -60,4 +60,4 @@ Product product =
     dao.findById(1, builder -> builder.setConsistencyLevel(DefaultConsistencyLevel.QUORUM));
 ```
 
-[@StatementAttributes]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/StatementAttributes.html
+[@StatementAttributes]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/StatementAttributes.html

--- a/manual/mapper/daos/update/README.md
+++ b/manual/mapper/daos/update/README.md
@@ -143,13 +143,13 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the naming convention).
 
-[default keyspace]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@Update]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Update.html
+[default keyspace]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@Update]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Update.html
 
-[AsyncResultSet]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[AsyncResultSet]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
 [Boolean]:              https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/Boolean.html
 [CompletionStage]:      https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]:    https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
-[ResultSet]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/ResultSet.html
-[BoundStatement]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/cql/BoundStatement.html
-[ReactiveResultSet]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[ResultSet]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[BoundStatement]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/cql/BoundStatement.html
+[ReactiveResultSet]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html

--- a/manual/mapper/entities/README.md
+++ b/manual/mapper/entities/README.md
@@ -555,22 +555,22 @@ the same level.
 
 To control how the class hierarchy is scanned, annotate classes with [@HierarchyScanStrategy].
 
-[@ClusteringColumn]:    https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
-[@CqlName]:             https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
-[@Dao]:                 https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Dao.html
-[@Entity]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Entity.html
-[NameConverter]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/entity/naming/NameConverter.html
-[NamingConvention]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/entity/naming/NamingConvention.html
-[@NamingStrategy]:      https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/NamingStrategy.html
-[@PartitionKey]:        https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
-[@Computed]:            https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Computed.html
-[@Select]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Select.html
-[@Insert]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Insert.html
-[@Update]:              https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Update.html
-[@GetEntity]:           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/GetEntity.html
-[@Query]:               https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Query.html
+[@ClusteringColumn]:    https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@CqlName]:             https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
+[@Dao]:                 https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Dao.html
+[@Entity]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Entity.html
+[NameConverter]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/entity/naming/NameConverter.html
+[NamingConvention]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/entity/naming/NamingConvention.html
+[@NamingStrategy]:      https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/NamingStrategy.html
+[@PartitionKey]:        https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@Computed]:            https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Computed.html
+[@Select]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Select.html
+[@Insert]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Insert.html
+[@Update]:              https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Update.html
+[@GetEntity]:           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/GetEntity.html
+[@Query]:               https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Query.html
 [aliases]:              http://cassandra.apache.org/doc/latest/cql/dml.html?#aliases
-[@Transient]:           https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Transient.html
-[@TransientProperties]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/TransientProperties.html
-[@HierarchyScanStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/HierarchyScanStrategy.html
-[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html
+[@Transient]:           https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Transient.html
+[@TransientProperties]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/TransientProperties.html
+[@HierarchyScanStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/HierarchyScanStrategy.html
+[@PropertyStrategy]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/PropertyStrategy.html

--- a/manual/mapper/mapper/README.md
+++ b/manual/mapper/mapper/README.md
@@ -230,8 +230,8 @@ InventoryMapper inventoryMapper = new InventoryMapperBuilder(session)
 You can also permanently disable validation of an individual entity by annotating it with
 `@SchemaHint(targetElement = NONE)`.
 
-[CqlIdentifier]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlIdentifier.html
-[@DaoFactory]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DaoFactory.html
-[@DaoKeyspace]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DaoKeyspace.html
-[@DaoTable]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/DaoTable.html
-[@Mapper]:       https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/mapper/annotations/Mapper.html
+[CqlIdentifier]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlIdentifier.html
+[@DaoFactory]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DaoFactory.html
+[@DaoKeyspace]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DaoKeyspace.html
+[@DaoTable]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/DaoTable.html
+[@Mapper]:       https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/mapper/annotations/Mapper.html

--- a/manual/osgi/README.md
+++ b/manual/osgi/README.md
@@ -138,7 +138,7 @@ starting the driver:
 [driver configuration]: ../core/configuration
 [OSGi]:https://www.osgi.org
 [JNR]: https://github.com/jnr/jnr-posix
-[withClassLoader()]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withClassLoader-java.lang.ClassLoader-
+[withClassLoader()]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withClassLoader-java.lang.ClassLoader-
 [JAVA-1127]:https://datastax-oss.atlassian.net/browse/JAVA-1127
-[DriverConfigLoader.fromDefaults(ClassLoader)]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromDefaults-java.lang.ClassLoader-
-[DriverConfigLoader.programmaticBuilder(ClassLoader)]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#programmaticBuilder-java.lang.ClassLoader-
+[DriverConfigLoader.fromDefaults(ClassLoader)]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#fromDefaults-java.lang.ClassLoader-
+[DriverConfigLoader.programmaticBuilder(ClassLoader)]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/config/DriverConfigLoader.html#programmaticBuilder-java.lang.ClassLoader-

--- a/manual/query_builder/README.md
+++ b/manual/query_builder/README.md
@@ -212,8 +212,8 @@ For a complete tour of the API, browse the child pages in this manual:
   * [Terms](term/)
   * [Idempotence](idempotence/)
   
-[QueryBuilder]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
-[CqlIdentifier]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/CqlIdentifier.html
-[DseQueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/querybuilder/DseQueryBuilder.html
-[DseSchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/dse/driver/api/querybuilder/DseSchemaBuilder.html
+[QueryBuilder]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[CqlIdentifier]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/CqlIdentifier.html
+[DseQueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/querybuilder/DseQueryBuilder.html
+[DseSchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/dse/driver/api/querybuilder/DseSchemaBuilder.html

--- a/manual/query_builder/condition/README.md
+++ b/manual/query_builder/condition/README.md
@@ -132,4 +132,4 @@ It is mutually exclusive with column conditions: if you previously specified col
 the statement, they will be ignored; conversely, adding a column condition cancels a previous IF
 EXISTS clause.
 
-[Condition]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/condition/Condition.html
+[Condition]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/condition/Condition.html

--- a/manual/query_builder/delete/README.md
+++ b/manual/query_builder/delete/README.md
@@ -141,5 +141,5 @@ deleteFrom("user")
 Conditions are a common feature used by UPDATE and DELETE, so they have a
 [dedicated page](../condition) in this manual.
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[Selector]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/select/Selector.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[Selector]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/select/Selector.html

--- a/manual/query_builder/insert/README.md
+++ b/manual/query_builder/insert/README.md
@@ -114,4 +114,4 @@ is executed. This is distinctly different than setting the value to null. Passin
 this method will only remove the USING TTL clause from the query, which will not alter the TTL (if
 one is set) in Cassandra.
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html

--- a/manual/query_builder/relation/README.md
+++ b/manual/query_builder/relation/README.md
@@ -201,5 +201,5 @@ This should be used with caution, as it's possible to generate invalid CQL that 
 execution time; on the other hand, it can be used as a workaround to handle new CQL features that
 are not yet covered by the query builder.
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[Relation]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/relation/Relation.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[Relation]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/relation/Relation.html

--- a/manual/query_builder/schema/README.md
+++ b/manual/query_builder/schema/README.md
@@ -44,4 +44,4 @@ element type:
 * [function](function/)
 * [aggregate](aggregate/)
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html

--- a/manual/query_builder/schema/aggregate/README.md
+++ b/manual/query_builder/schema/aggregate/README.md
@@ -76,4 +76,4 @@ dropAggregate("average").ifExists();
 // DROP AGGREGATE IF EXISTS average
 ```
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html

--- a/manual/query_builder/schema/function/README.md
+++ b/manual/query_builder/schema/function/README.md
@@ -92,4 +92,4 @@ dropFunction("log").ifExists();
 // DROP FUNCTION IF EXISTS log
 ```
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html

--- a/manual/query_builder/schema/index/README.md
+++ b/manual/query_builder/schema/index/README.md
@@ -99,4 +99,4 @@ dropIndex("my_idx").ifExists();
 // DROP INDEX IF EXISTS my_idx
 ```
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html

--- a/manual/query_builder/schema/keyspace/README.md
+++ b/manual/query_builder/schema/keyspace/README.md
@@ -83,6 +83,6 @@ dropKeyspace("cycling").ifExists();
 // DROP KEYSPACE IF EXISTS cycling
 ```
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
 
 

--- a/manual/query_builder/schema/materialized_view/README.md
+++ b/manual/query_builder/schema/materialized_view/README.md
@@ -85,5 +85,5 @@ dropTable("cyclist_by_age").ifExists();
 // DROP MATERIALIZED VIEW IF EXISTS cyclist_by_age
 ```
 
-[SchemaBuilder]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
-[RelationStructure]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/schema/RelationStructure.html
+[SchemaBuilder]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[RelationStructure]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/schema/RelationStructure.html

--- a/manual/query_builder/schema/table/README.md
+++ b/manual/query_builder/schema/table/README.md
@@ -107,6 +107,6 @@ dropTable("cyclist_name").ifExists();
 // DROP TABLE IF EXISTS cyclist_name
 ```
 
-[SchemaBuilder]:          https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
-[CreateTableWithOptions]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/schema/CreateTableWithOptions.html
-[AlterTableWithOptions]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/schema/AlterTableWithOptions.html
+[SchemaBuilder]:          https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[CreateTableWithOptions]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/schema/CreateTableWithOptions.html
+[AlterTableWithOptions]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/schema/AlterTableWithOptions.html

--- a/manual/query_builder/schema/type/README.md
+++ b/manual/query_builder/schema/type/README.md
@@ -88,4 +88,4 @@ dropTable("address").ifExists();
 // DROP TYPE IF EXISTS address
 ```
 
-[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html
+[SchemaBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/SchemaBuilder.html

--- a/manual/query_builder/select/README.md
+++ b/manual/query_builder/select/README.md
@@ -391,5 +391,5 @@ selectFrom("user").all().allowFiltering();
 // SELECT * FROM user ALLOW FILTERING
 ```
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[Selector]:     https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/select/Selector.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[Selector]:     https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/select/Selector.html

--- a/manual/query_builder/term/README.md
+++ b/manual/query_builder/term/README.md
@@ -105,5 +105,5 @@ This should be used with caution, as it's possible to generate invalid CQL that 
 execution time; on the other hand, it can be used as a workaround to handle new CQL features that
 are not yet covered by the query builder.
 
-[QueryBuilder]:  https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[CodecRegistry]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html
+[QueryBuilder]:  https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[CodecRegistry]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.html

--- a/manual/query_builder/truncate/README.md
+++ b/manual/query_builder/truncate/README.md
@@ -17,4 +17,4 @@ Truncate truncate2 = truncate(CqlIdentifier.fromCql("mytable"));
 Note that, at this stage, the query is ready to build. After creating a TRUNCATE query it does not
 take any values.
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html

--- a/manual/query_builder/update/README.md
+++ b/manual/query_builder/update/README.md
@@ -251,5 +251,5 @@ update("foo")
 Conditions are a common feature used by UPDATE and DELETE, so they have a
 [dedicated page](../condition) in this manual.
 
-[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
-[Assignment]:   https://docs.datastax.com/en/drivers/java/4.13/com/datastax/oss/driver/api/querybuilder/update/Assignment.html
+[QueryBuilder]: https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/QueryBuilder.html
+[Assignment]:   https://docs.datastax.com/en/drivers/java/4.14/com/datastax/oss/driver/api/querybuilder/update/Assignment.html

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-mapper-processor</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - object mapper processor</name>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-mapper-processor</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - object mapper processor</name>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-mapper-processor</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - object mapper processor</name>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-mapper-processor</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - object mapper processor</name>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-mapper-processor</artifactId>
   <name>DataStax Java driver for Apache Cassandra(R) - object mapper processor</name>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-mapper-runtime</artifactId>
   <packaging>bundle</packaging>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-mapper-runtime</artifactId>
   <packaging>bundle</packaging>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-mapper-runtime</artifactId>
   <packaging>bundle</packaging>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-mapper-runtime</artifactId>
   <packaging>bundle</packaging>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-mapper-runtime</artifactId>
   <packaging>bundle</packaging>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-micrometer</artifactId>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-micrometer</artifactId>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-micrometer</artifactId>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-micrometer</artifactId>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-micrometer</artifactId>

--- a/metrics/microprofile/pom.xml
+++ b/metrics/microprofile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-microprofile</artifactId>

--- a/metrics/microprofile/pom.xml
+++ b/metrics/microprofile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-microprofile</artifactId>

--- a/metrics/microprofile/pom.xml
+++ b/metrics/microprofile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-microprofile</artifactId>

--- a/metrics/microprofile/pom.xml
+++ b/metrics/microprofile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-microprofile</artifactId>

--- a/metrics/microprofile/pom.xml
+++ b/metrics/microprofile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>java-driver-metrics-microprofile</artifactId>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>reactive-streams</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tinkerpop</groupId>
       <artifactId>gremlin-core</artifactId>
     </dependency>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.15</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@
     When upgrading TinkerPop please upgrade the version matrix in
     manual/core/integration/README.md
     -->
-    <tinkerpop.version>3.4.10</tinkerpop.version>
+    <tinkerpop.version>3.5.3</tinkerpop.version>
     <slf4j.version>1.7.26</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <json.version>20210307</json.version>
-    <jackson.version>2.12.2</jackson.version>
-    <jackson-databind.version>2.12.2</jackson-databind.version>
+    <jackson.version>2.13.2</jackson.version>
+    <jackson-databind.version>2.13.2.2</jackson-databind.version>
     <legacy-jackson.version>1.9.12</legacy-jackson.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.7.3</snappy.version>
@@ -81,7 +81,7 @@
     <awaitility.version>4.0.3</awaitility.version>
     <apacheds.version>2.0.0-M19</apacheds.version>
     <surefire.version>2.22.2</surefire.version>
-    <graalapi.version>21.0.0.2</graalapi.version>
+    <graalapi.version>22.0.0.2</graalapi.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.13.0</version>
+  <version>4.13.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -955,7 +955,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
     <url>https://github.com/datastax/java-driver</url>
-    <tag>4.13.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <config.version>1.4.1</config.version>
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
-    <netty.version>4.1.60.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.14.1-SNAPSHOT</version>
+  <version>4.14.1</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -955,7 +955,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
     <url>https://github.com/datastax/java-driver</url>
-    <tag>HEAD</tag>
+    <tag>4.14.1</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.13.0-SNAPSHOT</version>
+  <version>4.13.0</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -955,7 +955,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
     <url>https://github.com/datastax/java-driver</url>
-    <tag>HEAD</tag>
+    <tag>4.13.0</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.13.1-SNAPSHOT</version>
+  <version>4.14.0</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -955,7 +955,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
     <url>https://github.com/datastax/java-driver</url>
-    <tag>HEAD</tag>
+    <tag>4.14.0</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.14.0</version>
+  <version>4.14.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -955,7 +955,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
     <url>https://github.com/datastax/java-driver</url>
-    <tag>4.14.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-query-builder</artifactId>
   <packaging>bundle</packaging>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-query-builder</artifactId>
   <packaging>bundle</packaging>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-query-builder</artifactId>
   <packaging>bundle</packaging>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-query-builder</artifactId>
   <packaging>bundle</packaging>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-query-builder</artifactId>
   <packaging>bundle</packaging>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0</version>
+    <version>4.13.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-test-infra</artifactId>
   <packaging>bundle</packaging>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.0</version>
+    <version>4.14.1-SNAPSHOT</version>
   </parent>
   <artifactId>java-driver-test-infra</artifactId>
   <packaging>bundle</packaging>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.14.1-SNAPSHOT</version>
+    <version>4.14.1</version>
   </parent>
   <artifactId>java-driver-test-infra</artifactId>
   <packaging>bundle</packaging>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>4.13.0</version>
   </parent>
   <artifactId>java-driver-test-infra</artifactId>
   <packaging>bundle</packaging>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.datastax.oss</groupId>
     <artifactId>java-driver-parent</artifactId>
-    <version>4.13.1-SNAPSHOT</version>
+    <version>4.14.0</version>
   </parent>
   <artifactId>java-driver-test-infra</artifactId>
   <packaging>bundle</packaging>

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -9,6 +9,26 @@ request cannot be executed because all nodes tried were busy. Previously you wou
 `NoNodeAvailableException` but you will now get back an `AllNodesFailedException` where the
 `getAllErrors` map contains a `NodeUnavailableException` for that node.
 
+#### Esri Geometry dependency now optional
+
+Previous versions of the Java driver defined a mandatory dependency on the Esri geometry library.
+This library offered support for primitive geometric types supported by DSE.  As of driver 4.14.0
+this dependency is now optional.
+
+If you do not use DSE (or if you do but do not use the support for geometric types within DSE) you
+should experience no disruption.  If you are using geometric types with DSE you'll now need to
+explicitly declare a dependency on the Esri library:
+
+```xml
+<dependency>
+  <groupId>com.esri.geometry</groupId>
+  <artifactId>esri-geometry-api</artifactId>
+  <version>${esri.version}</version>
+</dependency>
+```
+
+See the [integration](../manual/core/integration/#esri) section in the manual for more details.
+
 ### 4.13.0
 
 #### Enhanced support for GraalVM native images 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -1,5 +1,14 @@
 ## Upgrade guide
 
+### 4.14.0
+
+#### AllNodesFailedException instead of NoNodeAvailableException in certain cases
+
+[JAVA-2959](https://datastax-oss.atlassian.net/browse/JAVA-2959) changed the behavior for when a
+request cannot be executed because all nodes tried were busy. Previously you would get back a
+`NoNodeAvailableException` but you will now get back an `AllNodesFailedException` where the
+`getAllErrors` map contains a `NodeUnavailableException` for that node.
+
 ### 4.13.0
 
 #### Enhanced support for GraalVM native images 


### PR DESCRIPTION
Merging changes from datastax driver 4.14.0 and 4.14.1

One thing I'm not sure about is that in main pom.xml there is section about maven-deploy-plugin:
```
        <plugin>
          <artifactId>maven-deploy-plugin</artifactId>
          <version>2.8.2</version>
          <executions>
            <execution>
              <id>default-deploy</id>
              <phase>deploy</phase>
              <goals>
                <goal>deploy</goal>
              </goals>
            </execution>
          </executions>
        </plugin>
```

Whole executions block is added by us, but it seems we also downgraded version to 2.7 - is there any reason for that? I changed the version back to 2.8.2 and retained executions block - if that's not correct I'll change it.