### PR TITLE
Revert "Add setup Python 2 step to scylla-integration-tests in GH actions"

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -183,11 +183,6 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
 
-      - name: Setup Python 2
-        uses: actions/setup-python@v2
-        with:
-          python-version: '2.x'
-
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
This reverts commit https://github.com/avelanarius/java-driver/commit/834f2315fd874f65b8efe2844eef37a727cfc309.

The original reason for adding this step to CI was for serverless tests, for which ccm exectues cqlsh, which required Python 2.

However looking at the 3.x branch, where the serverless tests are routinely ran, it looks like this is not really necessary for some reason.