### PR TITLE
docs: update theme 1.3

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -33,6 +33,8 @@ jobs:
           java-version: 1.8
       - name: Set up env
         run: make -C docs setupenv
+      - name: Build redirects
+        run: make -C docs redirects
       - name: Build docs
         run: make -C docs multiversion
       - name: Deploy docs to GitHub Pages

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -95,6 +95,12 @@ preview: setup
 multiversionpreview: multiversion
 	$(POETRY) run python -m http.server 5500 --directory $(BUILDDIR)/dirhtml
 
+.PHONY: redirects
+redirects: setup
+	$(POETRY) run redirects-cli fromfile --yaml-file _utils/redirects.yaml --output-dir $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
 # Test commands
 .PHONY: test
 test: setup

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,9 +18,6 @@ ifeq ($(OS),Windows_NT)
     POETRY = $(APPDATA)\Python\Scripts\poetry
 endif
 
-define javadoc
-    cd .. && ./docs/_utils/javadoc.sh
-endef
 
 .PHONY: all
 all: dirhtml
@@ -56,7 +53,7 @@ dirhtml: setup
 
 .PHONY: javadoc
 javadoc: setup
-	@$(javadoc)
+	cd .. && ./docs/_utils/javadoc.sh
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,17 +50,15 @@ clean:
 # Generate output commands
 .PHONY: dirhtml
 dirhtml: setup
-	@$(javadoc)
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-.PHONY: singlehtml
-singlehtml: setup
+.PHONY: javadoc
+javadoc: setup
 	@$(javadoc)
-	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: multiversion
 multiversion: setup

--- a/docs/_utils/multiversion.sh
+++ b/docs/_utils/multiversion.sh
@@ -1,5 +1,5 @@
 #! /bin/bash	
 
 cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
-    --pre-build './docs/_utils/javadoc.sh' \
-    --pre-build "find . -mindepth 2 -name README.md -execdir mv '{}' index.md ';'"
+    --pre-build "find . -mindepth 2 -name README.md -execdir mv '{}' index.md ';'" \
+    --post-build './docs/_utils/javadoc.sh'

--- a/docs/_utils/redirections.yaml
+++ b/docs/_utils/redirections.yaml
@@ -1,1 +1,0 @@
-api: /api/overview-summary.html

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,11 +9,12 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.2.0"
 recommonmark = "0.7.1"
-sphinx-scylladb-theme = "~1.2.1"
+redirects_cli ="~0.1.2"
+sphinx-scylladb-theme = "~1.3.1"
 sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
-sphinx-multiversion-scylla = "~0.2.11"
+sphinx-multiversion-scylla = "~0.2.12"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,12 +9,14 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.2.0"
 recommonmark = "0.7.1"
-redirects_cli ="~0.1.2"
+redirects_cli ="~0.1.3"
 sphinx-scylladb-theme = "~1.3.1"
 sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.12"
+setuptools = "^65.6.3"
+wheel = "^0.38.4"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ LATEST_VERSION = 'scylla-4.13.0.x'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = []
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ['']
+DEPRECATED_VERSIONS = []
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -115,11 +115,6 @@ notfound_template =  '404.html'
 
 # Prefix added to all the URLs generated in the 404 page.
 notfound_urls_prefix = ''
-
-# -- Options for redirect extension ---------------------------------------
-
-# Read a YAML dictionary of redirections and generate an HTML file for each
-redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion extension ----------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@ from docutils import nodes
 from recommonmark.transform import AutoStructify
 from recommonmark.parser import CommonMarkParser, splitext, urlparse
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
-
+from redirects_cli import cli as redirects_cli
 
 # -- General configuration ------------------------------------------------
 
@@ -43,51 +43,6 @@ source_suffix = {
     '.md': 'markdown',
 }
 autosectionlabel_prefix_document = True
-
-class CustomCommonMarkParser(CommonMarkParser):
-    
-    def visit_document(self, node):
-        pass
-    
-    def visit_link(self, mdnode):
-        # Override to avoid checking if relative links exists
-        ref_node = nodes.reference()
-        destination = mdnode.destination
-        _, ext = splitext(destination)
-
-        url_check = urlparse(destination)
-        scheme_known = bool(url_check.scheme)
-
-        if not scheme_known and ext.replace('.', '') in self.supported:
-            destination = destination.replace(ext, '')
-        ref_node['refuri'] = destination
-        ref_node.line = self._get_line(mdnode)
-        if mdnode.title:
-            ref_node['title'] = mdnode.title
-        next_node = ref_node
-
-        self.current_node.append(next_node)
-        self.current_node = ref_node
-
-def replace_relative_links(app, docname, source):
-    result = source[0]
-    for key in app.config.replacements:
-        result = re.sub(key, app.config.replacements[key], result)
-    source[0] = result
-
-def setup(app):
-    app.add_source_parser(CustomCommonMarkParser)
-    app.add_config_value('recommonmark_config', {
-        'enable_eval_rst': True,
-        'enable_auto_toc_tree': False,
-    }, True)
-    app.add_transform(AutoStructify)
-
-    # Replace DataStax links
-    current_slug = os.getenv("SPHINX_MULTIVERSION_NAME", "stable")
-    replacements = {r'docs.datastax.com/en/drivers/java\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/api/"}
-    app.add_config_value('replacements', replacements, True)
-    app.connect('source-read', replace_relative_links)
 
 # The master toctree document.
 master_doc = 'contents'
@@ -177,3 +132,61 @@ html_baseurl = 'https://java-driver.docs.scylladb.com'
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {'html_baseurl': html_baseurl}
+
+# -- Initialize Sphinx ----------------------------------------------
+
+class CustomCommonMarkParser(CommonMarkParser):
+    
+    def visit_document(self, node):
+        pass
+    
+    def visit_link(self, mdnode):
+        # Override MarkDownParser to avoid checking if relative links exists
+        ref_node = nodes.reference()
+        destination = mdnode.destination
+        _, ext = splitext(destination)
+
+        url_check = urlparse(destination)
+        scheme_known = bool(url_check.scheme)
+
+        if not scheme_known and ext.replace('.', '') in self.supported:
+            destination = destination.replace(ext, '')
+        ref_node['refuri'] = destination
+        ref_node.line = self._get_line(mdnode)
+        if mdnode.title:
+            ref_node['title'] = mdnode.title
+        next_node = ref_node
+
+        self.current_node.append(next_node)
+        self.current_node = ref_node
+
+def replace_relative_links(app, docname, source):
+    result = source[0]
+    for key in app.config.replacements:
+        result = re.sub(key, app.config.replacements[key], result)
+    source[0] = result
+
+def build_finished(app, exception):
+    version_name = os.getenv("SPHINX_MULTIVERSION_NAME", "")
+    version_name = "/" + version_name if version_name else ""
+    redirect_to = version_name +'/api/index.html'
+    out_file = app.outdir +'/api.html'
+    redirects_cli.create(redirect_to=redirect_to,out_file=out_file)
+
+def setup(app):
+    # Setup Markdown parser
+    app.add_source_parser(CustomCommonMarkParser)
+    app.add_config_value('recommonmark_config', {
+        'enable_eval_rst': True,
+        'enable_auto_toc_tree': False,
+    }, True)
+    app.add_transform(AutoStructify)
+
+    # Replace DataStax links
+    current_slug = os.getenv("SPHINX_MULTIVERSION_NAME", "stable")
+    replacements = {r'docs.datastax.com/en/drivers/java\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/api/"}
+    app.add_config_value('replacements', replacements, True)
+    app.connect('source-read', replace_relative_links)
+
+    # Create redirect to JavaDoc API
+    app.connect('build-finished', build_finished)


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/548

ScyllaDB Sphinx Theme 1.3 is now released 🥳 

We’ve added better redirects support and introduced numerous UI updates.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/stable/upgrade/CHANGELOG.html#aug-2022).


## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

4. Open http://http://localhost:3000 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.3.x``:

![image](https://user-images.githubusercontent.com/9107969/185590281-c79c5278-36d1-4bca-8197-e94824be1759.png)
