### PR TITLE
Add support for BYPASS CACHE to QueryBuilder

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -43,6 +43,7 @@ public class Select extends BuiltStatement {
   private Object limit;
   private Object perPartitionLimit;
   private boolean allowFiltering;
+  private boolean bypassCache;
 
   Select(
       String keyspace, String table, List<Object> columnNames, boolean isDistinct, boolean isJson) {
@@ -121,6 +122,10 @@ public class Select extends BuiltStatement {
 
     if (allowFiltering) {
       builder.append(" ALLOW FILTERING");
+    }
+
+    if (bypassCache) {
+      builder.append(" BYPASS CACHE");
     }
 
     return builder;
@@ -283,6 +288,16 @@ public class Select extends BuiltStatement {
     return this;
   }
 
+  /**
+   * Adds on {@code BYPASS CACHE} clause to this statement.
+   *
+   * @return this statement.
+   */
+  public Select bypassCache() {
+    bypassCache = true;
+    return this;
+  }
+
   /** The {@code WHERE} clause of a {@code SELECT} statement. */
   public static class Where extends BuiltStatement.ForwardingStatement<Select> {
 
@@ -397,6 +412,16 @@ public class Select extends BuiltStatement {
      */
     public Select allowFiltering() {
       return statement.allowFiltering();
+    }
+
+    /**
+     * Adds an {@code BYPASS CACHE} clause to the {@code SELECT} statement this {@code WHERE} clause
+     * is part of.
+     *
+     * @return the {@code SELECT} statement this {@code WHERE} clause is part of.
+     */
+    public Select bypassCache() {
+      return statement.bypassCache();
     }
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -1686,4 +1686,14 @@ public class QueryBuilderTest {
     assertThat(select().all().from("foo").where(eq("x", 42)).allowFiltering().toString())
         .isEqualTo("SELECT * FROM foo WHERE x=42 ALLOW FILTERING;");
   }
+
+  /** @test_category queries:builder */
+  @Test(groups = "unit")
+  public void should_handle_bypass_cache() {
+    assertThat(select().all().from("foo").allowFiltering().bypassCache().toString())
+        .isEqualTo("SELECT * FROM foo ALLOW FILTERING BYPASS CACHE;");
+    assertThat(
+            select().all().from("foo").where(eq("x", 42)).allowFiltering().bypassCache().toString())
+        .isEqualTo("SELECT * FROM foo WHERE x=42 ALLOW FILTERING BYPASS CACHE;");
+  }
 }


### PR DESCRIPTION
Add support for adding BYPASS CACHE clause to the SELECT statements.