### PR TITLE
Fix ChannelPoolInitTest NullPointerException

### DIFF
--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
@@ -177,8 +177,8 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     // A reconnection should have been scheduled
     verify(reconnectionSchedule, VERIFY_TIMEOUT).nextDelay();
     inOrder.verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.reconnectionStarted(node));
-    assertThat(pool.channels[0]).containsOnly(channel1);
     inOrder.verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node));
+    assertThat(pool.channels[0]).containsOnly(channel1);
 
     channel2Future.complete(channel2);
     factoryHelper.waitForCalls(node, 1);


### PR DESCRIPTION
It seems that there was a race condition where we try to inspect `ChannelSet` while it is still null and `initialized` property is still false. This small reordering ensures that `initialize()` method of `ChannelPool` has been already called, because channelOpened event already fired.