### PR TITLE
Extend OpenTelemetry tracing with cluster-side gathered data

### DIFF
--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -17,6 +17,12 @@
 -->
 <differences>
     <difference>
+        <differenceType>7012</differenceType> <!-- method added to interface -->
+        <className>com/datastax/driver/core/Session</className>
+        <method>com.datastax.driver.core.tracing.TracingInfoFactory getTracingInfoFactory()</method>
+        <justification>New method to get the TracingInfo data factory associated with this Session</justification>
+    </difference>
+    <difference>
         <differenceType>7004</differenceType> <!-- the number of arguments has changed -->
         <className>com/datastax/driver/core/Metadata</className>
         <method>java.util.Set getReplicas(java.lang.String, java.nio.ByteBuffer)</method>

--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -18,6 +18,12 @@
 <differences>
     <difference>
         <differenceType>7012</differenceType> <!-- method added to interface -->
+        <className>com/datastax/driver/core/PreparedStatement</className>
+        <method>java.lang.String getOperationType()</method>
+        <justification>New method to get the type of operation performed by this PreparedStatement</justification>
+    </difference>
+    <difference>
+        <differenceType>7012</differenceType> <!-- method added to interface -->
         <className>com/datastax/driver/core/Session</className>
         <method>com.datastax.driver.core.tracing.TracingInfoFactory getTracingInfoFactory()</method>
         <justification>New method to get the TracingInfo data factory associated with this Session</justification>

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -74,6 +74,8 @@ public class BoundStatement extends Statement
 
   private ByteBuffer routingKey;
 
+  private final String operationType;
+
   /**
    * Creates a new {@code BoundStatement} from the provided prepared statement.
    *
@@ -92,6 +94,7 @@ public class BoundStatement extends Statement
       this.setSerialConsistencyLevel(statement.getSerialConsistencyLevel());
     if (statement.isTracing()) this.enableTracing();
     if (statement.getRetryPolicy() != null) this.setRetryPolicy(statement.getRetryPolicy());
+    this.operationType = statement.getOperationType();
     if (statement.getOutgoingPayload() != null)
       this.setOutgoingPayload(statement.getOutgoingPayload());
     else
@@ -102,6 +105,10 @@ public class BoundStatement extends Statement
     if (statement.isIdempotent() != null) {
       this.setIdempotent(statement.isIdempotent());
     }
+  }
+
+  public String getOperationType() {
+    return operationType;
   }
 
   @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -39,6 +39,8 @@ import com.datastax.driver.core.policies.Policies;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
@@ -146,6 +148,8 @@ public class Cluster implements Closeable {
 
   final Manager manager;
 
+  private TracingInfoFactory tracingInfoFactory = new NoopTracingInfoFactory();
+
   /**
    * Constructs a new Cluster instance.
    *
@@ -195,6 +199,25 @@ public class Cluster implements Closeable {
     System.out.println("===== Using optimized driver!!! =====");
     logger.info("===== Using optimized driver!!! =====");
     this.manager = new Manager(name, contactPoints, configuration, listeners);
+  }
+
+  /**
+   * The tracingInfo factory class used by this Cluster.
+   *
+   * @return the factory used currently by this Cluster.
+   */
+  public TracingInfoFactory getTracingInfoFactory() {
+    return tracingInfoFactory;
+  }
+
+  /**
+   * Sets desired factory for tracing information for this Cluster. By default it is {@link
+   * com.datastax.driver.core.tracing.NoopTracingInfoFactory}
+   *
+   * @param tracingInfoFactory the factory to be set for this Cluster.
+   */
+  public void setTracingInfoFactory(TracingInfoFactory tracingInfoFactory) {
+    this.tracingInfoFactory = tracingInfoFactory;
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -180,11 +180,11 @@ class Connection {
     this(name, endPoint, factory, null);
   }
 
-  ListenableFuture<Void> initAsync() {
-    return initAsync(-1, 0);
+  ListenableFuture<Void> initAsync(boolean tracingRequested) {
+    return initAsync(-1, 0, tracingRequested);
   }
 
-  ListenableFuture<Void> initAsync(final int shardId, int serverPort) {
+  ListenableFuture<Void> initAsync(final int shardId, int serverPort, boolean tracingRequested) {
     if (factory.isShutdown)
       return Futures.immediateFailedFuture(
           new ConnectionException(endPoint, "Connection factory is shut down"));
@@ -350,7 +350,9 @@ class Connection {
 
     ListenableFuture<Void> initializeTransportFuture =
         GuavaCompatibility.INSTANCE.transformAsync(
-            queryOptionsFuture, onOptionsReady(protocolVersion, initExecutor), initExecutor);
+            queryOptionsFuture,
+            onOptionsReady(protocolVersion, initExecutor, tracingRequested),
+            initExecutor);
 
     // Fallback on initializeTransportFuture so we can properly propagate specific exceptions.
     ListenableFuture<Void> initFuture =
@@ -497,12 +499,17 @@ class Connection {
   }
 
   private AsyncFunction<Void, Void> onOptionsReady(
-      final ProtocolVersion protocolVersion, final Executor initExecutor) {
+      final ProtocolVersion protocolVersion,
+      final Executor initExecutor,
+      final boolean tracingRequested) {
     return new AsyncFunction<Void, Void>() {
       @Override
       public ListenableFuture<Void> apply(Void input) throws Exception {
         ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
         Map<String, String> extraOptions = new HashMap<String, String>();
+        if (tracingRequested) {
+          extraOptions.put("SCYLLA_OPENTELEMETRY_TRACING", "true");
+        }
         LwtInfo lwtInfo = getHost().getLwtInfo();
         if (lwtInfo != null) {
           lwtInfo.addOption(extraOptions);
@@ -1288,7 +1295,7 @@ class Connection {
       Connection connection = new Connection(buildConnectionName(host), endPoint, this);
       // This method opens the connection synchronously, so wait until it's initialized
       try {
-        connection.initAsync().get();
+        connection.initAsync(false).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);
@@ -1306,10 +1313,11 @@ class Connection {
         throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException,
             ClusterNameMismatchException {
       pool.host.convictionPolicy.signalConnectionsOpening(1);
+      boolean tracingRequested = pool.isTracingRequested();
       Connection connection =
           new Connection(buildConnectionName(pool.host), pool.host.getEndPoint(), this, pool);
       try {
-        connection.initAsync(shardId, serverPort).get();
+        connection.initAsync(shardId, serverPort, tracingRequested).get();
         return connection;
       } catch (ExecutionException e) {
         throw launderAsyncInitException(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
@@ -41,6 +41,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
   final Cluster cluster;
   final boolean isLWT;
   final Token.Factory partitioner;
+  final String operationType;
 
   volatile ByteBuffer routingKey;
 
@@ -66,6 +67,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
     this.cluster = cluster;
     this.isLWT = isLWT;
     this.partitioner = partitioner;
+    this.operationType = null;
   }
 
   static DefaultPreparedStatement fromMessage(
@@ -314,5 +316,11 @@ public class DefaultPreparedStatement implements PreparedStatement {
   @Override
   public boolean isLWT() {
     return isLWT;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getOperationType() {
+    return operationType;
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -30,6 +30,7 @@ import com.datastax.driver.core.exceptions.AuthenticationException;
 import com.datastax.driver.core.exceptions.BusyPoolException;
 import com.datastax.driver.core.exceptions.ConnectionException;
 import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
@@ -267,6 +268,10 @@ class HostConnectionPool implements Connection.Owner {
     this.timeoutsExecutor = manager.getCluster().manager.connectionFactory.eventLoopGroup.next();
   }
 
+  protected boolean isTracingRequested() {
+    return !(manager.getTracingInfoFactory() == NoopTracingInfoFactory.INSTANCE);
+  }
+
   /**
    * @param reusedConnection an existing connection (from a reconnection attempt) that we want to
    *     reuse as part of this pool. Might be null or already used by another pool.
@@ -344,14 +349,15 @@ class HostConnectionPool implements Connection.Owner {
           }
         }
 
-        ListenableFuture<Void> connectionFuture = connection.initAsync(shardId, serverPort);
+        ListenableFuture<Void> connectionFuture =
+            connection.initAsync(shardId, serverPort, isTracingRequested());
         connectionFutures.add(handleErrors(connectionFuture, initExecutor));
 
         shardConnectionIndex++;
       }
     } else {
       for (Connection connection : newConnections) {
-        ListenableFuture<Void> connectionFuture = connection.initAsync();
+        ListenableFuture<Void> connectionFuture = connection.initAsync(isTracingRequested());
         connectionFutures.add(handleErrors(connectionFuture, initExecutor));
       }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
@@ -361,4 +361,7 @@ public interface PreparedStatement {
 
   /** Whether a prepared statement is LWT statement */
   public boolean isLWT();
+
+  /** Type of prepared operation (e.g. SELECT) */
+  public String getOperationType();
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -281,6 +281,7 @@ class RequestHandler {
         logServerWarnings(response.warnings);
       }
       callback.onSet(connection, response, info, statement, System.nanoTime() - startTime);
+      tracingInfo.setStatus(TracingInfo.StatusCode.OK);
       tracingInfo.tracingFinished();
     } catch (Exception e) {
       callback.onException(
@@ -290,6 +291,8 @@ class RequestHandler {
           System.nanoTime() - startTime, /*unused*/
           0);
 
+      tracingInfo.setStatus(TracingInfo.StatusCode.ERROR, e.toString());
+      tracingInfo.recordException(e);
       tracingInfo.tracingFinished();
     }
   }
@@ -315,6 +318,8 @@ class RequestHandler {
 
     cancelPendingExecutions(execution);
 
+    tracingInfo.recordException(exception);
+    tracingInfo.setStatus(TracingInfo.StatusCode.ERROR, exception.toString());
     tracingInfo.tracingFinished();
 
     try {

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.AuthenticationException;
@@ -20,6 +26,7 @@ import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.QueryExecutionException;
 import com.datastax.driver.core.exceptions.QueryValidationException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.Closeable;
 import java.util.Collection;
@@ -40,6 +47,13 @@ import java.util.Map;
  * names in queries.
  */
 public interface Session extends Closeable {
+
+  /**
+   * The tracingInfo factory class used by this Session.
+   *
+   * @return the factory used currently by this Session.
+   */
+  TracingInfoFactory getTracingInfoFactory();
 
   /**
    * The keyspace to which this Session is currently logged in, if any.

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -29,6 +29,7 @@ import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
@@ -74,6 +75,11 @@ class SessionManager extends AbstractSession {
     this.cluster = cluster;
     this.pools = new ConcurrentHashMap<Host, HostConnectionPool>();
     this.poolsState = new HostConnectionPool.PoolState();
+  }
+
+  @Override
+  public TracingInfoFactory getTracingInfoFactory() {
+    return cluster.getTracingInfoFactory();
   }
 
   @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -23,6 +23,15 @@ public class NoopTracingInfoFactory implements TracingInfoFactory {
     public void setNameAndStartTime(String name) {}
 
     @Override
+    public void recordException(Exception exception) {}
+
+    @Override
+    public void setStatus(StatusCode code, String description) {}
+
+    @Override
+    public void setStatus(StatusCode code) {}
+
+    @Override
     public void tracingFinished() {}
   }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+public class NoopTracingInfoFactory implements TracingInfoFactory {
+
+  private static class NoopTracingInfo implements TracingInfo {
+    @Override
+    public void setNameAndStartTime(String name) {}
+
+    @Override
+    public void tracingFinished() {}
+  }
+
+  public static final NoopTracingInfo INSTANCE = new NoopTracingInfo();
+
+  @Override
+  public TracingInfo buildTracingInfo() {
+    return INSTANCE;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo(TracingInfo parent) {
+    return new NoopTracingInfo();
+  }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/NoopTracingInfoFactory.java
@@ -16,11 +16,70 @@
 
 package com.datastax.driver.core.tracing;
 
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
+
 public class NoopTracingInfoFactory implements TracingInfoFactory {
 
   private static class NoopTracingInfo implements TracingInfo {
     @Override
     public void setNameAndStartTime(String name) {}
+
+    @Override
+    public void setConsistencyLevel(ConsistencyLevel consistency) {}
+
+    @Override
+    public void setStatementType(String statementType) {}
+
+    @Override
+    public void setRetryPolicy(RetryPolicy retryPolicy) {}
+
+    @Override
+    public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {};
+
+    @Override
+    public void setBatchSize(int batchSize) {}
+
+    @Override
+    public void setRetryCount(int retryCount) {}
+
+    @Override
+    public void setShardID(int shardID) {}
+
+    @Override
+    public void setPeerName(String peerName) {}
+
+    @Override
+    public void setPeerIP(InetAddress peerIP) {}
+
+    @Override
+    public void setPeerPort(int peerPort) {}
+
+    @Override
+    public void setQueryPaged(Boolean queryPaged) {}
+
+    @Override
+    public void setRowsCount(int rowsCount) {}
+
+    @Override
+    public void setStatement(String statement, int limit) {}
+
+    @Override
+    public void setKeyspace(String keyspace) {}
+
+    @Override
+    public void setPartitionKey(String partitionKey) {}
+
+    @Override
+    public void setTable(String table) {}
+
+    @Override
+    public void setOperationType(String operationType) {}
+
+    @Override
+    public void setReplicas(String replicas) {}
 
     @Override
     public void recordException(Exception exception) {}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/PrecisionLevel.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/PrecisionLevel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+/** The precision level of tracing data that is to be collected. May be extended in the future. */
+public enum PrecisionLevel {
+  // Enum elements must be listed in ascending order of precision level (i.e. each next element
+  // listed adds some new information).
+  NORMAL,
+  FULL;
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -22,6 +22,12 @@ package com.datastax.driver.core.tracing;
  */
 public interface TracingInfo {
 
+  /** Final status of the traced execution. */
+  enum StatusCode {
+    OK,
+    ERROR,
+  }
+
   /**
    * Starts a span corresponding to this {@link TracingInfo} object. Must be called exactly once,
    * before any other method, at the beginning of the traced execution.
@@ -29,6 +35,28 @@ public interface TracingInfo {
    * @param name the name given to the span being created.
    */
   void setNameAndStartTime(String name);
+
+  /**
+   * Records in the trace that the provided exception occured.
+   *
+   * @param exception the exception to be recorded.
+   */
+  void recordException(Exception exception);
+
+  /**
+   * Sets the final status of the traced execution.
+   *
+   * @param code the status code to be set.
+   */
+  void setStatus(StatusCode code);
+
+  /**
+   * Sets the final status of the traced execution, with additional description.
+   *
+   * @param code the status code to be set.
+   * @param description the additional description of the status.
+   */
+  void setStatus(StatusCode code, String description);
 
   /** Must be always called exactly once at the logical end of traced execution. */
   void tracingFinished();

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -16,6 +16,11 @@
 
 package com.datastax.driver.core.tracing;
 
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
+
 /**
  * An abstraction layer over instrumentation library API, corresponding to a logical span in the
  * trace.
@@ -35,6 +40,134 @@ public interface TracingInfo {
    * @param name the name given to the span being created.
    */
   void setNameAndStartTime(String name);
+
+  /**
+   * Adds provided consistency level to the trace.
+   *
+   * @param consistency the consistency level to be set.
+   */
+  void setConsistencyLevel(ConsistencyLevel consistency);
+
+  /**
+   * Adds provided statement type to the trace.
+   *
+   * @param statementType the statement type to be set.
+   */
+  void setStatementType(String statementType);
+
+  /**
+   * Adds provided retry policy to the trace.
+   *
+   * @param retryPolicy the retry policy to be set.
+   */
+  void setRetryPolicy(RetryPolicy retryPolicy);
+
+  /**
+   * Adds provided load balancing policy to the trace.
+   *
+   * @param loadBalancingPolicy the load balancing policy to be set.
+   */
+  void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy);
+
+  /**
+   * Adds provided batch size to the trace.
+   *
+   * @param batchSize the batch size to be set.
+   */
+  void setBatchSize(int batchSize);
+
+  /**
+   * Adds provided retry count to the trace.
+   *
+   * @param retryCount the retry count to be set.
+   */
+  void setRetryCount(int retryCount);
+
+  /**
+   * Adds provided shard ID to the trace.
+   *
+   * @param shardID the shard ID to be set.
+   */
+  void setShardID(int shardID);
+
+  /**
+   * Adds provided peer name to the trace.
+   *
+   * @param peerName the peer name to be set.
+   */
+  void setPeerName(String peerName);
+
+  /**
+   * Adds provided peer IP to the trace.
+   *
+   * @param peerIP the peer IP to be set.
+   */
+  void setPeerIP(InetAddress peerIP);
+
+  /**
+   * Adds provided peer port to the trace.
+   *
+   * @param peerPort the peer port to be set.
+   */
+  void setPeerPort(int peerPort);
+
+  /**
+   * Adds information whether the query was paged to the trace.
+   *
+   * @param queryPaged information whether the query was paged.
+   */
+  void setQueryPaged(Boolean queryPaged);
+
+  /**
+   * Adds provided number of returned rows to the trace.
+   *
+   * @param rowsCount the number of returned rows to be set.
+   */
+  void setRowsCount(int rowsCount);
+
+  /**
+   * Adds provided statement text to the trace. If the statement length is greater than given limit,
+   * the statement is trimmed to the first {@param limit} signs.
+   *
+   * @param statement the statement text to be set.
+   * @param limit the statement length limit.
+   */
+  void setStatement(String statement, int limit);
+
+  /**
+   * Adds provided keyspace to the trace.
+   *
+   * @param keyspace the keyspace to be set.
+   */
+  void setKeyspace(String keyspace);
+
+  /**
+   * Adds provided partition key string to the trace.
+   *
+   * @param partitionKey the partitionKey to be set.
+   */
+  void setPartitionKey(String partitionKey);
+
+  /**
+   * Adds provided table name to the trace.
+   *
+   * @param table the table name to be set.
+   */
+  void setTable(String table);
+
+  /**
+   * Adds provided operation type (e.g. SELECT) to the trace.
+   *
+   * @param operationType the operation type to be set.
+   */
+  void setOperationType(String operationType);
+
+  /**
+   * Adds provided list of contacted replicas to the trace.
+   *
+   * @param replicas the list of contacted replicas to be set.
+   */
+  void setReplicas(String replicas);
 
   /**
    * Records in the trace that the provided exception occured.

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+/**
+ * An abstraction layer over instrumentation library API, corresponding to a logical span in the
+ * trace.
+ */
+public interface TracingInfo {
+
+  /**
+   * Starts a span corresponding to this {@link TracingInfo} object. Must be called exactly once,
+   * before any other method, at the beginning of the traced execution.
+   *
+   * @param name the name given to the span being created.
+   */
+  void setNameAndStartTime(String name);
+
+  /** Must be always called exactly once at the logical end of traced execution. */
+  void tracingFinished();
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfoFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/tracing/TracingInfoFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+/** Factory of trace info objects. */
+public interface TracingInfoFactory {
+
+  /** Creates new trace info object, inheriting global context. */
+  TracingInfo buildTracingInfo();
+
+  /**
+   * Creates new trace info object, inheriting context from provided another trace info object.
+   *
+   * @param parent the trace info object to be set as the parent of newly created trace info object.
+   */
+  TracingInfo buildTracingInfo(TracingInfo parent);
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
@@ -284,6 +285,11 @@ public class AsyncQueryTest extends CCMTestsSupport {
       // test a custom call to checkNotInEventLoop()
       checkNotInEventLoop();
       return executeAsync(statement).getUninterruptibly();
+    }
+
+    @Override
+    public TracingInfoFactory getTracingInfoFactory() {
+      return session.getTracingInfoFactory();
     }
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterTest.java
@@ -29,7 +29,8 @@ import org.mockito.invocation.Invocation;
 import org.testng.annotations.Test;
 
 public class DelegatingClusterTest {
-  private static final Set<String> NON_DELEGATED_METHODS = ImmutableSet.of("getClusterName");
+  private static final Set<String> NON_DELEGATED_METHODS =
+      ImmutableSet.of("getClusterName", "setTracingInfoFactory", "getTracingInfoFactory");
 
   /**
    * Checks that all methods of {@link DelegatingCluster} invoke their counterpart in {@link

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/BasicTracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/BasicTracingTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
+import com.datastax.driver.core.policies.PagingOptimizingLoadBalancingPolicy;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.testng.annotations.Test;
+
+public class BasicTracingTest extends CCMTestsSupport {
+  private static TestTracingInfoFactory testTracingInfoFactory;
+  private Session session;
+
+  @Override
+  public void onTestContextInitialized() {
+    initializeTestTracing();
+    session.execute("USE " + keyspace);
+    session.execute("CREATE TABLE t (k int PRIMARY KEY, v int)");
+
+    Collection<TracingInfo> spans = testTracingInfoFactory.getSpans();
+    spans.clear();
+  }
+
+  @Test(groups = "short")
+  public void simpleTracingTest() {
+    session.execute("INSERT INTO t(k, v) VALUES (1, 7)");
+
+    Collection<TracingInfo> spans = testTracingInfoFactory.getSpans();
+    assertNotEquals(spans.size(), 0);
+
+    TracingInfo rootSpan = getRoot(spans);
+    assertTrue(rootSpan instanceof TestTracingInfo);
+    TestTracingInfo root = (TestTracingInfo) rootSpan;
+
+    assertTrue(root.isSpanStarted());
+    assertTrue(root.isSpanFinished());
+    assertEquals(root.getStatusCode(), TracingInfo.StatusCode.OK);
+
+    spans.clear();
+  }
+
+  @Test(groups = "short")
+  public void tagsTest() {
+    PreparedStatement prepared = session.prepare("INSERT INTO t(k, v) VALUES (?, ?)");
+
+    Collection<TracingInfo> prepareSpans = testTracingInfoFactory.getSpans();
+    assertNotEquals(prepareSpans.size(), 0);
+    assertTrue(getRoot(prepareSpans) instanceof TestTracingInfo);
+    prepareSpans.clear();
+
+    BoundStatement bound = prepared.bind(1, 7);
+    session.execute(bound);
+
+    Collection<TracingInfo> spans = testTracingInfoFactory.getSpans();
+    assertNotEquals(spans.size(), 0);
+
+    TracingInfo rootSpan = getRoot(spans);
+    assertTrue(rootSpan instanceof TestTracingInfo);
+    TestTracingInfo root = (TestTracingInfo) rootSpan;
+
+    assertTrue(root.isSpanStarted());
+    assertTrue(root.isSpanFinished());
+    assertEquals(root.getStatusCode(), TracingInfo.StatusCode.OK);
+
+    // these tags should be set for request span
+    assertEquals(root.getStatementType(), "prepared");
+    assertEquals(root.getBatchSize(), new Integer(1));
+    assertEquals(root.getConsistencyLevel(), ConsistencyLevel.ONE);
+    assertNull(root.getRowsCount()); // no rows are returned in insert
+    assertTrue(root.getLoadBalancingPolicy() instanceof PagingOptimizingLoadBalancingPolicy);
+    assertTrue(root.getRetryPolicy() instanceof DefaultRetryPolicy);
+    assertFalse(root.getQueryPaged());
+    assertNull(root.getStatement()); // because of precision level NORMAL
+    // these are tags specific to bound statement
+    assertEquals(root.getKeyspace(), keyspace);
+    assertEquals(root.getPartitionKey(), "k=1");
+    assertEquals(root.getTable(), "t");
+
+    // these tags should not be set for request span
+    assertNull(root.getPeerName());
+    assertNull(root.getPeerIP());
+    assertNull(root.getPeerPort());
+    assertNull(root.getRetryCount());
+
+    ArrayList<TracingInfo> speculativeExecutions = getChildren(spans, root);
+    assertTrue(speculativeExecutions.size() > 0);
+
+    for (TracingInfo speculativeExecutionSpan : speculativeExecutions) {
+      assertTrue(speculativeExecutionSpan instanceof TestTracingInfo);
+      TestTracingInfo tracingInfo = (TestTracingInfo) speculativeExecutionSpan;
+
+      // these tags should not be set for speculative execution span
+      assertNull(tracingInfo.getStatementType());
+      assertNull(tracingInfo.getBatchSize());
+      assertNull(tracingInfo.getConsistencyLevel());
+      assertNull(tracingInfo.getRowsCount());
+      assertNull(tracingInfo.getLoadBalancingPolicy());
+      assertNull(tracingInfo.getRetryPolicy());
+      assertNull(tracingInfo.getQueryPaged());
+      assertNull(tracingInfo.getStatement());
+      assertNull(tracingInfo.getPeerName());
+      assertNull(tracingInfo.getPeerIP());
+      assertNull(tracingInfo.getPeerPort());
+      // these are tags specific to bound statement
+      assertNull(tracingInfo.getKeyspace());
+      assertNull(tracingInfo.getPartitionKey());
+      assertNull(tracingInfo.getTable());
+
+      // this tag should be set for speculative execution span
+      assertTrue(tracingInfo.getRetryCount() >= 0);
+    }
+
+    ArrayList<TracingInfo> queries = new ArrayList<TracingInfo>();
+    for (TracingInfo tracingInfo : speculativeExecutions) {
+      queries.addAll(getChildren(spans, tracingInfo));
+    }
+    assertTrue(queries.size() > 0);
+
+    for (TracingInfo querySpan : queries) {
+      assertTrue(querySpan instanceof TestTracingInfo);
+      TestTracingInfo tracingInfo = (TestTracingInfo) querySpan;
+
+      // these tags should not be set for query span
+      assertNull(tracingInfo.getStatementType());
+      assertNull(tracingInfo.getBatchSize());
+      assertNull(tracingInfo.getConsistencyLevel());
+      assertNull(tracingInfo.getRowsCount());
+      assertNull(tracingInfo.getLoadBalancingPolicy());
+      assertNull(tracingInfo.getRetryPolicy());
+      assertNull(tracingInfo.getQueryPaged());
+      assertNull(tracingInfo.getStatement());
+      assertNull(tracingInfo.getRetryCount());
+      // these are tags specific to bound statement
+      assertNull(tracingInfo.getKeyspace());
+      assertNull(tracingInfo.getPartitionKey());
+      assertNull(tracingInfo.getTable());
+
+      // these tags should be set for query span
+      assertNotNull(tracingInfo.getPeerName());
+      assertNotNull(tracingInfo.getPeerIP());
+      assertNotNull(tracingInfo.getPeerPort());
+      assertTrue(tracingInfo.getPeerPort() >= 0 && tracingInfo.getPeerPort() <= 65535);
+    }
+
+    spans.clear();
+  }
+
+  private void initializeTestTracing() {
+    testTracingInfoFactory = new TestTracingInfoFactory(PrecisionLevel.NORMAL);
+    cluster().setTracingInfoFactory(testTracingInfoFactory);
+    session = cluster().connect();
+  }
+
+  private TracingInfo getRoot(Collection<TracingInfo> spans) {
+    TracingInfo root = null;
+    for (TracingInfo tracingInfo : spans) {
+      if (tracingInfo instanceof TestTracingInfo
+          && ((TestTracingInfo) tracingInfo).getParent() == null) {
+        assertNull(root); // There should be only one root.
+        root = tracingInfo;
+      }
+    }
+
+    return root;
+  }
+
+  private ArrayList<TracingInfo> getChildren(Collection<TracingInfo> spans, TracingInfo parent) {
+    ArrayList<TracingInfo> children = new ArrayList<TracingInfo>();
+    for (TracingInfo tracingInfo : spans) {
+      if (tracingInfo instanceof TestTracingInfo
+          && ((TestTracingInfo) tracingInfo).getParent() == parent) {
+        children.add(tracingInfo);
+      }
+    }
+    return children;
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfo.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TestTracingInfo implements TracingInfo {
+
+  private final PrecisionLevel precision;
+  private TracingInfo parent = null;
+
+  private Boolean spanStarted = false;
+  private Boolean spanFinished = false;
+  private String spanName;
+  private ConsistencyLevel consistencyLevel;
+  private String statement;
+  private String statementType;
+  private Collection<Exception> exceptions;
+  private StatusCode statusCode;
+  private String description;
+  private InetAddress peerIP;
+  private RetryPolicy retryPolicy;
+  private LoadBalancingPolicy loadBalancingPolicy;
+  private Integer batchSize;
+  private Integer retryCount;
+  private Integer shardID;
+  private String peerName;
+  private Integer peerPort;
+  private Boolean queryPaged;
+  private Integer rowsCount;
+  private String keyspace;
+  private String partitionKey;
+  private String table;
+  private String operationType;
+  private String replicas;
+
+  public TestTracingInfo(PrecisionLevel precision) {
+    this.precision = precision;
+  }
+
+  public TestTracingInfo(PrecisionLevel precision, TracingInfo parent) {
+    this(precision);
+    this.parent = parent;
+  }
+
+  public PrecisionLevel getPrecision() {
+    return precision;
+  }
+
+  @Override
+  public void setNameAndStartTime(String name) {
+    this.spanStarted = true;
+    this.spanName = name;
+  }
+
+  @Override
+  public void setConsistencyLevel(ConsistencyLevel consistency) {
+    this.consistencyLevel = consistency;
+  }
+
+  @Override
+  public void setStatementType(String statementType) {
+    this.statementType = statementType;
+  }
+
+  @Override
+  public void setRetryPolicy(RetryPolicy retryPolicy) {
+    this.retryPolicy = retryPolicy;
+  }
+
+  @Override
+  public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {
+    this.loadBalancingPolicy = loadBalancingPolicy;
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void setRetryCount(int retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  @Override
+  public void setShardID(int shardID) {
+    this.shardID = shardID;
+  }
+
+  @Override
+  public void setPeerName(String peerName) {
+    this.peerName = peerName;
+  }
+
+  @Override
+  public void setPeerIP(InetAddress peerIP) {
+    this.peerIP = peerIP;
+  }
+
+  @Override
+  public void setPeerPort(int peerPort) {
+    this.peerPort = peerPort;
+  }
+
+  @Override
+  public void setQueryPaged(Boolean queryPaged) {
+    this.queryPaged = queryPaged;
+  }
+
+  @Override
+  public void setRowsCount(int rowsCount) {
+    this.rowsCount = rowsCount;
+  }
+
+  @Override
+  public void setStatement(String statement, int limit) {
+    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
+      if (statement.length() > limit) statement = statement.substring(0, limit);
+      this.statement = statement;
+    }
+  }
+
+  @Override
+  public void setKeyspace(String keyspace) {
+    this.keyspace = keyspace;
+  }
+
+  @Override
+  public void setPartitionKey(String partitionKey) {
+    this.partitionKey = partitionKey;
+  }
+
+  @Override
+  public void setTable(String table) {
+    this.table = table;
+  }
+
+  @Override
+  public void setOperationType(String operationType) {
+    this.operationType = operationType;
+  }
+
+  @Override
+  public void setReplicas(String replicas) {
+    this.replicas = replicas;
+  }
+
+  @Override
+  public void recordException(Exception exception) {
+    if (this.exceptions == null) {
+      this.exceptions = new ArrayList();
+    }
+    this.exceptions.add(exception);
+  }
+
+  @Override
+  public void setStatus(StatusCode code) {
+    this.statusCode = code;
+  }
+
+  @Override
+  public void setStatus(StatusCode code, String description) {
+    this.statusCode = code;
+    this.description = description;
+  }
+
+  @Override
+  public void tracingFinished() {
+    this.spanFinished = true;
+  }
+
+  private boolean currentPrecisionLevelIsAtLeast(PrecisionLevel requiredLevel) {
+    return requiredLevel.compareTo(precision) <= 0;
+  }
+
+  public boolean isSpanStarted() {
+    return spanStarted;
+  }
+
+  public boolean isSpanFinished() {
+    return spanFinished;
+  }
+
+  public String getSpanName() {
+    return spanName;
+  }
+
+  public ConsistencyLevel getConsistencyLevel() {
+    return consistencyLevel;
+  }
+
+  public String getStatementType() {
+    return statementType;
+  }
+
+  public RetryPolicy getRetryPolicy() {
+    return retryPolicy;
+  }
+
+  public LoadBalancingPolicy getLoadBalancingPolicy() {
+    return loadBalancingPolicy;
+  }
+
+  public Integer getBatchSize() {
+    return batchSize;
+  }
+
+  public Integer getRetryCount() {
+    return retryCount;
+  }
+
+  public Integer getShardID() {
+    return shardID;
+  }
+
+  public String getPeerName() {
+    return peerName;
+  }
+
+  public InetAddress getPeerIP() {
+    return peerIP;
+  }
+
+  public Integer getPeerPort() {
+    return peerPort;
+  }
+
+  public Boolean getQueryPaged() {
+    return queryPaged;
+  }
+
+  public Integer getRowsCount() {
+    return rowsCount;
+  }
+
+  public String getStatement() {
+    return statement;
+  }
+
+  public String getKeyspace() {
+    return keyspace;
+  }
+
+  public String getPartitionKey() {
+    return partitionKey;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public String getOperationType() {
+    return operationType;
+  }
+
+  public String getReplicas() {
+    return replicas;
+  }
+
+  public StatusCode getStatusCode() {
+    return statusCode;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public TracingInfo getParent() {
+    return parent;
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfoFactory.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/tracing/TestTracingInfoFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.core.tracing;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class TestTracingInfoFactory implements TracingInfoFactory {
+  private final PrecisionLevel precision;
+  private Collection<TracingInfo> spans =
+      Collections.synchronizedList(new ArrayList<TracingInfo>());
+
+  public TestTracingInfoFactory() {
+    this.precision = PrecisionLevel.NORMAL;
+  }
+
+  public TestTracingInfoFactory(final PrecisionLevel precision) {
+    this.precision = precision;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo() {
+    TracingInfo tracingInfo = new TestTracingInfo(precision);
+    spans.add(tracingInfo);
+    return tracingInfo;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo(TracingInfo parent) {
+    TracingInfo tracingInfo;
+
+    if (parent instanceof TestTracingInfo) {
+      final TestTracingInfo castedParent = (TestTracingInfo) parent;
+      tracingInfo = new TestTracingInfo(castedParent.getPrecision(), parent);
+      spans.add(tracingInfo);
+      return tracingInfo;
+    }
+
+    tracingInfo = new NoopTracingInfoFactory().buildTracingInfo();
+    spans.add(tracingInfo);
+    return tracingInfo;
+  }
+
+  public Collection<TracingInfo> getSpans() {
+    return spans;
+  }
+}

--- a/driver-examples/README.md
+++ b/driver-examples/README.md
@@ -5,6 +5,17 @@ Apache Cassandra.
 
 ## Usage
 
-Unless otherwise stated, all examples assume that you have a single-node Cassandra 3.0 cluster 
+Unless otherwise stated, all examples assume that you have a single-node Cassandra 3.0 cluster
 listening on localhost:9042.
 
+Before running examples, make sure you installed repo artifacts (in root driver directory):
+```
+mvn install -q -Dmaven.test.skip=true
+```
+
+To conveniently run the example showing OpenTelemetry integration (ZipkinConfiguration),
+you can use the provided ```docker-compose.yaml``` file (which runs both Scylla cluster and Zipkin instance):
+```
+docker-compose up
+./runOpenTelemetryExample.sh
+```

--- a/driver-examples/docker-compose.yaml
+++ b/driver-examples/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.4'
+
+services:
+    zipkin:
+        image: openzipkin/zipkin
+        ports:
+            - "9411:9411"
+    scylla_node:
+        image: scylladb/scylla
+        ports:
+            - "9042:9042"
+        command: "--smp 1 --skip-wait-for-gossip-to-settle 0"

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -48,6 +48,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-opentelemetry</artifactId>
+        </dependency>
+
         <!--Jackson-->
 
         <dependency>
@@ -134,6 +139,26 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <!-- OpenTelemetry -->
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.9.0-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -181,6 +206,15 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 

--- a/driver-examples/runOpenTelemetryExample.sh
+++ b/driver-examples/runOpenTelemetryExample.sh
@@ -1,0 +1,1 @@
+mvn -q exec:java -Dexec.mainClass="com.datastax.driver.examples.opentelemetry.ZipkinUsage"

--- a/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/OpenTelemetryConfiguration.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/OpenTelemetryConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.examples.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+/** Example showing how to configure OpenTelemetry for tracing with Scylla Java Driver. */
+class OpenTelemetryConfiguration {
+  private static final String SERVICE_NAME = "Scylla Java driver";
+
+  public static OpenTelemetry initialize(SpanExporter spanExporter) {
+    Resource serviceNameResource =
+        Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, SERVICE_NAME));
+
+    // Set to process the spans by the spanExporter.
+    final SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .setResource(Resource.getDefault().merge(serviceNameResource))
+            .build();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+
+    // Add a shutdown hook to shut down the SDK.
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    tracerProvider.close();
+                  }
+                }));
+
+    // Return the configured instance so it can be used for instrumentation.
+    return openTelemetry;
+  }
+
+  public static OpenTelemetry initializeForZipkin(String ip, int port) {
+    String endpointPath = "/api/v2/spans";
+    String httpUrl = String.format("http://%s:%s", ip, port);
+
+    SpanExporter exporter =
+        ZipkinSpanExporter.builder().setEndpoint(httpUrl + endpointPath).build();
+
+    return initialize(exporter);
+  }
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/opentelemetry/ZipkinUsage.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.driver.examples.opentelemetry;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
+import com.datastax.driver.opentelemetry.OpenTelemetryTracingInfoFactory;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Creates a keyspace and tables, and loads some data into them. Sends OpenTelemetry tracing data to
+ * Zipkin tracing backend
+ *
+ * <p>Preconditions: - a Scylla cluster is running and accessible through the contacts points
+ * identified by CONTACT_POINTS and PORT and Zipkin backend is running and accessible through the
+ * contacts points identified by ZIPKIN_CONTACT_POINT and ZIPKIN_PORT.
+ *
+ * <p>Side effects: - creates a new keyspace "simplex" in the cluster. If a keyspace with this name
+ * already exists, it will be reused; - creates two tables "simplex.songs" and "simplex.playlists".
+ * If they exist already, they will be reused; - inserts a row in each table.
+ */
+public class ZipkinUsage {
+  private static final String CONTACT_POINT = "127.0.0.1";
+  private static final int PORT = 9042;
+
+  private static final String ZIPKIN_CONTACT_POINT = "127.0.0.1";
+  private static final int ZIPKIN_PORT = 9411;
+
+  private Cluster cluster;
+  private Session session;
+
+  private Tracer tracer;
+
+  public static void main(String[] args) {
+    // Workaround for setting ContextStorage to ThreadLocalContextStorage.
+    System.setProperty("io.opentelemetry.context.contextStorageProvider", "default");
+
+    ZipkinUsage client = new ZipkinUsage();
+
+    try {
+      client.connect();
+      client.createSchema();
+      client.loadData();
+      client.querySchema();
+      System.out.println(
+          "All requests have been completed. Now you can visit Zipkin at "
+              + "http://"
+              + ZIPKIN_CONTACT_POINT
+              + ":"
+              + ZIPKIN_PORT
+              + " and examine the produced trace.");
+    } finally {
+      client.close();
+    }
+  }
+
+  /** Initiates a connection to the cluster. */
+  public void connect() {
+    cluster = Cluster.builder().addContactPoints(CONTACT_POINT).withPort(PORT).build();
+
+    System.out.printf("Connected to cluster: %s%n", cluster.getMetadata().getClusterName());
+
+    OpenTelemetry openTelemetry =
+        OpenTelemetryConfiguration.initializeForZipkin(ZIPKIN_CONTACT_POINT, ZIPKIN_PORT);
+    tracer = openTelemetry.getTracerProvider().get("this");
+    TracingInfoFactory tracingInfoFactory = new OpenTelemetryTracingInfoFactory(tracer);
+    cluster.setTracingInfoFactory(tracingInfoFactory);
+
+    session = cluster.connect();
+  }
+
+  /** Creates the schema (keyspace) and tables for this example. */
+  public void createSchema() {
+    session.execute("DROP KEYSPACE IF EXISTS simplex;");
+    Span parentSpan = tracer.spanBuilder("create schema").startSpan();
+    try (Scope parentScope = parentSpan.makeCurrent()) {
+      {
+        Span span = tracer.spanBuilder("create simplex").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.execute(
+              "CREATE KEYSPACE IF NOT EXISTS simplex WITH replication "
+                  + "= {'class':'SimpleStrategy', 'replication_factor':1};");
+
+        } finally {
+          span.end();
+        }
+      }
+      {
+        Span span = tracer.spanBuilder("create simplex.songs").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.executeAsync(
+              "CREATE TABLE IF NOT EXISTS simplex.songs ("
+                  + "id uuid,"
+                  + "title text,"
+                  + "album text,"
+                  + "artist text,"
+                  + "tags set<text>,"
+                  + "data blob,"
+                  + "PRIMARY KEY ((title, artist), album)"
+                  + ");");
+        } finally {
+          span.end();
+        }
+      }
+      {
+        Span span = tracer.spanBuilder("create simplex.playlists").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+          session.execute(
+              "CREATE TABLE IF NOT EXISTS simplex.playlists ("
+                  + "id uuid,"
+                  + "title text,"
+                  + "album text, "
+                  + "artist text,"
+                  + "song_id uuid,"
+                  + "PRIMARY KEY (id, title, album, artist)"
+                  + ");");
+
+        } finally {
+          span.end();
+        }
+      }
+    } finally {
+      parentSpan.end();
+    }
+  }
+
+  /** Inserts data into the tables. */
+  public void loadData() {
+    Span parentSpan = tracer.spanBuilder("load data").startSpan();
+    try (Scope parentScope = parentSpan.makeCurrent()) {
+
+      Span prepareSpan = tracer.spanBuilder("prepare").startSpan();
+      PreparedStatement ps;
+      try (Scope prepareScope = prepareSpan.makeCurrent()) {
+        ps =
+            session.prepare(
+                "INSERT INTO simplex.songs (id, title, album, artist, tags) "
+                    + "VALUES ("
+                    + "756716f7-2e54-4715-9f00-91dcbea6cf50,"
+                    + "?,"
+                    + "?,"
+                    + "?,"
+                    + "{'jazz', '2013'})"
+                    + ";");
+      } finally {
+        prepareSpan.end();
+      }
+
+      Span bindSpan = tracer.spanBuilder("bind").startSpan();
+      BoundStatement bound;
+      try (Scope bindScope = bindSpan.makeCurrent()) {
+        bound = ps.bind("La Petite Tonkinoise", "Bye Bye Blackbird", "Joséphine Baker");
+      } finally {
+        bindSpan.end();
+      }
+
+      Span span = tracer.spanBuilder("insert simplex.songs").startSpan();
+      try (Scope scope = span.makeCurrent()) {
+        session.execute(bound);
+      } finally {
+        span.end();
+      }
+
+    } finally {
+      parentSpan.end();
+    }
+  }
+
+  public void querySchema() {
+    Span parentSpan = tracer.spanBuilder("query schema").startSpan();
+    try (Scope parentScope = parentSpan.makeCurrent()) {
+
+      Span prepareSpan = tracer.spanBuilder("prepare").startSpan();
+      PreparedStatement ps;
+      try (Scope prepareScope = prepareSpan.makeCurrent()) {
+        ps = session.prepare("SELECT * FROM simplex.songs WHERE artist = ? AND title = ?;");
+      } finally {
+        prepareSpan.end();
+      }
+
+      Span bindSpan = tracer.spanBuilder("bind").startSpan();
+      BoundStatement bound;
+      try (Scope bindScope = bindSpan.makeCurrent()) {
+        bound = ps.bind("Joséphine Baker", "La Petite Tonkinoise");
+      } finally {
+        bindSpan.end();
+      }
+
+      Span span = tracer.spanBuilder("query simplex.songs").startSpan();
+      try (Scope scope = span.makeCurrent()) {
+        session.execute(bound);
+      } finally {
+        span.end();
+      }
+
+    } finally {
+      parentSpan.end();
+    }
+  }
+
+  /** Closes the session and the cluster. */
+  public void close() {
+    session.close();
+    cluster.close();
+  }
+}

--- a/driver-opentelemetry/pom.xml
+++ b/driver-opentelemetry/pom.xml
@@ -1,0 +1,149 @@
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+    Copyright (C) 2021 ScyllaDB
+    Modified by ScyllaDB
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scylladb</groupId>
+        <artifactId>scylla-driver-parent</artifactId>
+        <version>3.11.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scylla-driver-opentelemetry</artifactId>
+    <name>Java Driver for Scylla and Apache Cassandra - OpenTelemetry integration</name>
+    <description>An extension of Java Driver for Scylla and Apache Cassandra by adding
+        functionality of creating traces and spans in OpenTelemetry format.
+    </description>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.9.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- driver dependencies -->
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-core</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry -->
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
+        <!-- tests -->
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <!-- Disable check-jdk6 check for this submodule. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.15</version>
+                <executions>
+                    <execution>
+                        <id>check-jdk6</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>check-jdk8</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+</project>

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfo.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.opentelemetry;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import com.datastax.driver.core.tracing.PrecisionLevel;
+import com.datastax.driver.core.tracing.TracingInfo;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import java.net.InetAddress;
+
+public class OpenTelemetryTracingInfo implements TracingInfo {
+  private Span span;
+  private final Tracer tracer;
+  private final Context context;
+  private boolean tracingStarted;
+  private final PrecisionLevel precision;
+
+  protected OpenTelemetryTracingInfo(Tracer tracer, Context context, PrecisionLevel precision) {
+    this.tracer = tracer;
+    this.context = context;
+    this.precision = precision;
+    this.tracingStarted = false;
+  }
+
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  public Context getContext() {
+    return context.with(span);
+  }
+
+  private void assertStarted() {
+    assert tracingStarted : "TracingInfo.setStartTime must be called before any other method";
+  }
+
+  public PrecisionLevel getPrecision() {
+    return precision;
+  }
+
+  @Override
+  public void setNameAndStartTime(String name) {
+    assert !tracingStarted : "TracingInfo.setStartTime may only be called once.";
+    tracingStarted = true;
+    span = tracer.spanBuilder(name).setParent(context).startSpan();
+  }
+
+  @Override
+  public void setConsistencyLevel(ConsistencyLevel consistency) {
+    assertStarted();
+    span.setAttribute("db.scylla.consistency_level", consistency.toString());
+  }
+
+  public void setStatement(String statement) {
+    assertStarted();
+    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
+      span.setAttribute("db.scylla.statement", statement);
+    }
+  }
+
+  public void setHostname(String hostname) {
+    assertStarted();
+    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
+      span.setAttribute("net.peer.name", hostname);
+    }
+  }
+
+  @Override
+  public void setStatementType(String statementType) {
+    assertStarted();
+    span.setAttribute("db.scylla.statement_type", statementType);
+  }
+
+  @Override
+  public void setRetryPolicy(RetryPolicy retryPolicy) {
+    assertStarted();
+    span.setAttribute("db.scylla.retry_policy", retryPolicy.getClass().getSimpleName());
+  }
+
+  @Override
+  public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {
+    assertStarted();
+    span.setAttribute(
+        "db.scylla.load_balancing_policy", loadBalancingPolicy.getClass().getSimpleName());
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    assertStarted();
+    span.setAttribute("db.scylla.batch_size", String.valueOf(batchSize));
+  }
+
+  @Override
+  public void setRetryCount(int retryCount) {
+    assertStarted();
+    span.setAttribute("db.scylla.retry_count", String.valueOf(retryCount));
+  }
+
+  @Override
+  public void setShardID(int shardID) {
+    assertStarted();
+    span.setAttribute("db.scylla.shard_id", String.valueOf(shardID));
+  }
+
+  @Override
+  public void setPeerName(String peerName) {
+    assertStarted();
+    span.setAttribute("net.peer.name", peerName);
+  }
+
+  @Override
+  public void setPeerIP(InetAddress peerIP) {
+    assertStarted();
+    span.setAttribute("net.peer.ip", peerIP.getHostAddress());
+  }
+
+  @Override
+  public void setPeerPort(int peerPort) {
+    assertStarted();
+    span.setAttribute("net.peer.port", String.valueOf(peerPort));
+  }
+
+  @Override
+  public void setQueryPaged(Boolean queryPaged) {
+    assertStarted();
+    if (queryPaged) span.setAttribute("db.scylla.query_paged", "true");
+    else span.setAttribute("db.scylla.query_paged", "false");
+  }
+
+  @Override
+  public void setRowsCount(int rowsCount) {
+    assertStarted();
+    span.setAttribute("db.scylla.rows_count", rowsCount);
+  }
+
+  @Override
+  public void setStatement(String statement, int limit) {
+    assertStarted();
+    if (currentPrecisionLevelIsAtLeast(PrecisionLevel.FULL)) {
+      if (statement.length() > limit) statement = statement.substring(0, limit);
+      span.setAttribute("db.scylla.statement", statement);
+    }
+  }
+
+  @Override
+  public void setKeyspace(String keyspace) {
+    assertStarted();
+    span.setAttribute("db.scylla.keyspace", keyspace);
+  }
+
+  @Override
+  public void setPartitionKey(String partitionKey) {
+    assertStarted();
+    span.setAttribute("db.scylla.partition_key", partitionKey);
+  }
+
+  @Override
+  public void setTable(String table) {
+    assertStarted();
+    span.setAttribute("db.scylla.table", table);
+  }
+
+  @Override
+  public void setOperationType(String operationType) {
+    assertStarted();
+    span.setAttribute("db.operation", operationType);
+  }
+
+  @Override
+  public void setReplicas(String replicas) {
+    assertStarted();
+    span.setAttribute("db.scylla.replicas", replicas);
+  }
+
+  private io.opentelemetry.api.trace.StatusCode mapStatusCode(StatusCode code) {
+    switch (code) {
+      case OK:
+        return io.opentelemetry.api.trace.StatusCode.OK;
+      case ERROR:
+        return io.opentelemetry.api.trace.StatusCode.ERROR;
+    }
+    return null;
+  }
+
+  @Override
+  public void recordException(Exception exception) {
+    assertStarted();
+    span.recordException(exception);
+  }
+
+  @Override
+  public void setStatus(StatusCode code, String description) {
+    assertStarted();
+    span.setStatus(mapStatusCode(code), description);
+  }
+
+  @Override
+  public void setStatus(StatusCode code) {
+    assertStarted();
+    span.setStatus(mapStatusCode(code));
+  }
+
+  @Override
+  public void tracingFinished() {
+    assertStarted();
+    span.end();
+  }
+
+  private boolean currentPrecisionLevelIsAtLeast(PrecisionLevel requiredLevel) {
+    return requiredLevel.compareTo(precision) <= 0;
+  }
+}

--- a/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
+++ b/driver-opentelemetry/src/main/java/com/datastax/driver/opentelemetry/OpenTelemetryTracingInfoFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.driver.opentelemetry;
+
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.PrecisionLevel;
+import com.datastax.driver.core.tracing.TracingInfo;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+public class OpenTelemetryTracingInfoFactory implements TracingInfoFactory {
+  private final Tracer tracer;
+  private final PrecisionLevel precision;
+
+  public OpenTelemetryTracingInfoFactory(final Tracer tracer) {
+    this(tracer, PrecisionLevel.NORMAL);
+  }
+
+  public OpenTelemetryTracingInfoFactory(final Tracer tracer, final PrecisionLevel precision) {
+    this.tracer = tracer;
+    this.precision = precision;
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo() {
+    final Context current = Context.current();
+    return new OpenTelemetryTracingInfo(tracer, current, precision);
+  }
+
+  @Override
+  public TracingInfo buildTracingInfo(TracingInfo parent) {
+    if (parent instanceof OpenTelemetryTracingInfo) {
+      final OpenTelemetryTracingInfo castedParent = (OpenTelemetryTracingInfo) parent;
+      return new OpenTelemetryTracingInfo(
+          castedParent.getTracer(), castedParent.getContext(), castedParent.getPrecision());
+    }
+
+    return new NoopTracingInfoFactory().buildTracingInfo();
+  }
+
+  public TracingInfo buildTracingInfo(Span parent) {
+    final Context current = Context.current().with(parent);
+    return new OpenTelemetryTracingInfo(tracer, current, precision);
+  }
+}

--- a/driver-opentelemetry/src/test/java/com/datastax/driver/opentelemetry/OpenTelemetryTest.java
+++ b/driver-opentelemetry/src/test/java/com/datastax/driver/opentelemetry/OpenTelemetryTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.opentelemetry;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.tracing.NoopTracingInfoFactory;
+import com.datastax.driver.core.tracing.TracingInfoFactory;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+/** Tests for OpenTelemetry integration. */
+public class OpenTelemetryTest extends CCMTestsSupport {
+  /** Collects and saves spans. */
+  private static final class SpansCollector implements SpanProcessor {
+    final Collection<ReadableSpan> startedSpans =
+        Collections.synchronizedList(new ArrayList<ReadableSpan>());
+    final Collection<ReadableSpan> spans =
+        Collections.synchronizedList(new ArrayList<ReadableSpan>());
+
+    @Override
+    public void onStart(Context parentContext, ReadWriteSpan span) {
+      startedSpans.add(span);
+    }
+
+    @Override
+    public boolean isStartRequired() {
+      return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+      spans.add(span);
+    }
+
+    @Override
+    public boolean isEndRequired() {
+      return true;
+    }
+
+    public Collection<ReadableSpan> getSpans() {
+      for (ReadableSpan span : startedSpans) {
+        assertTrue(span.hasEnded());
+      }
+
+      return spans;
+    }
+  }
+
+  private Session session;
+
+  /**
+   * Prepare OpenTelemetry configuration and run test with it.
+   *
+   * @param test test to run.
+   * @return collected spans.
+   */
+  private Collection<ReadableSpan> collectSpans(BiConsumer<Tracer, TracingInfoFactory> test) {
+    final Resource serviceNameResource =
+        Resource.create(
+            Attributes.of(ResourceAttributes.SERVICE_NAME, "Scylla Java driver - test"));
+
+    final SpansCollector collector = new SpansCollector();
+
+    final SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(collector)
+            .setResource(Resource.getDefault().merge(serviceNameResource))
+            .build();
+    final OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+
+    final Tracer tracer = openTelemetry.getTracerProvider().get("this");
+    final OpenTelemetryTracingInfoFactory tracingInfoFactory =
+        new OpenTelemetryTracingInfoFactory(tracer);
+    cluster().setTracingInfoFactory(tracingInfoFactory);
+    session = cluster().connect();
+
+    session.execute("USE " + keyspace);
+    session.execute("CREATE TABLE t (k int PRIMARY KEY, v int)");
+    collector.getSpans().clear();
+
+    test.accept(tracer, tracingInfoFactory);
+
+    tracerProvider.close();
+    cluster().setTracingInfoFactory(new NoopTracingInfoFactory());
+
+    return collector.getSpans();
+  }
+
+  /** Basic test for creating spans. */
+  @Test(groups = "short")
+  public void simpleTracingTest() {
+    final Collection<ReadableSpan> spans =
+        collectSpans(
+            (tracer, tracingInfoFactory) -> {
+              Span userSpan = tracer.spanBuilder("user span").startSpan();
+              Scope scope = userSpan.makeCurrent();
+
+              session.execute("INSERT INTO t(k, v) VALUES (4, 2)");
+              session.execute("INSERT INTO t(k, v) VALUES (2, 1)");
+
+              scope.close();
+              userSpan.end();
+            });
+
+    // Retrieve span created directly by tracer.
+    final List<ReadableSpan> userSpans =
+        spans.stream()
+            .filter(span -> !span.getParentSpanContext().isValid())
+            .collect(Collectors.toList());
+    assertEquals(userSpans.size(), 1);
+    final ReadableSpan userSpan = userSpans.get(0);
+
+    for (ReadableSpan span : spans) {
+      assertTrue(span.getSpanContext().isValid());
+      assertTrue(
+          span.getSpanContext().equals(userSpan.getSpanContext())
+              || span.getParentSpanContext().isValid());
+    }
+
+    // Retrieve spans representing requests.
+    final Collection<ReadableSpan> rootSpans =
+        spans.stream()
+            .filter(span -> span.getParentSpanContext().equals(userSpan.getSpanContext()))
+            .collect(Collectors.toList());
+    assertEquals(rootSpans.size(), 2);
+
+    rootSpans.stream()
+        .map(ReadableSpan::toSpanData)
+        .forEach(
+            spanData -> {
+              assertEquals(spanData.getName(), "request");
+              assertEquals(spanData.getStatus().getStatusCode(), StatusCode.OK);
+            });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>driver-examples</module>
         <module>driver-tests</module>
         <module>driver-dist</module>
+        <module>driver-opentelemetry</module>
     </modules>
 
     <properties>
@@ -130,6 +131,12 @@
             <dependency>
                 <groupId>com.scylladb</groupId>
                 <artifactId>scylla-driver-extras</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.scylladb</groupId>
+                <artifactId>scylla-driver-opentelemetry</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
 
@@ -727,6 +734,9 @@
                                     <artifactId>java18</artifactId>
                                     <version>1.0</version>
                                 </signature>
+                                <excludeDependencies>
+                                    <excludeDependency>io.opentelemetry:*</excludeDependency>
+                                </excludeDependencies>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
This is an extension of OTel tracing in the driver that implements a proof-of-concept of gathering additional tracing metadata from the cluster via CQL custom payload.