### PR TITLE
Add per partition rate limit table options

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
@@ -121,6 +121,8 @@ public class AlterTest {
             .memtableFlushPeriodInMillis(12)
             .populateIOCacheOnFlush(true)
             .replicateOnWrite(true)
+            .maxReadsPerSecond(123)
+            .maxWritesPerSecond(456)
             .readRepairChance(0.42)
             .speculativeRetry(always())
             .cdc(true);
@@ -147,6 +149,7 @@ public class AlterTest {
                 + "AND populate_io_cache_on_flush = true "
                 + "AND read_repair_chance = 0.42 "
                 + "AND replicate_on_write = true "
+                + "AND per_partition_rate_limit = {'max_reads_per_second': 123, 'max_writes_per_second': 456} "
                 + "AND speculative_retry = 'ALWAYS' "
                 + "AND cdc = true");
 


### PR DESCRIPTION
Added `maxReadsPerSecond` and `maxWritesPerSecond` options to `TableOptions` which will allow convenient creation of CREATE and ALTER statements with rate limit options for read and write operations.
Both maxReadsPerSecond and maxWritesPerSecond are optional - omitting one of them means "no limit" for that type of operation.

Fixes #166