### PR TITLE
Bump version of Jackson libraries to 2.15.2

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -166,11 +166,18 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.15.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
         <dependency>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -167,17 +167,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.15.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,7 @@
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
-        <jackson.version>2.8.11</jackson.version>
-        <!-- jackson-databind 2.7.x is the last to support java 6 -->
-        <jackson-databind.version>2.7.9.7</jackson-databind.version>
+        <jackson.version>2.15.2</jackson.version>
         <joda.version>2.9.9</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
@@ -202,7 +200,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
@@ -560,7 +558,7 @@
                             <additionalDependency>
                                 <groupId>com.fasterxml.jackson.core</groupId>
                                 <artifactId>jackson-databind</artifactId>
-                                <version>${jackson-databind.version}</version>
+                                <version>${jackson.version}</version>
                             </additionalDependency>
                             <additionalDependency>
                                 <groupId>joda-time</groupId>


### PR DESCRIPTION
Previous versions of Jackson libraries included an old version of snakeyaml which was susceptible to CVE-2022-1471.