### PR TITLE
Add setup Python 2 step to scylla-integration-tests in GH actions

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -183,6 +183,11 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
 
+      - name: Setup Python 2
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.x'
+
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
New test using SNI proxy functionality that is about to be added requires ccm to use cqlsh queries to setup cluster properly. However without Python 2 set up cqlsh returns with '(EE) No appropriate python interpreter found.'.

With this setup `python --version` should return 3.x because of the ordering. `python2 --version` and `python3 --version` will return their versions respectively.