### PR TITLE
Add TestRule for preserving logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,10 @@ If you use CCM, it **must** be with `CcmRule`.
 For an example of a Simulacron-based parallelizable test, see `NodeTargetingIT`. For a CCM-based
 test, see `DirectCompressionIT`.
 
+Currently `CcmRule` based tests will not preserve CCM config directory upon failure. To have CCM
+logs available in case of failure during automated testing combine it with `PreserveLogsRule` so
+that logs can be uploaded.
+
 ##### Serial tests
 
 These tests cannot run in parallel, in general because they require CCM clusters of different sizes,

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectKeyspaceIT.java
@@ -24,10 +24,12 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.PreserveLogsRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -41,6 +43,8 @@ public class ConnectKeyspaceIT {
 
   @ClassRule
   public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  @Rule public PreserveLogsRule LOGS_RULE = new PreserveLogsRule(CCM_RULE.getCcmBridge());
 
   @Test
   public void should_connect_to_existing_keyspace() {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -42,7 +42,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
             new Thread(
                 () -> {
                   try {
-                    ccmBridge.remove();
+                    ccmBridge.removeOrStop();
                   } catch (Exception e) {
                     // silently remove as may have already been removed.
                   }
@@ -57,7 +57,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
 
   @Override
   protected void after() {
-    ccmBridge.remove();
+    ccmBridge.removeOrStop();
   }
 
   private Statement buildErrorStatement(
@@ -231,5 +231,9 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     } else {
       return DefaultProtocolVersion.V3;
     }
+  }
+
+  public CcmBridge getCcmBridge() {
+    return ccmBridge;
   }
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -179,6 +179,8 @@ public class CcmBridge implements AutoCloseable {
   private final List<String> dseWorkloads;
   private final String jvmArgs;
 
+  private boolean keepLogs = false;
+
   private CcmBridge(
       Path configDirectory,
       int[] nodes,
@@ -378,6 +380,14 @@ public class CcmBridge implements AutoCloseable {
     execute("remove");
   }
 
+  public void removeOrStop() {
+    if (keepLogs) {
+      stop();
+    } else {
+      remove();
+    }
+  }
+
   public void pause(int n) {
     execute("node" + n, "pause");
   }
@@ -471,7 +481,11 @@ public class CcmBridge implements AutoCloseable {
 
   @Override
   public void close() {
-    remove();
+    removeOrStop();
+  }
+
+  public void setKeepLogs(boolean keepLogs) {
+    this.keepLogs = keepLogs;
   }
 
   /**

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
@@ -50,10 +50,6 @@ public class CustomCcmRule extends BaseCcmRule {
     CURRENT.compareAndSet(this, null);
   }
 
-  public CcmBridge getCcmBridge() {
-    return ccmBridge;
-  }
-
   public static Builder builder() {
     return new Builder();
   }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/PreserveLogsRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/PreserveLogsRule.java
@@ -1,0 +1,17 @@
+package com.datastax.oss.driver.api.testinfra.ccm;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class PreserveLogsRule extends TestWatcher {
+  private final CcmBridge ccmBridge;
+
+  public PreserveLogsRule(CcmBridge ccmBridge) {
+    this.ccmBridge = ccmBridge;
+  }
+
+  @Override
+  protected void failed(Throwable e, Description description) {
+    ccmBridge.setKeepLogs(true);
+  }
+}


### PR DESCRIPTION
This TestRule can be combined with other CCM Rules to prevent them from deleting logs of failed tests during cleanup.