### PR TITLE
Bump minimum Java version to 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ UDT and tuple support is available only when using Apache Cassandra 2.1 or highe
 Other features are available only when using Apache Cassandra 2.0 or higher (e.g. result set paging,
 [lightweight transactions](https://docs.scylladb.com/using-scylla/lwt/))
 
-The java driver supports Java JDK versions 6 and above.
+The java driver supports Java JDK versions 8 and above.
 
 
 

--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -403,4 +403,10 @@
         <to>*com.datastax.driver.core.EndPoint*</to>
         <justification>JAVA-2355: Abstract connection information into new EndPoint type for sni support</justification>
     </difference>
+    <difference>
+        <differenceType>7002</differenceType> <!-- method removed -->
+        <className>com/datastax/driver/core/ResultSet</className>
+        <method>*one*</method>
+        <justification>False positive. Method is still present in parent interface (and was only introduced in ResultSet as a workaround for another clirr false positive)</justification>
+    </difference>
 </differences>

--- a/driver-core/src/main/java/com/datastax/driver/core/Crc.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Crc.java
@@ -138,7 +138,6 @@ class Crc {
     }
   }
 
-  @IgnoreJDK6Requirement
   private static class Java8CrcUpdater implements CrcUpdater {
     @Override
     public void update(CRC32 crc, ByteBuf buffer) {

--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
@@ -33,10 +33,6 @@ package com.datastax.driver.core;
  */
 public interface ResultSet extends PagingIterable<ResultSet, Row> {
 
-  // redeclared only to make clirr happy
-  @Override
-  Row one();
-
   /**
    * Returns the columns returned in this ResultSet.
    *

--- a/driver-core/src/main/java/com/datastax/driver/core/SniSSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SniSSLOptions.java
@@ -31,7 +31,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
-@IgnoreJDK6Requirement
 @SuppressWarnings("deprecation")
 public class SniSSLOptions extends JdkSSLOptions implements ExtendedRemoteEndpointAwareSslOptions {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java
@@ -22,7 +22,6 @@ import static com.datastax.driver.core.ParseUtils.unquote;
 import static java.lang.Long.parseLong;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
@@ -43,7 +42,6 @@ import java.nio.ByteBuffer;
  * @see <a href="https://cassandra.apache.org/doc/cql3/CQL-2.2.html#usingtimestamps">'Working with
  *     timestamps' section of CQL specification</a>
  */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class InstantCodec extends TypeCodec<java.time.Instant> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateCodec.java
@@ -25,14 +25,12 @@ import static com.datastax.driver.core.ParseUtils.unquote;
 import static java.lang.Long.parseLong;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import java.nio.ByteBuffer;
 
 /** {@link TypeCodec} that maps {@link java.time.LocalDate} to CQL {@code date}. */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class LocalDateCodec extends TypeCodec<java.time.LocalDate> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateTimeCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalDateTimeCodec.java
@@ -19,7 +19,6 @@ import static com.datastax.driver.core.ParseUtils.isLongLiteral;
 import static com.datastax.driver.core.ParseUtils.quote;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ParseUtils;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
@@ -43,7 +42,6 @@ import java.nio.ByteBuffer;
  * @see <a href="https://cassandra.apache.org/doc/cql3/CQL-2.2.html#usingtimestamps">'Working with
  *     timestamps' section of CQL specification</a>
  */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class LocalDateTimeCodec extends TypeCodec<java.time.LocalDateTime> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalTimeCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/LocalTimeCodec.java
@@ -18,7 +18,6 @@ package com.datastax.driver.extras.codecs.jdk8;
 import static com.datastax.driver.core.ParseUtils.quote;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ParseUtils;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
@@ -29,7 +28,6 @@ import java.nio.ByteBuffer;
  * {@link TypeCodec} that maps {@link java.time.LocalTime} to CQL {@code time} (long representing
  * nanoseconds since midnight).
  */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class LocalTimeCodec extends TypeCodec<java.time.LocalTime> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodec.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.extras.codecs.jdk8;
 
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.extras.codecs.MappingCodec;
 import com.google.common.reflect.TypeParameter;
@@ -28,7 +27,6 @@ import java.util.Map;
  *
  * @param <T> The wrapped Java type
  */
-@IgnoreJDK6Requirement
 @SuppressWarnings({"Since15", "OptionalUsedAsFieldOrParameterType"})
 public class OptionalCodec<T> extends MappingCodec<java.util.Optional<T>, T> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZoneIdCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZoneIdCodec.java
@@ -16,7 +16,6 @@
 package com.datastax.driver.extras.codecs.jdk8;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
@@ -24,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.time.DateTimeException;
 
 /** {@link TypeCodec} that maps {@link java.time.ZoneId} to CQL {@code varchar}. */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class ZoneIdCodec extends TypeCodec<java.time.ZoneId> {
 

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java
@@ -20,7 +20,6 @@ import static com.datastax.driver.core.ParseUtils.quote;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.IgnoreJDK6Requirement;
 import com.datastax.driver.core.ParseUtils;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TupleType;
@@ -50,7 +49,6 @@ import java.util.List;
  * @see <a href="https://cassandra.apache.org/doc/cql3/CQL-2.2.html#usingtimestamps">'Working with
  *     timestamps' section of CQL specification</a>
  */
-@IgnoreJDK6Requirement
 @SuppressWarnings("Since15")
 public class ZonedDateTimeCodec extends TypeCodec.AbstractTupleCodec<java.time.ZonedDateTime> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cassandra.version>3.11.2</cassandra.version>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
@@ -662,8 +662,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>clirr-maven-plugin</artifactId>
-                    <!-- Last version compatible with Java 6 -->
-                    <version>2.7</version>
+                    <version>2.8</version>
                     <executions>
                         <execution>
                             <phase>compile</phase>
@@ -705,23 +704,6 @@
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
                     <version>1.18</version>
                     <executions>
-                        <execution>
-                            <id>check-jdk6</id>
-                            <phase>process-classes</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <signature>
-                                    <groupId>org.codehaus.mojo.signature</groupId>
-                                    <artifactId>java16</artifactId>
-                                    <version>1.0</version>
-                                </signature>
-                                <annotations>
-                                    <annotation>com.datastax.driver.core.IgnoreJDK6Requirement</annotation>
-                                </annotations>
-                            </configuration>
-                        </execution>
                         <execution>
                             <id>check-jdk8</id>
                             <goals>
@@ -1082,34 +1064,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>legacy-jdks</id>
-            <activation>
-                <jdk>[,1.8)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!--
-                        Exclude Jdk* test classes from being run
-                        This is needed in event that code was built with JDK8
-                        and tests are ran with JDK6 or 7.
-                        Note that running CCM tests with a legacy JDK require
-                        setting two system properties: ccm.java.home and ccm.path;
-                        both should point to a valid JDK8+ installation.
-                        -->
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/jdk8/*.java</exclude>
-                                <exclude>**/Jdk8*.java</exclude>
-                            </excludes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Up until now, minimum Java version was 1.6.
This is ancient - 1.6 is not supported for a few years now, even by Oracle's extended support. This is similar situation to Python 2 in Scylla, which we took way too long to drop.