### PR TITLE
Fix non core modules not being present in generated javadocs

### DIFF
--- a/docs/_utils/javadoc.sh
+++ b/docs/_utils/javadoc.sh
@@ -15,3 +15,5 @@ mvn javadoc:javadoc
 [ -d $OUTPUT_DIR ] && rm -r $OUTPUT_DIR
 mkdir -p "$OUTPUT_DIR"
 mv -f core/target/site/apidocs/* $OUTPUT_DIR
+cp -f -r query-builder/target/site/apidocs/* $OUTPUT_DIR
+cp -f -r mapper-runtime/target/site/apidocs/* $OUTPUT_DIR

--- a/docs/_utils/setup.sh
+++ b/docs/_utils/setup.sh
@@ -6,6 +6,8 @@ if pwd | egrep -q '\s'; then
 fi
 
 which python3 || { echo "Failed to find python3. Try installing Python for your operative system: https://www.python.org/downloads/" && exit 1; }
-which poetry || curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.1.3/get-poetry.py | python3 - && source ${HOME}/.poetry/env
+which poetry || curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/d222411ae9d01a04ec8eda348a65aa83852c37d0/get-poetry.py | python3 - --version 1.1.15
+source ${HOME}/.poetry/env
+which poetry || { echo "Failed to find poetry. Exiting." && exit 1; }
 poetry install
 poetry update

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -14,6 +14,7 @@ sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "0.7.1"
 Sphinx = "2.4.4"
 sphinx-multiversion-scylla = "~0.2.6"
+jinja2 = "< 3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.2"


### PR DESCRIPTION
Fixes setup for generating javadocs.
It seems that javadocs for other modules were also being generated, but they were not moved to the same place the core module javadocs were. Now query builder and mapper modules should also be included (after updating website with generated files).