### PR TITLE
Enable disabled load balancing integration tests

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/PagingOptimizingLatencyTracker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PagingOptimizingLatencyTracker.java
@@ -8,6 +8,9 @@ class PagingOptimizingLatencyTracker implements LatencyTracker {
 
   @Override
   public void update(Host host, Statement statement, Exception exception, long newLatencyNanos) {
+    if (!(statement instanceof BoundStatement)) {
+      return;
+    }
     if (exception == null) {
       statement.setLastHost(host);
     } else {

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
@@ -87,7 +87,7 @@ public class DCAwareRoundRobinPolicyTest {
    *
    * @test_category load_balancing:dc_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_round_robin_within_local_dc() {
     // given: a 10 node 2 DC cluster.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(5, 5).build();
@@ -123,7 +123,7 @@ public class DCAwareRoundRobinPolicyTest {
    *
    * @test_category load_balancing:dc_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_not_use_remote_hosts_if_some_nodes_are_up_in_local_dc() {
     // given: a 10 node 2 DC cluster with DC policy with 2 remote hosts.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(5, 5).build();
@@ -172,7 +172,7 @@ public class DCAwareRoundRobinPolicyTest {
    *
    * @test_category load_balancing:dc_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_round_robin_on_remote_hosts_when_no_up_nodes_in_local_dc() {
     // given: a 10 node 2 DC cluster with DC policy with 2 remote hosts.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(5, 5).build();
@@ -221,8 +221,7 @@ public class DCAwareRoundRobinPolicyTest {
   @Test(
       groups = "short",
       dataProvider = "consistencyLevels",
-      dataProviderClass = DataProviders.class,
-      enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+      dataProviderClass = DataProviders.class)
   public void should_only_use_remote_hosts_when_using_non_dc_local_cl(ConsistencyLevel cl) {
     // given: a 4 node 2 DC Cluster with a LB policy that specifies to not allow remote dcs for
     // a local consistency level.
@@ -276,8 +275,7 @@ public class DCAwareRoundRobinPolicyTest {
   @Test(
       groups = "short",
       dataProvider = "consistencyLevels",
-      dataProviderClass = DataProviders.class,
-      enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+      dataProviderClass = DataProviders.class)
   public void should_use_remote_hosts_for_local_cl_when_allowed(ConsistencyLevel cl) {
     // given: a 4 node 2 DC Cluster with a LB policy that specifies to allow remote dcs for
     // a local consistency level.
@@ -325,7 +323,7 @@ public class DCAwareRoundRobinPolicyTest {
    *
    * @test_category load_balancing:dc_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_not_send_requests_to_blacklisted_dc_using_host_filter_policy() {
     // given: a 6 node 3 DC cluster with a DCAwareRoundRobinPolicy that is filtering hosts in DC2.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(2, 2, 2).build();
@@ -382,7 +380,7 @@ public class DCAwareRoundRobinPolicyTest {
    *
    * @test_category load_balancing:dc_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_send_requests_to_whitelisted_dcs_using_host_filter_policy() {
     // given: a 6 node 3 DC cluster with a DCAwareRoundRobinPolicy that is whitelisting hosts in DC1
     // and DC2.

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/RoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/RoundRobinPolicyTest.java
@@ -65,7 +65,7 @@ public class RoundRobinPolicyTest {
    *
    * @test_category load_balancing:round_robin
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_round_robin_within_single_datacenter() {
     // given: a 5 node cluster using RoundRobinPolicy.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(5).build();
@@ -102,7 +102,7 @@ public class RoundRobinPolicyTest {
    *
    * @test_category load_balancing:round_robin
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_round_robin_irrespective_of_topology() {
     // given: a 10 node, 5 DC cluster using RoundRobinPolicy.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(2, 2, 2, 2, 2).build();
@@ -145,8 +145,7 @@ public class RoundRobinPolicyTest {
   @Test(
       groups = "short",
       dataProvider = "consistencyLevels",
-      dataProviderClass = DataProviders.class,
-      enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+      dataProviderClass = DataProviders.class)
   public void should_warn_if_using_dc_local_consistency_level(ConsistencyLevel cl) {
     // given: a 2 node, 2 DC cluster using RoundRobinPolicy.
     ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(1, 1).build();

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -329,7 +329,7 @@ public class TokenAwarePolicyTest {
    *
    * @test_category load_balancing:token_aware
    */
-  @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
+  @Test(groups = "short")
   public void should_use_other_nodes_when_replicas_having_token_are_down() {
     // given: A 4 node cluster using TokenAwarePolicy with a replication factor of 2.
     ScassandraCluster sCluster =


### PR DESCRIPTION
Enable previously disabled load balancing integration tests. The tests were disabled, because they were failing. 

It turns out that the root cause of the problem was that c083ccf6a767bb903fcdafca7455e3ddb7a369ac introduced PagingOptimizingLoadBalancingPolicy which is wrapped on top of all policies (see issue #225). 

This policy makes sure that queries for reading the next page of a statement are sent to the same node. However, it turns out that if you reuse a SimpleStatement many times, the policy incorrectly treats the next execution of it as if it is a next page fetch.

A workaround is introduced - do not apply this policy for statements which are not BoundStatement. This a heuristic that BoundStatements are generally not reused (you call .bind() with different parameters), but all other statement types can be reused (such as SimpleStatement).

Ultimately, this should be fixed in a better fashion: see #225.