### PR TITLE
Fix should_unset_flag_on_failed_agreement flakiness

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -68,7 +68,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
   static final Logger logger = LoggerFactory.getLogger(ControlConnectionTest.class);
 
   @Test(groups = "short")
-  @CCMConfig(numberOfNodes = 2)
+  @CCMConfig(numberOfNodes = 2, dirtiesContext = true)
   public void should_prevent_simultaneous_reconnection_attempts() throws InterruptedException {
 
     // Custom load balancing policy that counts the number of calls to newQueryPlan().

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -47,7 +47,7 @@ public class SchemaAgreementTest extends CCMTestsSupport {
     assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
   }
 
-  @Test(groups = "short", priority = 1)
+  @Test(groups = "short")
   public void should_unset_flag_on_failed_agreement() {
     // Setting to 0 results in no query being set, so agreement fails
     ProtocolOptions protocolOptions = cluster().getConfiguration().getProtocolOptions();

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -54,6 +54,13 @@ public class SchemaAgreementTest extends CCMTestsSupport {
     protocolOptions.maxSchemaAgreementWaitSeconds = 0;
     ResultSet rs = session().execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
     assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isFalse();
+
+    // Execute a dummy query, that will wait for schema agreement,
+    // so that the next tests that run afterwards have a clean state.
+    protocolOptions = cluster().getConfiguration().getProtocolOptions();
+    protocolOptions.maxSchemaAgreementWaitSeconds = 10;
+    rs = session().execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
+    assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
   }
 
   @Test(groups = "short")


### PR DESCRIPTION
This PR aims to fix flakiness of `should_unset_flag_on_failed_agreement` test (as seen in #170).

Firstly, during investigation of the issue, it was discovered that an unrelated test had missing `dirtiesContext = true` configuration in `@CCMConfig` of `ControlConnectionTest.should_prevent_simultaneous_reconnection_attempts`. That test stops cluster nodes: `ccm().stop(1)`, so it requires `dirtiesContext = true`. Even though the test class itself had this option correctly set, the test method annotation overwrote this configuration. Depending on the order of tests, this could cause another test to fail, as all of the nodes of cluster were removed.

Next, a d962bf603682ed0e8b8defc01f2a99643b79320b commit was reverted. That commit tried to deal with the fact, that  `should_unset_flag_on_failed_agreement` would leave the schema in  disagreement. If another test ran after that one, it would start with schema in disagreement. 

The previous solution was to set `priority=1`, so that this test would run after other tests. The problem with that solution is that all other tests from SchemaAgreementTests would run at one moment, then some unrelated tests would run and finally `should_unset_flag_on_failed_agreement` would run. Those unrelated tests could screw up the execution of `should_unset_flag_on_failed_agreement`, as seen in #170.

The final commit fixes that problem by running a dummy query with long schema agreement timeout, so that after this test runs, the schema is in agreement and the state of affairs is clean and `priority=1` fix is no longer needed.

Fixes #170