### PR TITLE
Several minor Maven fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -855,58 +855,6 @@
                     </configuration>
                 </plugin>
 
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-jar-plugin</artifactId>
-                                        <versionRange>[2.2,)</versionRange>
-                                        <goals>
-                                            <goal>test-jar</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>clirr-maven-plugin</artifactId>
-                                        <versionRange>[2.7,)</versionRange>
-                                        <goals>
-                                            <goal>check</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.codehaus.gmaven</groupId>
-                                        <artifactId>gmaven-plugin</artifactId>
-                                        <versionRange>[1.5,)</versionRange>
-                                        <goals>
-                                            <goal>testCompile</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-
             </plugins>
 
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,27 @@
                 <artifactId>clirr-maven-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.2.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
 
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,6 @@
 
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <!-- do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-1302 is fixed -->
                     <version>3.0.0-M6</version>
                     <configuration>
                         <groups>${test.groups}</groups>


### PR DESCRIPTION
1. Remove outdated comment about Surefire version - the comment warned about updating the version of Surefire until a Surefire bug was fixed, but it was fixed back in 2017.
2. Specify minimum Maven version, in order to silence a warning.
3. Remove org.eclipse.m2e:lifecycle-mapping plugin. This plugin was only used for Eclipse IDE - we don't use that IDE. Moreover, inclusion of this plugin caused build warnings (Maven could not find that package in Maven Central Repository). 