### PR TITLE
Collection of test fixes

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -197,7 +197,7 @@ public class ClusterStressTest extends CCMTestsSupport {
         assertEquals(cluster.manager.sessions.size(), 1);
         assertEquals(
             (int) cluster.getMetrics().getOpenConnections().getValue(),
-            1 + TestUtils.numberOfLocalCoreConnections(cluster));
+            1 + TestUtils.numberOfLocalCoreConnectionsSharded(cluster));
         assertEquals(
             channelMonitor.openChannels(getContactPointsWithPorts()).size(),
             1 + TestUtils.numberOfLocalCoreConnections(cluster));

--- a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
@@ -89,7 +89,7 @@ public class NettyOptionsTest extends CCMTestsSupport {
     // when
     cluster.connect(); // force session creation to populate pools
 
-    int expectedNumberOfCalls = TestUtils.numberOfLocalCoreConnections(cluster) * hosts + 1;
+    int expectedNumberOfCalls = TestUtils.numberOfLocalCoreConnectionsSharded(cluster) + 1;
     // If the driver supports a more recent protocol version than C*, the negotiation at startup
     // will open an additional connection for each protocol version tried.
     ProtocolVersion version = ProtocolVersion.DEFAULT;

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsIntegrationTest.java
@@ -74,7 +74,7 @@ public class PoolingOptionsIntegrationTest extends CCMTestsSupport {
 
     // Expect core connections + control connection.
     assertThat(cluster().getMetrics().getOpenConnections().getValue())
-        .isEqualTo(TestUtils.numberOfLocalCoreConnections(cluster()) + 1);
+        .isEqualTo(TestUtils.numberOfLocalCoreConnectionsSharded(cluster()) + 1);
 
     reset();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -237,7 +237,7 @@ public class ReconnectionTest extends CCMTestsSupport {
     cluster.connect();
     cluster.connect();
 
-    int corePoolSize = TestUtils.numberOfLocalCoreConnections(cluster);
+    int corePoolSize = TestUtils.numberOfLocalCoreConnectionsSharded(cluster);
 
     // Right after init, 1 connection has been opened by the control connection, and the core size
     // for each pool.

--- a/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.verify;
 import com.datastax.driver.core.utils.ScyllaOnly;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
 import org.testng.annotations.Test;
 
 @CreateCCM(CreateCCM.TestMode.PER_METHOD)
@@ -27,13 +30,14 @@ public class ScyllaSniProxyTest extends CCMTestsSupport {
 
     Collection<Host> hosts = s.getState().getConnectedHosts();
     assertThat(hosts.size()).isEqualTo(testNodes);
+    Set<UUID> uuidSet = new TreeSet<UUID>();
     for (Host host : hosts) {
-      assertThat(host.getListenAddress()).isNotNull();
-      assertThat(host.getListenAddress()).isEqualTo(TestUtils.addressOfNode(1));
+      uuidSet.add(host.getHostId());
       assertThat(host.getEndPoint().resolve().getAddress()).isEqualTo(TestUtils.addressOfNode(1));
       assertThat(host.getEndPoint().resolve().getPort()).isEqualTo(ccm().getSniPort());
       assertThat(host.getEndPoint().toString()).doesNotContain("any.");
     }
+    assertThat(uuidSet.size()).isEqualTo(testNodes);
     ((SessionManager) s).cluster.manager.controlConnection.triggerReconnect();
 
     SchemaChangeListener listener = mock(SchemaChangeListenerBase.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
@@ -3,6 +3,7 @@
  */
 package com.datastax.driver.core;
 
+import static com.datastax.driver.core.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
@@ -25,13 +26,13 @@ public class ScyllaSniProxyTest extends CCMTestsSupport {
     TestUtils.waitForUp(TestUtils.ipOfNode(1), c);
 
     Collection<Host> hosts = s.getState().getConnectedHosts();
-    assert hosts.size() == testNodes;
+    assertThat(hosts.size()).isEqualTo(testNodes);
     for (Host host : hosts) {
-      assert (host.getListenAddress() == null
-          || host.getListenAddress().equals(TestUtils.addressOfNode(1)));
-      assert host.getEndPoint().resolve().getAddress().equals(TestUtils.addressOfNode(1));
-      assert host.getEndPoint().resolve().getPort() == ccm().getSniPort();
-      assert !host.getEndPoint().toString().contains("any.");
+      assertThat(host.getListenAddress()).isNotNull();
+      assertThat(host.getListenAddress()).isEqualTo(TestUtils.addressOfNode(1));
+      assertThat(host.getEndPoint().resolve().getAddress()).isEqualTo(TestUtils.addressOfNode(1));
+      assertThat(host.getEndPoint().resolve().getPort()).isEqualTo(ccm().getSniPort());
+      assertThat(host.getEndPoint().toString()).doesNotContain("any.");
     }
     ((SessionManager) s).cluster.manager.controlConnection.triggerReconnect();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
@@ -116,11 +116,12 @@ public class SessionStressTest extends CCMTestsSupport {
       // This is a local cluster so we also have 2 connections per session
       Session session = stressCluster.connect();
       assertEquals(stressCluster.manager.sessions.size(), 1);
-      int coreConnections = TestUtils.numberOfLocalCoreConnections(stressCluster);
+      int coreConnections = TestUtils.numberOfLocalCoreConnectionsSharded(stressCluster);
       assertEquals(
           (int) stressCluster.getMetrics().getOpenConnections().getValue(), 1 + coreConnections);
       assertEquals(
-          channelMonitor.openChannels(getContactPointsWithPorts()).size(), 1 + coreConnections);
+          channelMonitor.openChannels(getContactPointsWithPorts()).size(),
+          1 + TestUtils.numberOfLocalCoreConnections(stressCluster));
 
       // Closing the session keeps the control connection opened
       session.close();

--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
@@ -82,7 +82,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
           event.getSource(),
           event.getThreadName(),
           event.getDescription());
-      assertThat(event.getThreadName()).isEqualTo(shard);
+      assertThat(event.getThreadName()).startsWith(shard);
       if (event.getDescription().contains("querying locally")) {
         anyLocal = true;
       }

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
@@ -30,11 +30,12 @@ public class SingleConnectionPoolTest extends CCMTestsSupport {
   @Test(groups = "short")
   public void should_throttle_requests() {
     // Throttle to a very low value. Even a single thread can generate a higher throughput.
-    final int maxRequests = 10;
+    final int maxRequestsPerConnection = 10;
     cluster()
         .getConfiguration()
         .getPoolingOptions()
-        .setMaxRequestsPerConnection(HostDistance.LOCAL, maxRequests);
+        .setMaxRequestsPerConnection(HostDistance.LOCAL, maxRequestsPerConnection);
+    final int maxRequests = 10 * TestUtils.numberOfLocalCoreConnectionsSharded(cluster());
 
     // Track in flight requests in a dedicated thread every second
     final AtomicBoolean excessInflightQueriesSpotted = new AtomicBoolean(false);

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -728,6 +728,25 @@ public abstract class TestUtils {
     return configuration.getPoolingOptions().getCoreConnectionsPerHost(HostDistance.LOCAL);
   }
 
+  // Calculates number of connections the same way
+  // HostConnectionPool.initAsyncWithConnection(connection) does
+  public static int numberOfLocalCoreConnectionsSharded(Cluster cluster) {
+    int connections = 0;
+    for (Host host : cluster.getMetadata().getAllHosts()) {
+      ShardingInfo shardingInfo = host.getShardingInfo();
+      int shardsCount = 1;
+      if (shardingInfo != null) {
+        shardsCount = shardingInfo.getShardsCount();
+      }
+      int optionsCoreConnections = TestUtils.numberOfLocalCoreConnections(cluster);
+      connections +=
+          shardsCount
+              * (optionsCoreConnections / shardsCount
+                  + (optionsCoreConnections % shardsCount > 0 ? 1 : 0));
+    }
+    return connections;
+  }
+
   /**
    * @return A Scassandra instance with an arbitrarily chosen binary port from 8042-8142 and admin
    *     port from 8052-8152.

--- a/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
@@ -132,8 +132,9 @@ public class TimeoutStressTest extends CCMTestsSupport {
     AtomicBoolean stopped = new AtomicBoolean(false);
 
     // Ensure that we never exceed MaxConnectionsPerHost * nodes + 1 control connection.
-    int maxConnections =
-        TestUtils.numberOfLocalCoreConnections(cluster()) * getContactPoints().size() + 1;
+    // numberOfLocalCoreConnectionsSharded iterates over all hosts, so there is no need to multiply
+    // by nodes now.
+    int maxConnections = TestUtils.numberOfLocalCoreConnectionsSharded(cluster()) + 1;
 
     try {
       Semaphore concurrentQueries = new Semaphore(CONCURRENT_QUERIES);


### PR DESCRIPTION
Modifies verifyCorrectShardSingleRow() method to account for addition of extra shard info in event.getThreadName() from trace queries (e.g. "shard 0[/sl:default]" instead of "shard 0[]").