### PR TITLE
Bump animal-sniffer-maven-plugin to version 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -697,7 +697,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.15</version>
+                    <version>1.18</version>
                     <executions>
                         <execution>
                             <id>check-jdk6</id>


### PR DESCRIPTION
When implementing new changes animal sniffer sometimes fails without giving clear reason why.
Upgrading the version seems to solve most of those problems. I've chosen 1.18 because versions from 1.19 to 1.22 produce following false positives:
```
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodec.java: Undefined reference: java.util.function.Predicate
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateCodec.java: Undefined reference: java.time.LocalDate
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
[ERROR] /home/wo/Documents/gites/java-driver/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java: Undefined reference: java.time.format.DateTimeFormatter
```
```
[ERROR] Failed to execute goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.22:check (check-jdk6) on project scylla-driver-extras: Signature errors found. Verify them and ignore them with the proper annotation if needed. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.22:check (check-jdk6) on project scylla-driver-extras: Signature errors found. Verify them and ignore them with the proper annotation if needed.
```
Those classes are correctly annotated with `@IgnoreJDK6Requirement`. I haven't been able to figure out if the issue lies with the plugin or driver's configuration, but I believe upgrading to 1.18 for now would help with moving other things forward.