### PR TITLE
Fix flakiness in ScyllaSniProxyTest

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.datastax.driver.core.utils.ScyllaOnly;
+import java.util.ArrayList;
 import java.util.Collection;
 import org.testng.annotations.Test;
 
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 public class ScyllaSniProxyTest extends CCMTestsSupport {
 
   private void test_ccm_cluster(int testNodes) {
+    ccm().setKeepLogs(true);
     Cluster c = cluster().init();
     Session s = c.connect();
     TestUtils.waitForUp(TestUtils.ipOfNode(1), c);
@@ -35,14 +36,59 @@ public class ScyllaSniProxyTest extends CCMTestsSupport {
     ((SessionManager) s).cluster.manager.controlConnection.triggerReconnect();
 
     SchemaChangeListener listener = mock(SchemaChangeListenerBase.class);
+    final ArrayList<String> keyspaceMismatches = new ArrayList<String>();
+    final ArrayList<String> tableMismatches = new ArrayList<String>();
+
+    SchemaChangeListener assertingListener =
+        new SchemaChangeListenerBase() {
+          @Override
+          public void onKeyspaceAdded(KeyspaceMetadata keyspace) {
+            if (!keyspace.getName().equals("testks")) {
+              keyspaceMismatches.add(keyspace.getName());
+            }
+          }
+
+          @Override
+          public void onTableAdded(TableMetadata table) {
+            if (!table.getName().equals("testtab")) {
+              tableMismatches.add(table.getName());
+            }
+          }
+        };
+
     c.register(listener);
+    c.register(assertingListener);
 
     s.execute(String.format(TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT, "testks", testNodes));
     s.execute("CREATE TABLE testks.testtab (a int PRIMARY KEY, b int);");
 
-    verify(listener, times(1)).onTableAdded(any(TableMetadata.class));
+    // Sometimes (probably due to reconnection) both events can be read twice
+    // assertingListener ensures we deal with the same keyspace and table
+    verify(listener, atLeast(1)).onTableAdded(any(TableMetadata.class));
+    verify(listener, atMost(2)).onTableAdded(any(TableMetadata.class));
     verify(listener, atLeast(1)).onKeyspaceAdded(any(KeyspaceMetadata.class));
     verify(listener, atMost(2)).onKeyspaceAdded(any(KeyspaceMetadata.class));
+
+    if (!keyspaceMismatches.isEmpty()) {
+      StringBuilder ksNames = new StringBuilder();
+      for (String str : keyspaceMismatches) {
+        ksNames.append(", " + ksNames + str);
+      }
+      throw new RuntimeException(
+          "assertingListener registered keyspace added event with keyspaces named: ["
+              + ksNames.substring(2)
+              + "] which is not \"testks\"");
+    }
+    if (!tableMismatches.isEmpty()) {
+      StringBuilder tabNames = new StringBuilder();
+      for (String str : tableMismatches) {
+        tabNames.append(", " + tabNames + str);
+      }
+      throw new RuntimeException(
+          "assertingListener registered table added event with tables named: ["
+              + tabNames.substring(2)
+              + "] which is not \"testtab\"");
+    }
 
     s.close();
     c.close();


### PR DESCRIPTION
Sometimes listener gets notified twice, causing
assertion checking for exactly 1 call to fail.
Now we permit at most 2 calls, but both have to refer to correct keyspace and table names.