### PR TITLE
Fix fetching version numbers in CI

### DIFF
--- a/ci/version_fetch.py
+++ b/ci/version_fetch.py
@@ -162,6 +162,7 @@ def fetch_all_scylla_enterprise_rc_versions():
     stable_tags_data = map(lambda e: SCYLLA_ENTERPRISE_RELEASED_VERSION_REGEX.match(
         e).groups(), stable_tags_data)
     stable_tags_data = map(lambda e: tuple(map(int, e[0:2])), stable_tags_data)
+    stable_tags_data = set(stable_tags_data)
 
     # Group by (major, minor) and select latest RC version
     rc_tags_data = sorted(rc_tags_data)

--- a/ci/version_fetch.py
+++ b/ci/version_fetch.py
@@ -25,11 +25,12 @@ DOCKER_HUB_SCYLLA_NAMESPACE = 'scylladb'
 
 SCYLLA_OSS = (DOCKER_HUB_SCYLLA_NAMESPACE, 'scylla')
 SCYLLA_OSS_RELEASED_VERSION_REGEX = re.compile(r'(\d+)\.(\d+)\.(\d+)')
-SCYLLA_OSS_RC_VERSION_REGEX = re.compile(r'(\d+)\.(\d+)\.rc(\d+)')
+SCYLLA_OSS_RC_VERSION_REGEX = re.compile(r'(\d+)\.(\d+)\.(?:0-)?rc(\d+)')
 
 SCYLLA_ENTERPRISE = (DOCKER_HUB_SCYLLA_NAMESPACE, 'scylla-enterprise')
 SCYLLA_ENTERPRISE_RELEASED_VERSION_REGEX = re.compile(r'(\d{4})\.(\d+)\.(\d+)')
-SCYLLA_ENTERPRISE_RC_VERSION_REGEX = re.compile(r'(\d{4})\.(\d+)\.rc(\d+)')
+SCYLLA_ENTERPRISE_RC_VERSION_REGEX = re.compile(
+    r'(\d{4})\.(\d+)\.(?:0-)?rc(\d+)')
 
 CASSANDRA_ENDPOINT = 'https://dlcdn.apache.org/cassandra/'
 
@@ -87,7 +88,7 @@ def fetch_all_scylla_oss_rc_versions():
     # Download Docker tags for repository
     tags_data = fetch_docker_hub_tags(*SCYLLA_OSS)
 
-    # Parse only those tags which match 'NUM.NUM.rcNUM'
+    # Parse only those tags which match 'NUM.NUM.rcNUM' or 'NUM.NUM.0-rcNUM'
     # into tuple (NUM, NUM, NUM)
     rc_tags_data = filter(SCYLLA_OSS_RC_VERSION_REGEX.fullmatch, tags_data)
     rc_tags_data = map(lambda e: SCYLLA_OSS_RC_VERSION_REGEX.match(
@@ -112,7 +113,9 @@ def fetch_all_scylla_oss_rc_versions():
     # Filter out those RCs that are obsoleted by released stable version
     rc_tags_data = filter(lambda e: (
         e[0], e[1]) not in stable_tags_data, rc_tags_data)
-    rc_tags_data = [f'{e[0]}.{e[1]}.rc{e[2]}' for e in rc_tags_data]
+    rc_tags_data = [
+        f'{e[0]}.{e[1]}.0-rc{e[2]}' if (e[0], e[1]) >= (5, 1) else
+        f'{e[0]}.{e[1]}.rc{e[2]}' for e in rc_tags_data]
     return rc_tags_data
 
 
@@ -144,7 +147,7 @@ def fetch_all_scylla_enterprise_rc_versions():
     # Download Docker tags for repository
     tags_data = fetch_docker_hub_tags(*SCYLLA_ENTERPRISE)
 
-    # Parse only those tags which match 'YEAR.NUM.rcNUM'
+    # Parse only those tags which match 'YEAR.NUM.rcNUM' or 'YEAR.NUM.0-rcNUM'
     # into tuple (YEAR, NUM, NUM)
     rc_tags_data = filter(
         SCYLLA_ENTERPRISE_RC_VERSION_REGEX.fullmatch, tags_data)
@@ -169,7 +172,8 @@ def fetch_all_scylla_enterprise_rc_versions():
     # Filter out those RCs that are obsoleted by released stable version
     rc_tags_data = filter(lambda e: (
         e[0], e[1]) not in stable_tags_data, rc_tags_data)
-    rc_tags_data = [f'{e[0]}.{e[1]}.rc{e[2]}' for e in rc_tags_data]
+    rc_tags_data = [f'{e[0]}.{e[1]}.0-rc{e[2]}' if (e[0], e[1]) >=
+                    (2022, 2) else f'{e[0]}.{e[1]}.rc{e[2]}' for e in rc_tags_data]
     return rc_tags_data
 
 


### PR DESCRIPTION
This PR fixes two issues with fetching version numbers of Scylla in CI.

The first issue was that new semver version numbers of RC releases were not recognized. After scylladb/scylla-machine-image#359 was merged, naming of RC versions of Scylla was changed from X.Y.rcZ to X.Y.0-rcZ. version_fetch.py script did not detect those versions.

The second issue was a copy-paste error from fetch_all_scylla_oss_rc_versions(). Before the change, stable_tags_data was an iterator, but it could be read multiple times. In such a case, the second time it would return an empty result. Fix the problem by constructing a set.