### PR TITLE
Fix possible NullPointerException in Connection.shardId()

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1047,7 +1047,7 @@ class Connection {
   }
 
   public int shardId() {
-    return shardId == null || getHost().getShardingInfo() == null ? 0 : shardId;
+    return shardId == null ? 0 : shardId;
   }
 
   /**


### PR DESCRIPTION
There is no need to call getShardingInfo() because when shardId is set to null
 getShardingInfo() is also null.

Fixes https://github.com/scylladb/java-driver/issues/180.