### PR TITLE
Fix typo in workflow configuration

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -160,7 +160,7 @@ jobs:
         if: ${{ failure() }}
         with:
           name: ccm-logs-cassandra-${{ matrix.cassandra-version }}
-          path: /tmp/*-0/ccm*/node*/logs/*
+          path: /tmp/ccm*/ccm*/node*/logs/*
 
   scylla-integration-tests:
     name: Scylla ITs


### PR DESCRIPTION
Currently CCM logs are not being uploaded due to a typo in directory pattern. 
This should take care of that.