### PR TITLE
Add license notice

### DIFF
--- a/docs/source/_templates/notice.html
+++ b/docs/source/_templates/notice.html
@@ -1,0 +1,5 @@
+<div class="notice">
+    <p>ScyllaDB Java Driver is available under the <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache v2 License</a>.
+    ScyllaDB Java Driver is a fork of <a href="https://github.com/datastax/java-driver">DataStax Java Driver</a>.
+    See Copyright <a href="https://java-driver.docs.scylladb.com/stable/#license">here</a>.</p>
+</div>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,9 @@ extensions = [
     'sphinx_multiversion',
 ]
 
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #


### PR DESCRIPTION
Related issue: https://github.com/scylladb/sphinx-scylladb-theme/pull/611

## How to test this PR

1. Build the docs with `make preview`. 
1. Open http://127.0.0.1:5500
1. You should see the copyright notice after the prev / next navigation buttons on every page:

![image](https://user-images.githubusercontent.com/9107969/213773984-355a5549-6673-47aa-bbc7-7928cc8e7bda.png)

