### PR TITLE
Skip should_set_all_occurrences_of_variable() test

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -374,6 +374,7 @@ public class BoundStatementCcmIT {
   }
 
   @Test
+  @ScyllaSkip /* Skipping due to https://github.com/scylladb/scylla/issues/10956. */
   public void should_set_all_occurrences_of_variable() {
     CqlSession session = sessionRule.session();
     PreparedStatement ps = session.prepare("INSERT INTO test3 (pk1, pk2, v) VALUES (:i, :i, :i)");


### PR DESCRIPTION
Skip `should_set_all_occurrences_of_variable()` test of `BoundStatementCcmIT` due to scylladb/scylla#10956. It was decided that Scylla will have different behavior compared to Cassandra when there are multiple uses of the same named variable - only a single copy of that value will be sent by the driver and the driver will receive a single "slot" for that value.