### PR TITLE
Fix ConfigurationException in integration tests

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/Version.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/Version.java
@@ -50,6 +50,7 @@ public class Version implements Comparable<Version>, Serializable {
   @NonNull public static final Version V2_2_0 = Objects.requireNonNull(parse("2.2.0"));
   @NonNull public static final Version V3_0_0 = Objects.requireNonNull(parse("3.0.0"));
   @NonNull public static final Version V4_0_0 = Objects.requireNonNull(parse("4.0.0"));
+  @NonNull public static final Version V4_1_0 = Objects.requireNonNull(parse("4.1.0"));
   @NonNull public static final Version V5_0_0 = Objects.requireNonNull(parse("5.0.0"));
   @NonNull public static final Version V6_7_0 = Objects.requireNonNull(parse("6.7.0"));
   @NonNull public static final Version V6_8_0 = Objects.requireNonNull(parse("6.8.0"));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -60,7 +60,11 @@ public class SchemaChangesIT {
     CustomCcmRule.Builder builder = CustomCcmRule.builder();
     if (!CcmBridge.DSE_ENABLEMENT
         && CcmBridge.VERSION.nextStable().compareTo(Version.V4_0_0) >= 0) {
-      builder.withCassandraConfiguration("enable_materialized_views", true);
+      if (CcmBridge.VERSION.nextStable().compareTo(Version.V4_1_0) >= 0) {
+        builder.withCassandraConfiguration("materialized_views_enabled", true);
+      } else {
+        builder.withCassandraConfiguration("enable_materialized_views", true);
+      }
     }
     CCM_RULE = builder.build();
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -269,6 +269,19 @@ public class SchemaIT {
                   + "    total bigint,\n"
                   + "    unit text,\n"
                   + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
+                  + "); */",
+              // Cassandra 4.1
+              "/* VIRTUAL TABLE system_views.sstable_tasks (\n"
+                  + "    keyspace_name text,\n"
+                  + "    table_name text,\n"
+                  + "    task_id timeuuid,\n"
+                  + "    completion_ratio double,\n"
+                  + "    kind text,\n"
+                  + "    progress bigint,\n"
+                  + "    sstables int,\n"
+                  + "    total bigint,\n"
+                  + "    unit text,\n"
+                  + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
                   + "); */");
       // ColumnMetadata is as expected
       ColumnMetadata cm = tm.getColumn("progress").get();

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
@@ -30,8 +30,13 @@ public class DefaultCcmBridgeBuilderCustomizer {
   public static CcmBridge.Builder configureBuilder(CcmBridge.Builder builder) {
     if (!CcmBridge.DSE_ENABLEMENT
         && CcmBridge.VERSION.nextStable().compareTo(Version.V4_0_0) >= 0) {
-      builder.withCassandraConfiguration("enable_materialized_views", true);
-      builder.withCassandraConfiguration("enable_sasi_indexes", true);
+      if (CcmBridge.VERSION.nextStable().compareTo(Version.V4_1_0) >= 0) {
+        builder.withCassandraConfiguration("materialized_views_enabled", true);
+        builder.withCassandraConfiguration("sasi_indexes_enabled", true);
+      } else {
+        builder.withCassandraConfiguration("enable_materialized_views", true);
+        builder.withCassandraConfiguration("enable_sasi_indexes", true);
+      }
     }
     if (CcmBridge.VERSION.nextStable().compareTo(Version.V3_0_0) >= 0) {
       if (!CcmBridge.SCYLLA_ENABLEMENT) {


### PR DESCRIPTION
CASSANDRA-15234 introduced several changes to cassandra.yaml
This results in ConifugrationExceptions during ccm start.
As a workaround this change adds as jvmArg "-Dcassandra.allow_new_old_config_keys=true"
if the Cassandra version is at least 4.1.0 and this arg was not added yet.

Additionally any config key explicitly added by driver code has been
conditionally changed to new form depending on Cassandra version.

JvmArg "-Dcassandra.allow_duplicate_config_keys=false" has been added to
ensure that nothing gets implicitly overwritten with wrong value.