### PR TITLE
Add InflightRequest load balancing policy

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/InFlightRequestPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/InFlightRequestPolicy.java
@@ -1,0 +1,190 @@
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.*;
+import com.google.common.collect.AbstractIterator;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InFlightRequestPolicy implements LoadBalancingPolicy {
+  private volatile Metrics metrics;
+  private volatile Metadata clusterMetadata;
+  private volatile ProtocolVersion protocolVersion;
+  private volatile CodecRegistry codecRegistry;
+  private final CopyOnWriteArrayList<Host> liveHosts = new CopyOnWriteArrayList<Host>();
+  private final AtomicInteger liveHostsIndex = new AtomicInteger();
+  private final AtomicInteger replicasStartIndex = new AtomicInteger();
+
+  /** Creates a new {@code InflightRequest} policy. */
+  public InFlightRequestPolicy() {}
+
+  @Override
+  public void init(Cluster cluster, Collection<Host> hosts) {
+    this.metrics = cluster.getMetrics();
+    this.clusterMetadata = cluster.getMetadata();
+    this.protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+    this.codecRegistry = cluster.getConfiguration().getCodecRegistry();
+    this.liveHosts.addAll(hosts);
+    this.liveHostsIndex.set(new Random().nextInt(Math.max(hosts.size(), 1)));
+  }
+
+  /**
+   * Return the HostDistance for the provided host.
+   *
+   * <p>This policy consider all nodes as local. TODO: make it a DC aware policy
+   *
+   * @param host the host of which to return the distance of.
+   * @return the HostDistance to {@code host}.
+   */
+  @Override
+  public HostDistance distance(Host host) {
+    return HostDistance.LOCAL;
+  }
+
+  private Iterator<Host> getRoundRobinIteratorOnLiveHosts() {
+    @SuppressWarnings("unchecked")
+    final List<Host> hosts = (List<Host>) liveHosts.clone();
+    final int startIndex = liveHostsIndex.getAndIncrement();
+
+    // Overflow protection; not theoretically thread safe but should be good enough
+    if (startIndex > Integer.MAX_VALUE - 10000) liveHostsIndex.set(0);
+
+    return new AbstractIterator<Host>() {
+      private int index = startIndex;
+      private int remainingSize = hosts.size();
+
+      @Override
+      protected Host computeNext() {
+        if (remainingSize <= 0) return endOfData();
+
+        // Round-robin policy
+        remainingSize--;
+        int c = index++ % hosts.size();
+        if (c < 0) c += hosts.size();
+        return hosts.get(c);
+      }
+    };
+  }
+
+  /**
+   * This policy considers inflight request metric for each node/shard for creating a query plan.
+   * The query plan will first return replicas with the target shard having the least amount of
+   * inflight requests. It will round-robin over the replicas with equal inflight requests. The
+   * policy considers two replicas to be equal if the target shards of both replicas have inflight
+   * requests that may differ by at most 32. If the set of replicas for {@linkplain Statement} is
+   * empty or the statement's {@linkplain Statement#getRoutingKey(ProtocolVersion, CodecRegistry)
+   * routing key} is {@code null} then the query plan will cycle over all live hosts of the cluster
+   * in a round-robin fashion.
+   *
+   * @param loggedKeyspace the currently logged keyspace (the one set through either {@link
+   *     Cluster#connect(String)} or by manually doing a {@code USE} query) for the session on which
+   *     this plan need to be built. This can be {@code null} if the corresponding session has no
+   *     keyspace logged in.
+   * @param statement the query for which to build a plan.
+   */
+  @Override
+  public Iterator<Host> newQueryPlan(String loggedKeyspace, final Statement statement) {
+    String keyspace = statement.getKeyspace();
+    if (keyspace == null) keyspace = loggedKeyspace;
+
+    ByteBuffer routingKey = statement.getRoutingKey(protocolVersion, codecRegistry);
+
+    if (routingKey == null || keyspace == null) {
+      return getRoundRobinIteratorOnLiveHosts();
+    }
+
+    final Set<Host> replicaSet =
+        clusterMetadata.getReplicas(
+            Metadata.quote(keyspace), statement.getPartitioner(), routingKey);
+
+    if (replicaSet.isEmpty()) {
+      return getRoundRobinIteratorOnLiveHosts();
+    }
+
+    final Host[] replicas = replicaSet.toArray(new Host[0]);
+
+    final Token t = this.clusterMetadata.newToken(statement.getPartitioner(), routingKey);
+    Arrays.sort(
+        replicas,
+        new Comparator<Host>() {
+          @Override
+          public int compare(Host host1, Host host2) {
+            int host1ShardId = host1.getShardingInfo().shardId(t);
+            int host2ShardId = host2.getShardingInfo().shardId(t);
+            int host1ShardInflightRequests =
+                metrics.getPerShardInflightRequestInfo().getValue().get(host1).get(host1ShardId);
+            int host2ShardInflightRequests =
+                metrics.getPerShardInflightRequestInfo().getValue().get(host2).get(host2ShardId);
+
+            return host1ShardInflightRequests - host2ShardInflightRequests;
+          }
+        });
+
+    final Host[] replicasWithEqualRequests = new Host[replicas.length];
+
+    int minInflightRequestReplicaShardId = replicas[0].getShardingInfo().shardId(t);
+    int minInflightRequests =
+        metrics
+            .getPerShardInflightRequestInfo()
+            .getValue()
+            .get(replicas[0])
+            .get(minInflightRequestReplicaShardId);
+    replicasWithEqualRequests[0] = replicas[0];
+    int replicasWithEqualRequestsSize = 1;
+    for (int i = 1; i < replicas.length; i++) {
+      int shardId = replicas[i].getShardingInfo().shardId(t);
+      int inflightRequests =
+          metrics.getPerShardInflightRequestInfo().getValue().get(replicas[i]).get(shardId);
+      if (Math.abs(minInflightRequests - inflightRequests) <= 32) {
+        replicasWithEqualRequests[i] = replicas[i];
+        replicasWithEqualRequestsSize++;
+      } else {
+        break;
+      }
+    }
+
+    this.replicasStartIndex.set(new Random().nextInt(replicasWithEqualRequestsSize));
+    final int finalReplicasSize = replicasWithEqualRequestsSize;
+
+    return new AbstractIterator<Host>() {
+      private int index = InFlightRequestPolicy.this.replicasStartIndex.get();
+      private int remainingSize = finalReplicasSize;
+
+      @Override
+      protected Host computeNext() {
+        if (remainingSize <= 0) return endOfData();
+
+        remainingSize--;
+        int c = index++ % finalReplicasSize;
+        if (c < 0) c += finalReplicasSize;
+        return replicasWithEqualRequests[c];
+      }
+    };
+  }
+
+  @Override
+  public void onAdd(Host host) {
+    onUp(host);
+  }
+
+  @Override
+  public void onUp(Host host) {
+    this.liveHosts.addIfAbsent(host);
+  }
+
+  @Override
+  public void onDown(Host host) {
+    this.liveHosts.remove(host);
+  }
+
+  @Override
+  public void onRemove(Host host) {
+    onDown(host);
+  }
+
+  @Override
+  public void close() {
+    // Nothing to do
+  }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RandomTwoChoicePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RandomTwoChoicePolicy.java
@@ -1,0 +1,172 @@
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.*;
+import com.google.common.collect.AbstractIterator;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RandomTwoChoicePolicy implements LoadBalancingPolicy {
+  private volatile Metrics metrics;
+  private volatile Metadata clusterMetadata;
+  private volatile ProtocolVersion protocolVersion;
+  private volatile CodecRegistry codecRegistry;
+  private final CopyOnWriteArrayList<Host> liveHosts = new CopyOnWriteArrayList<Host>();
+  private final AtomicInteger roundRobinIndex = new AtomicInteger();
+
+  public RandomTwoChoicePolicy() {}
+
+  @Override
+  public void init(Cluster cluster, Collection<Host> hosts) {
+    this.metrics = cluster.getMetrics();
+    this.clusterMetadata = cluster.getMetadata();
+    this.protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+    this.codecRegistry = cluster.getConfiguration().getCodecRegistry();
+    this.liveHosts.addAll(hosts);
+    this.roundRobinIndex.set(new Random().nextInt(Math.max(1, hosts.size())));
+  }
+
+  @Override
+  public HostDistance distance(Host host) {
+    return HostDistance.LOCAL;
+  }
+
+  private Iterator<Host> getRoundRobinIteratorOnLiveHosts() {
+    @SuppressWarnings("unchecked")
+    final List<Host> hosts = (List<Host>) liveHosts.clone();
+    final int startIndex = roundRobinIndex.getAndIncrement();
+
+    // Overflow protection; not theoretically thread safe but should be good enough
+    if (startIndex > Integer.MAX_VALUE - 10000) roundRobinIndex.set(0);
+
+    return new AbstractIterator<Host>() {
+      private int index = startIndex;
+      private int remainingSize = hosts.size();
+
+      @Override
+      protected Host computeNext() {
+        if (remainingSize <= 0) return endOfData();
+
+        // Round-robin policy
+        remainingSize--;
+        int c = index++ % hosts.size();
+        if (c < 0) c += hosts.size();
+        return hosts.get(c);
+      }
+    };
+  }
+
+  private void swap(Object[] elements, int i, int j) {
+    if (i != j) {
+      Object tmp = elements[i];
+      elements[i] = elements[j];
+      elements[j] = tmp;
+    }
+  }
+
+  private void bubbleUp(Object[] elements, int sourceIndex, int targetIndex) {
+    for (int i = sourceIndex; i > targetIndex; i--) {
+      swap(elements, i, i - 1);
+    }
+  }
+
+  private void shuffleFirstN(Object[] elements, int n) {
+    assert n <= elements.length;
+
+    if (n > 1) {
+      for (int i = n - 1; i > 0; i--) {
+        int j = new Random().nextInt(i + 1);
+        swap(elements, i, j);
+      }
+    }
+  }
+
+  @Override
+  public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+    String keyspace = statement.getKeyspace();
+    if (keyspace == null) keyspace = loggedKeyspace;
+
+    ByteBuffer routingKey = statement.getRoutingKey(protocolVersion, codecRegistry);
+
+    if (routingKey == null || keyspace == null) {
+      return getRoundRobinIteratorOnLiveHosts();
+    }
+
+    final Set<Host> replicaSet =
+        clusterMetadata.getReplicas(
+            Metadata.quote(keyspace), statement.getPartitioner(), routingKey);
+
+    if (replicaSet.isEmpty()) {
+      return getRoundRobinIteratorOnLiveHosts();
+    }
+
+    final Object[] currentNodes = this.liveHosts.toArray();
+    int replicaCount = 0;
+
+    // Move all replica nodes to the front of the array
+    for (int i = 0; i < currentNodes.length; i++) {
+      Host host = (Host) currentNodes[i];
+      if (replicaSet.contains(host)) {
+        bubbleUp(currentNodes, i, replicaCount);
+        replicaCount++;
+      }
+    }
+
+    // Shuffle only replica nodes
+    shuffleFirstN(currentNodes, replicaCount);
+
+    if (replicaCount >= 2) {
+      final Token t = this.clusterMetadata.newToken(statement.getPartitioner(), routingKey);
+      final Host host1 = (Host) currentNodes[0];
+      final Host host2 = (Host) currentNodes[1];
+      final int host1ShardId = host1.getShardingInfo().shardId(t);
+      final int host2ShardId = host2.getShardingInfo().shardId(t);
+      final int host1ShardInflightRequests =
+          this.metrics.getPerShardInflightRequestInfo().getValue().get(host1).get(host1ShardId);
+      final int host2ShardInflightRequests =
+          this.metrics.getPerShardInflightRequestInfo().getValue().get(host2).get(host2ShardId);
+
+      // First choose the host out of the first 2 hosts with the least inflight requests
+      if (host2ShardInflightRequests < host1ShardInflightRequests) {
+        swap(currentNodes, 0, 1);
+      }
+    }
+
+    return new AbstractIterator<Host>() {
+      private int index = 0;
+
+      @Override
+      protected Host computeNext() {
+        if (index >= currentNodes.length) return endOfData();
+
+        return (Host) currentNodes[index++];
+      }
+    };
+  }
+
+  @Override
+  public void onAdd(Host host) {
+    onUp(host);
+  }
+
+  @Override
+  public void onUp(Host host) {
+    this.liveHosts.addIfAbsent(host);
+  }
+
+  @Override
+  public void onDown(Host host) {
+    this.liveHosts.remove(host);
+  }
+
+  @Override
+  public void onRemove(Host host) {
+    onDown(host);
+  }
+
+  @Override
+  public void close() {
+    // Nothing to do
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/InflightRequestPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/InflightRequestPolicyTest.java
@@ -1,0 +1,178 @@
+package com.datastax.driver.core.policies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Gauge;
+import com.datastax.driver.core.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+import org.assertj.core.util.Sets;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class InflightRequestPolicyTest {
+  private final ByteBuffer routingKey = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+  private final RegularStatement statement =
+      new SimpleStatement("irrelevant").setRoutingKey(routingKey).setKeyspace("keyspace");
+  private final Host host1 = mock(Host.class);
+  private final Host host2 = mock(Host.class);
+  private final Host host3 = mock(Host.class);
+  private Cluster cluster;
+
+  @SuppressWarnings("unchecked")
+  private final Gauge<Map<Host, Map<Integer, Integer>>> gauge =
+      mock((Class<Gauge<Map<Host, Map<Integer, Integer>>>>) (Object) Gauge.class);
+
+  @BeforeMethod(groups = "unit")
+  public void initMocks() {
+    CodecRegistry codecRegistry = new CodecRegistry();
+    cluster = mock(Cluster.class);
+    Configuration configuration = mock(Configuration.class);
+    ProtocolOptions protocolOptions = mock(ProtocolOptions.class);
+    Metadata metadata = mock(Metadata.class);
+    Metrics metrics = mock(Metrics.class);
+    Token t = mock(Token.class);
+    ShardingInfo shardingInfo = mock(ShardingInfo.class);
+
+    when(metrics.getPerShardInflightRequestInfo()).thenReturn(gauge);
+    when(cluster.getConfiguration()).thenReturn(configuration);
+    when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
+    when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
+    when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.DEFAULT);
+    when(cluster.getMetadata()).thenReturn(metadata);
+    when(cluster.getMetrics()).thenReturn(metrics);
+    when(metadata.getReplicas(Metadata.quote("keyspace"), null, routingKey))
+        .thenReturn(Sets.newLinkedHashSet(host1, host2, host3));
+    when(metadata.newToken(null, routingKey)).thenReturn(t);
+    when(host1.getShardingInfo()).thenReturn(shardingInfo);
+    when(host2.getShardingInfo()).thenReturn(shardingInfo);
+    when(host3.getShardingInfo()).thenReturn(shardingInfo);
+    when(shardingInfo.shardId(t)).thenReturn(0);
+    when(shardingInfo.shardId(t)).thenReturn(0);
+    when(shardingInfo.shardId(t)).thenReturn(0);
+    when(host1.isUp()).thenReturn(true);
+    when(host2.isUp()).thenReturn(true);
+    when(host3.isUp()).thenReturn(true);
+  }
+
+  @Test(groups = "unit")
+  public void should_round_robin_over_all_hosts() {
+    // given
+    Map<Host, Map<Integer, Integer>> perHostInflightRequests =
+        new HashMap<Host, Map<Integer, Integer>>() {
+          {
+            put(
+                host1,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 6);
+                  }
+                });
+            put(
+                host2,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 2);
+                  }
+                });
+            put(
+                host3,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 4);
+                  }
+                });
+          }
+        };
+    InFlightRequestPolicy policy = new InFlightRequestPolicy();
+    policy.init(
+        cluster,
+        new ArrayList<Host>() {
+
+          {
+            add(host1);
+            add(host2);
+            add(host3);
+          }
+        });
+    when(gauge.getValue()).thenReturn(perHostInflightRequests);
+
+    Map<Host, Integer> hostReachedCount = new HashMap<Host, Integer>();
+    hostReachedCount.put(host1, 0);
+    hostReachedCount.put(host2, 0);
+    hostReachedCount.put(host3, 0);
+
+    // when
+    for (int i = 0; i < 10; i++) {
+      Iterator<Host> queryPlan = policy.newQueryPlan("keyspace", statement);
+      while (queryPlan.hasNext()) {
+        Host host = queryPlan.next();
+        hostReachedCount.put(host, hostReachedCount.get(host) + 1);
+      }
+    }
+    // then
+    assertThat(hostReachedCount.get(host1)).isEqualTo(10);
+    assertThat(hostReachedCount.get(host2)).isEqualTo(10);
+    assertThat(hostReachedCount.get(host3)).isEqualTo(10);
+  }
+
+  @Test(groups = "unit")
+  public void should_exclude_replicas_out_of_min_inflight_request_range() {
+    // given
+    Map<Host, Map<Integer, Integer>> perHostInflightRequests =
+        new HashMap<Host, Map<Integer, Integer>>() {
+          {
+            put(
+                host1,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 35);
+                  }
+                });
+            put(
+                host2,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 2);
+                  }
+                });
+            put(
+                host3,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 4);
+                  }
+                });
+          }
+        };
+    InFlightRequestPolicy policy = new InFlightRequestPolicy();
+    policy.init(
+        cluster,
+        new ArrayList<Host>() {
+          {
+            add(host1);
+            add(host2);
+            add(host3);
+          }
+        });
+
+    when(gauge.getValue()).thenReturn(perHostInflightRequests);
+
+    Set<Host> hostSet = new HashSet<Host>();
+    hostSet.add(host1);
+    hostSet.add(host2);
+    hostSet.add(host3);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan("keyspace", statement);
+    while (queryPlan.hasNext()) {
+      hostSet.remove(queryPlan.next());
+    }
+    // then
+    assertThat(!hostSet.contains(host1));
+    assertThat(!hostSet.contains(host2));
+    assertThat(hostSet.contains(host3));
+  }
+}


### PR DESCRIPTION
The new load balancing policy will consider inflight request metrics for each node/shard for creating a query plan. It will first return replicas with the target shard having the least amount of inflight requests. It will round robin over the replicas with equal inflight requests. The policy considers two replicas to be equal if the target shards of both replicas have inflight requests that may differ by at most 32.