### PR TITLE
4.x: Add rack awareness to default load balancing policy

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -94,6 +94,12 @@ public enum DefaultDriverOption implements DriverOption {
    */
   LOAD_BALANCING_LOCAL_DATACENTER("basic.load-balancing-policy.local-datacenter"),
   /**
+   * The rack that is considered "local".
+   *
+   * <p>Value-type: {@link String}
+   */
+  LOAD_BALANCING_LOCAL_RACK("basic.load-balancing-policy.local-rack"),
+  /**
    * A custom filter to include/exclude nodes.
    *
    * <p>Value-Type: {@link String}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -137,6 +137,9 @@ public class TypedDriverOption<ValueT> {
   public static final TypedDriverOption<String> LOAD_BALANCING_LOCAL_DATACENTER =
       new TypedDriverOption<>(
           DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, GenericType.STRING);
+
+  public static final TypedDriverOption<String> LOAD_BALANCING_LOCAL_RACK =
+      new TypedDriverOption<>(DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK, GenericType.STRING);
   /**
    * A custom filter to include/exclude nodes.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/LocalRackHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/LocalRackHelper.java
@@ -1,0 +1,12 @@
+package com.datastax.oss.driver.internal.core.loadbalancing.helper;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LocalRackHelper {
+  @NonNull
+  Optional<String> discoverLocalRack(@NonNull Map<UUID, Node> nodes);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalRackHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalRackHelper.java
@@ -1,0 +1,44 @@
+package com.datastax.oss.driver.internal.core.loadbalancing.helper;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link LocalRackHelper} that fetches the local rack from the driver
+ * configuration. If no user-supplied rack can be retrieved, it returns {@link Optional#empty
+ * empty}.
+ */
+@ThreadSafe
+public class OptionalLocalRackHelper implements LocalRackHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(OptionalLocalRackHelper.class);
+
+  @NonNull protected final DriverExecutionProfile profile;
+  @NonNull protected final String logPrefix;
+
+  public OptionalLocalRackHelper(
+      @NonNull DriverExecutionProfile profile, @NonNull String logPrefix) {
+    this.profile = profile;
+    this.logPrefix = logPrefix;
+  }
+
+  @NonNull
+  @Override
+  public Optional<String> discoverLocalRack(@NonNull Map<UUID, Node> nodes) {
+    if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK)) {
+      String localRack = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK);
+      LOG.debug("[{}] Local rack set from configuration: {}", logPrefix, localRack);
+      return Optional.of(localRack);
+    } else {
+      LOG.debug("[{}] Local rack not set, rack awareness will be disabled", logPrefix);
+      return Optional.empty();
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
@@ -89,6 +89,34 @@ public class ArrayUtils {
     }
   }
 
+  /**
+   * Shuffles elements of the array in a range.
+   *
+   * @param elements the array to shuffle.
+   * @param startIndex the start index of the range; must be {@code >= 0}.
+   * @param endIndex the end index of the range; must be {@code <= elements.length}.
+   * @see <a
+   *     href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm">Modern
+   *     Fisher-Yates shuffle</a>
+   */
+  public static <ElementT> void shuffleInRange(
+      @NonNull ElementT[] elements, int startIndex, int endIndex) {
+    assert startIndex >= 0 && startIndex < elements.length;
+    assert endIndex >= 0 && endIndex < elements.length;
+
+    if (startIndex > endIndex) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Start index %d should be less than or equal to endIndex %d", startIndex, endIndex));
+    }
+
+    final ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = endIndex; i > startIndex; i--) {
+      int j = random.nextInt(startIndex, i + 1);
+      swap(elements, i, j);
+    }
+  }
+
   /** Rotates the elements in the specified range by the specified amount (round-robin). */
   public static <ElementT> void rotate(
       @NonNull ElementT[] elements, int startIndex, int length, int amount) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyQueryPlanTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyQueryPlanTest.java
@@ -33,6 +33,9 @@ public class DcInferringLoadBalancingPolicyQueryPlanTest
               protected void shuffleHead(Object[] array, int n) {}
 
               @Override
+              protected void shuffleInRange(Object[] currentNodes, int startIndex, int endIndex) {}
+
+              @Override
               protected long nanoTime() {
                 return nanoTime;
               }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
@@ -52,6 +52,23 @@ public class DefaultLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestB
   }
 
   @Test
+  public void should_use_local_rack_if_provided_via_config() {
+    // Given
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK)).thenReturn(true);
+    when(defaultProfile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK))
+        .thenReturn("rack1");
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    DefaultLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter);
+
+    // Then
+    assertThat(policy.getLocalRack()).isEqualTo("rack1");
+  }
+
+  @Test
   public void should_use_local_dc_if_provided_via_context() {
     // Given
     when(context.getLocalDatacenter(DriverExecutionProfile.DEFAULT_NAME)).thenReturn("dc1");

--- a/manual/core/load_balancing/README.md
+++ b/manual/core/load_balancing/README.md
@@ -139,7 +139,24 @@ that case, the driver will connect to 127.0.0.1:9042, and use that node's datace
 for a better out-of-the-box experience for users who have just downloaded the driver; beyond that
 initial development phase, you should provide explicit contact points and a local datacenter.
 
-##### Finding the local datacenter
+##### Rack awareness
+
+The `DefaultLoadBalancingPolicy` and implicitly the `DcInferringLoadBalancingPolicy` prioritize replicas that are in the
+local datacenter, however, sometimes there is a need to prioritize replicas that are in the local rack and to not send
+queries to other replicas in the local datacenter. This will allow to avoid high network traffic between racks/availability zones
+and thus will reduce data transfer costs. The rack-awareness feature is optional and to enable it the local rack should
+be supplied through the configuration:
+
+```
+datastax-java-driver.basic.load-balancing-policy {
+  local-rack = rack1
+}
+```
+
+The feature is disabled by default and unlike the local datacenter it will not be implicitly fetched from the provided
+contact points.
+
+##### Finding the local datacenter & local rack
 
 To check which datacenters are defined in a given cluster, you can run [`nodetool status`]. It will 
 print information about each node in the cluster, grouped by datacenters. Here is an example: 
@@ -165,17 +182,17 @@ UN  <IP5>      1.5 TB     256     ?     <ID5>    rack2
 UN  <IP6>      1.5 TB     256     ?     <ID6>    rack3
 ```
 
-To find out which datacenter should be considered local, you need to first determine which nodes the 
-driver is going to be co-located with, then choose their datacenter as local. In case of doubt, you
+To find out which datacenter and rack(availability zone) should be considered local, you need to first determine which nodes the 
+driver is going to be co-located with, then choose their datacenter and rack as local. In case of doubt, you
 can also use [cqlsh]; if cqlsh is co-located too in the same datacenter, simply run the command 
 below:
 
 ```
-cqlsh> select data_center from system.local;
+cqlsh> select data_center,rack from system.local;
 
-data_center
--------------
-DC1 
+ data_center | rack
+-------------+-------
+ datacenter1 | rack1
 ```
 
 #### Cross-datacenter failover


### PR DESCRIPTION
The default load balancing policy will prefer replicas that are in the local datacenter and in the local rack.
The rack awareness feature is optional, to enable it a local rack should be supplied through configuration by defining the option `DefaultDriverOption.LOAD_BALANCING_LOCAL_RACK`
`basic.load-balancing-policy.local-rack`, otherwise it will be disabled and unlike the local datacenter it will not be implicitly fetched from the provided contact points.