### PR TITLE
Add support for USING TIMEOUT to QueryBuilder

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.RegularStatement;
-import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -619,6 +616,33 @@ public final class QueryBuilder {
    */
   public static Using ttl(BindMarker marker) {
     return new Using.WithMarker("TTL", marker);
+  }
+
+  /**
+   * Adds a {@code USING TIMEOUT} clause to this statement with a {@link Duration} value.
+   *
+   * <p>If this method or {@link #timeout(BindMarker) } is called multiple times, the value from the
+   * last invocation is used.
+   *
+   * @param timeout A timeout value controlling server-side query timeout.
+   */
+  public static Using timeout(Duration timeout) {
+    if (timeout == null) throw new IllegalArgumentException("Invalid timeout, should not be null");
+
+    return new Using.WithObject("TIMEOUT", timeout.toString());
+  }
+
+  /**
+   * Adds a {@code USING TIMEOUT} clause to this statement with a bind marker.
+   *
+   * <p>If this method or {@link #timeout(Duration) } is called multiple times, the value from the
+   * last invocation is used.
+   *
+   * @param marker A bind marker understood as {@link Duration} controlling server-side query
+   *     timeout.
+   */
+  public static Using timeout(BindMarker marker) {
+    return new Using.WithMarker("TIMEOUT", marker);
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
@@ -63,4 +63,23 @@ public abstract class Using extends Utils.Appendeable {
       return true;
     }
   }
+
+  static class WithObject extends Using {
+    private final Object object;
+
+    WithObject(String optionName, Object object) {
+      super(optionName);
+      this.object = object;
+    }
+
+    @Override
+    void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
+      sb.append(optionName).append(' ').append(object);
+    }
+
+    @Override
+    boolean containsBindMarker() {
+      return false;
+    }
+  }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -15,67 +15,13 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.add;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.addAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.alias;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.append;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.appendAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.asc;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.batch;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.cast;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.column;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.contains;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.containsKey;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.decr;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.desc;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.discard;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.discardAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.fcall;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.fromJson;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.gt;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.in;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.incr;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.like;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.lt;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.lte;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.ne;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.notNull;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.path;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.prepend;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.prependAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.put;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.putAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.quote;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.raw;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.remove;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.removeAll;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.setIdx;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.timestamp;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.toJson;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.token;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.truncate;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.RegularStatement;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.CodecNotFoundException;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
@@ -262,6 +208,10 @@ public class QueryBuilderTest {
 
     query = "SELECT * FROM foo WHERE k IS NOT NULL;";
     select = select().from("foo").where(notNull("k"));
+    assertEquals(select.toString(), query);
+
+    query = "SELECT * FROM foo WHERE k IS NOT NULL USING TIMEOUT 50ms;";
+    select = select().from("foo").where(notNull("k")).using(timeout(Duration.from("50ms")));
     assertEquals(select.toString(), query);
 
     try {


### PR DESCRIPTION
Add support for adding USING TIMEOUT clause to SELECT statements. The value of the clause (the timeout) can be passed either as a literal value (Duration) or as a BindMarker filled at the time of execution.