### PR TITLE
Fix typos in 3.x tests workflow

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          pip3 install https://github.com/avelanarius/scylla-ccm/archive/master.zip
+          pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
           sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
 
       - name: Run integration tests on Scylla (${{ matrix.scylla-version }})


### PR DESCRIPTION
Replaces 1 ccm link since main repo is up to date now.