### PR TITLE
3.x: Add RandomTwoChoice load balancing policy

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RandomTwoChoicePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RandomTwoChoicePolicy.java
@@ -1,0 +1,157 @@
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.*;
+import com.google.common.collect.AbstractIterator;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A wrapper load balancing policy that adds "Power of 2 Choice" algorithm to a child policy.
+ *
+ * <p>This policy encapsulates another policy. The resulting policy works in the following way:
+ *
+ * <ul>
+ *   <li>the {@code distance} method is inherited from the child policy.
+ *   <li>the {@code newQueryPlan} method will compare first two hosts (by number of inflight
+ *       requests) returned from the {@code newQueryPlan} method of the child policy, and the host
+ *       with fewer number of inflight requests will be returned the first. It will allow to always
+ *       avoid the worst option (comparing by number of inflight requests).
+ *   <li>besides the first two hosts returned by the child policy's {@code newQueryPlan} method, the
+ *       ordering of the rest of the hosts will remain the same.
+ * </ul>
+ *
+ * <p>If you wrap the {@code RandomTwoChoicePolicy} policy with {@code TokenAwarePolicy}, it will
+ * compare the first two replicas by the number of inflight requests, and the worse option will
+ * always be avoided. In that case, it is recommended to use the TokenAwarePolicy with {@code
+ * ReplicaOrdering.RANDOM strategy}, which will return the replicas in a shuffled order and thus
+ * will make the "Power of 2 Choice" algorithm more efficient.
+ */
+public class RandomTwoChoicePolicy implements ChainableLoadBalancingPolicy {
+  private final LoadBalancingPolicy childPolicy;
+  private volatile Metrics metrics;
+  private volatile Metadata clusterMetadata;
+  private volatile ProtocolVersion protocolVersion;
+  private volatile CodecRegistry codecRegistry;
+
+  /**
+   * Creates a new {@code RandomTwoChoicePolicy}.
+   *
+   * @param childPolicy the load balancing policy to wrap with "Power of 2 Choice" algorithm.
+   */
+  public RandomTwoChoicePolicy(LoadBalancingPolicy childPolicy) {
+    this.childPolicy = childPolicy;
+  }
+
+  @Override
+  public LoadBalancingPolicy getChildPolicy() {
+    return childPolicy;
+  }
+
+  @Override
+  public void init(Cluster cluster, Collection<Host> hosts) {
+    this.metrics = cluster.getMetrics();
+    this.clusterMetadata = cluster.getMetadata();
+    this.protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+    this.codecRegistry = cluster.getConfiguration().getCodecRegistry();
+    childPolicy.init(cluster, hosts);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation always returns distances as reported by the wrapped policy.
+   */
+  @Override
+  public HostDistance distance(Host host) {
+    return childPolicy.distance(host);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned plan will compare (by the number of inflight requests) the first 2 hosts
+   * returned by the child policy's {@code newQueryPlan} method, and the host with fewer inflight
+   * requests will be returned the first. The rest of the child policy's query plan will be left
+   * intact.
+   */
+  @Override
+  public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+    String keyspace = statement.getKeyspace();
+    if (keyspace == null) keyspace = loggedKeyspace;
+
+    ByteBuffer routingKey = statement.getRoutingKey(protocolVersion, codecRegistry);
+    if (routingKey == null || keyspace == null) {
+      return childPolicy.newQueryPlan(loggedKeyspace, statement);
+    }
+
+    final Token t = clusterMetadata.newToken(statement.getPartitioner(), routingKey);
+    final Iterator<Host> childIterator = childPolicy.newQueryPlan(keyspace, statement);
+
+    final Host host1 = childIterator.hasNext() ? childIterator.next() : null;
+    final Host host2 = childIterator.hasNext() ? childIterator.next() : null;
+
+    final AtomicInteger host1ShardInflightRequests = new AtomicInteger(0);
+    final AtomicInteger host2ShardInflightRequests = new AtomicInteger(0);
+
+    if (host1 != null) {
+      final int host1ShardId = host1.getShardingInfo().shardId(t);
+      host1ShardInflightRequests.set(
+          metrics.getPerShardInflightRequestInfo().getValue().get(host1).get(host1ShardId));
+    }
+
+    if (host2 != null) {
+      final int host2ShardId = host2.getShardingInfo().shardId(t);
+      host2ShardInflightRequests.set(
+          metrics.getPerShardInflightRequestInfo().getValue().get(host2).get(host2ShardId));
+    }
+
+    return new AbstractIterator<Host>() {
+      private final Host firstChosenHost =
+          host1ShardInflightRequests.get() < host2ShardInflightRequests.get() ? host1 : host2;
+      private final Host secondChosenHost =
+          host1ShardInflightRequests.get() < host2ShardInflightRequests.get() ? host2 : host1;
+      private int index = 0;
+
+      @Override
+      protected Host computeNext() {
+        if (index == 0) {
+          index++;
+          return firstChosenHost;
+        } else if (index == 1) {
+          index++;
+          return secondChosenHost;
+        } else if (childIterator.hasNext()) {
+          return childIterator.next();
+        }
+
+        return endOfData();
+      }
+    };
+  }
+
+  @Override
+  public void onAdd(Host host) {
+    childPolicy.onAdd(host);
+  }
+
+  @Override
+  public void onUp(Host host) {
+    childPolicy.onUp(host);
+  }
+
+  @Override
+  public void onDown(Host host) {
+    childPolicy.onDown(host);
+  }
+
+  @Override
+  public void onRemove(Host host) {
+    childPolicy.onRemove(host);
+  }
+
+  @Override
+  public void close() {
+    childPolicy.close();
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/RandomTwoChoicePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/RandomTwoChoicePolicyTest.java
@@ -1,0 +1,110 @@
+package com.datastax.driver.core.policies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Gauge;
+import com.datastax.driver.core.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+import org.assertj.core.util.Sets;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RandomTwoChoicePolicyTest {
+  private final ByteBuffer routingKey = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+  private final RegularStatement statement =
+      new SimpleStatement("irrelevant").setRoutingKey(routingKey).setKeyspace("keyspace");
+  private final Host host1 = mock(Host.class);
+  private final Host host2 = mock(Host.class);
+  private final Host host3 = mock(Host.class);
+  private Cluster cluster;
+
+  @SuppressWarnings("unchecked")
+  private final Gauge<Map<Host, Map<Integer, Integer>>> gauge =
+      mock((Class<Gauge<Map<Host, Map<Integer, Integer>>>>) (Object) Gauge.class);
+
+  @BeforeMethod(groups = "unit")
+  public void initMocks() {
+    CodecRegistry codecRegistry = new CodecRegistry();
+    cluster = mock(Cluster.class);
+    Configuration configuration = mock(Configuration.class);
+    ProtocolOptions protocolOptions = mock(ProtocolOptions.class);
+    Metadata metadata = mock(Metadata.class);
+    Metrics metrics = mock(Metrics.class);
+    Token t = mock(Token.class);
+    ShardingInfo shardingInfo = mock(ShardingInfo.class);
+
+    when(metrics.getPerShardInflightRequestInfo()).thenReturn(gauge);
+    when(cluster.getConfiguration()).thenReturn(configuration);
+    when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
+    when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
+    when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.DEFAULT);
+    when(cluster.getMetadata()).thenReturn(metadata);
+    when(cluster.getMetrics()).thenReturn(metrics);
+    when(metadata.getReplicas(Metadata.quote("keyspace"), null, routingKey))
+        .thenReturn(Sets.newLinkedHashSet(host1, host2, host3));
+    when(metadata.newToken(null, routingKey)).thenReturn(t);
+    when(host1.getShardingInfo()).thenReturn(shardingInfo);
+    when(host2.getShardingInfo()).thenReturn(shardingInfo);
+    when(host3.getShardingInfo()).thenReturn(shardingInfo);
+    when(shardingInfo.shardId(t)).thenReturn(0);
+    when(host1.isUp()).thenReturn(true);
+    when(host2.isUp()).thenReturn(true);
+    when(host3.isUp()).thenReturn(true);
+  }
+
+  @Test(groups = "unit")
+  public void should_prefer_host_with_less_inflight_requests() {
+    // given
+    Map<Host, Map<Integer, Integer>> perHostInflightRequests =
+        new HashMap<Host, Map<Integer, Integer>>() {
+          {
+            put(
+                host1,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 6);
+                  }
+                });
+            put(
+                host2,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 2);
+                  }
+                });
+            put(
+                host3,
+                new HashMap<Integer, Integer>() {
+                  {
+                    put(0, 4);
+                  }
+                });
+          }
+        };
+    RandomTwoChoicePolicy policy =
+        new RandomTwoChoicePolicy(
+            new TokenAwarePolicy(
+                new RoundRobinPolicy(), TokenAwarePolicy.ReplicaOrdering.TOPOLOGICAL));
+    policy.init(
+        cluster,
+        new ArrayList<Host>() {
+
+          {
+            add(host1);
+            add(host2);
+            add(host3);
+          }
+        });
+    when(gauge.getValue()).thenReturn(perHostInflightRequests);
+
+    Iterator<Host> queryPlan = policy.newQueryPlan("keyspace", statement);
+    // host2 should appear first in the query plan with fewer inflight requests than host1
+
+    assertThat(queryPlan.next()).isEqualTo(host2);
+    assertThat(queryPlan.next()).isEqualTo(host1);
+    assertThat(queryPlan.next()).isEqualTo(host3);
+  }
+}


### PR DESCRIPTION
#### TL;DR
The RandomTwoChoice policy is a wrapper load balancing policy that adds the "Power of 2 Choice" algorithm to its child policy. It will compare the first two hosts returned from the child policy query plan, and will first return the host with the target shard having fewer inflight requests. The rest of the child query plan will be left intact.

It is intended to be used with TokenAwarePolicy and RoundRobinPolicy, to send queries to the replica nodes by always avoiding the worst option (the replica with the target shard having the most inflight requests will not be chosen).

#### The original problem
The current default load-balancing policy is the TokenAwarePolicy, which is able to fetch the replica set based on the prepared statement and iterate over the replicas in a round-robin style. This approach has a certain limitation when one of the replicas gets overloaded with background processing like compactions. In that case, the driver keeps sending queries to the overloaded replica which potentially increases the latencies and even queries end up being timed out.

#### The solution
Now, to avoid sending queries to replicas under high load, we need to collect metrics about the request queues of each replica and for each shard. The shard-awareness feature will allow us to identify the target shard for a prepared statement, and then choose a replica with the target shard having the least number of inflight requests (shortest request queue). It will be particularly effective for environments where latency to each replica may vary unpredictably. However, this may all fall apart if there are multiple clients, as momentarily queries from multiple clients may be sent to the same replica with the target shard having the least number of inflight requests, and this will cause unbalanced and unfair distribution. So, instead of making the absolute best choice, similar to the “power of two choices” algorithm. we pick two replicas at random and choose the better option from them, thus, always avoiding the worst option. It is effective with multiple clients, as it simply avoids the worst choice and distributes the traffic with some degree of randomness.

#### Benchmarks

* Start a Scylla cluster with 5 `i3.4xlarge` nodes with Scylla 5.1.3 (AMI-07d0ff1841b1a9d8a)
* Start 2 `c5n.9xlarge` loaders with Ubuntu 22.04 LTS (AMI-0ab0629dba5ae551d)
* Run on each loader a c-s process with the following command:
    `./cassandra-stress read duration=150m -schema 'replication(strategy=SimpleStrategy, factor=3)' -mode native cql3 -rate "threads=500" -pop 'dist=UNIFORM(1..100000000)'  -node NODE_IP`

###### All the nodes and loaders were in `us-east-2a`

To test how well the new load-balancing policy will perform in comparison with the TokenAwarePolicy, shard 4 (randomly chosen shard) of one of the nodes was overloaded with a simple C application that made the CPU core busy and thus increased the number of inflight requests for that specific shard. There were run 4 copies of the overloading application which used approximately 75% of the CPU core.

Additionally, data was collected about the inflight requests for all nodes and shards and how many times a certain node was chosen to sent a request to. Charts were generated based on this data which highlights the better performance of the RandomTwoChoicePolicy over the TokenAwarePolicy.

_____
#### Results of the TokenAwarePolicy

#### Overview
![image](https://user-images.githubusercontent.com/29541844/217113199-cc2890d2-e2f6-4f5f-b7d4-611791bc5fb3.png)

#### Load and Throughput by instance,shard
![image](https://user-images.githubusercontent.com/29541844/217113272-65b6f483-9383-48ed-b5e8-df1c6f313a6a.png)

#### Latencies by instance,shard
![image](https://user-images.githubusercontent.com/29541844/217113324-e94cfd97-8d53-4668-9932-9a3e7a2a5135.png)

#### Inflight Requests and Host Chosen (for all nodes and shard 4)
![image](https://user-images.githubusercontent.com/29541844/217114115-6ef53291-a5be-465e-b576-addcd8e96343.png)

_____
#### Results of the RandomTwoChoicePolicy

#### Overview
![image](https://user-images.githubusercontent.com/29541844/217110012-fed8712a-0a96-4a2b-b1df-db4599175c18.png)

#### Load and Throughput by instance,shard
![image](https://user-images.githubusercontent.com/29541844/217110972-4d71635c-8373-43ca-9bc5-d527b8808f1f.png)

#### Latencies by instance,shard
![image](https://user-images.githubusercontent.com/29541844/217111242-8c7801b9-d685-4db7-93d1-bf12bdca1893.png)

#### Inflight Requests and Host Chosen/Not Chosen (for all nodes and shard 4)

![image](https://user-images.githubusercontent.com/29541844/217113768-11cd3b41-dda7-45d3-a7ae-1688b219fd85.png)

#### Conclusion
The benchmark with a node having a single shard overloaded shows that the RandomTwoChoice policy performs better in terms of throughput, latencies and smart distribution of the requests to the nodes. The replica with an overloaded shard was chosen less frequently in case of RandomTwoChoice policy as the number of inflight/hanging requests were higher. This resulted in small latencies by instance and shard comparing to the TokenAwarePolicy where the P95 and P99 latencies were almost 300ms. Also the overall throughput was significantly higher and the loaders were able to maximize their use of CPU cores. However, the RandomTwoChoice policy may happen to be less efficient for write workloads, as writes result in a lot of background processing like compaction, hints, etc. So, as a result, the lattencies may rapidly increase and even cause frequent timeouts. In fact, the average and P95 latencies were not so different, but the P99 latency was significantly higher for the RandomTwoChoice policy. The throughput however, was more or less the same in comparision with the TokenAwarePolicy, so perhaps benchmarking with write workloads without throttling the throughput will not show significant differences as the cluster gets easily overloaded with background processings resulting in skyrocketing latencies, hints, background and foreground writes, etc:

##### Cluster Throughput (RandomTwoChoice vs TokenAwarePolicy) 
![image](https://user-images.githubusercontent.com/29541844/217121476-dce1d150-9289-4be1-a535-762ca10b9c6a.png)

##### Cluster Latencies (RandomTwoChoice vs TokenAwarePolicy)
![image](https://user-images.githubusercontent.com/29541844/217121687-7c33e50b-e4ca-4111-bb0b-8108bc3739c7.png)
