### PR TITLE
Expose ShardingInfo

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Node.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Node.java
@@ -214,4 +214,13 @@ public interface Node {
    */
   @Nullable
   UUID getSchemaVersion();
+
+  /**
+   * Node's sharding information.
+   *
+   * <p>May be null if the node is not a Scylla node or the connection pool to the node was never
+   * created.
+   */
+  @Nullable
+  NodeShardingInfo getShardingInfo();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/NodeShardingInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/NodeShardingInfo.java
@@ -1,0 +1,19 @@
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.api.core.metadata.token.Token;
+
+/** Holds sharding information for a particular Node. */
+public interface NodeShardingInfo {
+
+  public int getShardsCount();
+
+  /**
+   * Returns a shardId for a given Token.
+   *
+   * <p>Accepts all types of Tokens but if the Token is not an instance of {@link
+   * com.datastax.oss.driver.internal.core.metadata.token.TokenLong64} then the return value could
+   * be not meaningful (e.g. random shard). This method does not verify if the given Token belongs
+   * to the Node.
+   */
+  public int shardId(Token t);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -340,6 +340,7 @@ public class ChannelPool implements AsyncAutoCloseable {
 
     private void initialize(DriverChannel c) {
       shardingInfo = c.getShardingInfo();
+      ((DefaultNode) node).setShardingInfo(shardingInfo);
       int wanted = getConfiguredSize(distance);
       int shardsCount = shardingInfo == null ? 1 : shardingInfo.getShardsCount();
       wantedCount = wanted / shardsCount + (wanted % shardsCount > 0 ? 1 : 0);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ShardingInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ShardingInfo.java
@@ -21,6 +21,7 @@
  */
 package com.datastax.oss.driver.internal.core.protocol;
 
+import com.datastax.oss.driver.api.core.metadata.NodeShardingInfo;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenLong64;
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 /** Keeps the information the driver maintains on data layout of a given node. */
-public class ShardingInfo {
+public class ShardingInfo implements NodeShardingInfo {
   private static final String SCYLLA_SHARD_PARAM_KEY = "SCYLLA_SHARD";
   private static final String SCYLLA_NR_SHARDS_PARAM_KEY = "SCYLLA_NR_SHARDS";
   private static final String SCYLLA_PARTITIONER = "SCYLLA_PARTITIONER";
@@ -48,6 +49,7 @@ public class ShardingInfo {
     this.shardingIgnoreMSB = shardingIgnoreMSB;
   }
 
+  @Override
   public int getShardsCount() {
     return shardsCount;
   }
@@ -60,6 +62,7 @@ public class ShardingInfo {
     return shardingAlgorithm;
   }
 
+  @Override
   public int shardId(Token t) {
     if (!(t instanceof TokenLong64)) {
       return ThreadLocalRandom.current().nextInt(shardsCount);

--- a/examples/src/main/java/com/datastax/oss/driver/examples/basic/TokenMapAndShardIdLookup.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/basic/TokenMapAndShardIdLookup.java
@@ -1,0 +1,89 @@
+package com.datastax.oss.driver.examples.basic;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.TraceEvent;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.TokenMap;
+import com.datastax.oss.driver.api.core.metadata.token.Token;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import java.nio.ByteBuffer;
+import java.util.Set;
+
+/**
+ * Demonstrates usage of TokenMap and NodeShardingInfo Needs a Scylla cluster to be running locally
+ * or adjustment of session builder.
+ */
+public class TokenMapAndShardIdLookup {
+
+  private static String CREATE_KEYSPACE =
+      "CREATE KEYSPACE IF NOT EXISTS tokenmap_example_ks "
+          + "WITH replication = {"
+          + "'class': 'SimpleStrategy', "
+          + "'replication_factor': 1"
+          + "}";
+
+  private static String CREATE_TABLE =
+      ""
+          + "CREATE TABLE IF NOT EXISTS tokenmap_example_ks.example_tab ("
+          + "my_column bigint,"
+          + "PRIMARY KEY (my_column)"
+          + ")";
+
+  private static String INSERT_COLUMN =
+      "INSERT INTO tokenmap_example_ks.example_tab (my_column) VALUES (2)";
+
+  private static String SELECT_COLUMN =
+      "SELECT * FROM tokenmap_example_ks.example_tab WHERE my_column = 2";
+
+  private static ByteBuffer PARTITION_KEY = TypeCodecs.BIGINT.encode(2L, DefaultProtocolVersion.V3);
+
+  public static void main(String[] args) {
+
+    try (CqlSession session = CqlSession.builder().build()) {
+
+      System.out.printf("Connected session: %s%n", session.getName());
+
+      session.execute(CREATE_KEYSPACE);
+      session.execute(CREATE_TABLE);
+      session.execute(INSERT_COLUMN);
+
+      Metadata metadata = session.refreshSchema();
+
+      System.out.println("Prepared example data");
+
+      TokenMap tokenMap = metadata.getTokenMap().get();
+
+      Set<Node> nodes =
+          tokenMap.getReplicas(CqlIdentifier.fromCql("tokenmap_example_ks"), PARTITION_KEY);
+      System.out.println("Replica set size: " + nodes.size());
+
+      Token token = tokenMap.newToken(PARTITION_KEY);
+      assert nodes.size() > 0;
+      Node node = nodes.iterator().next();
+
+      assert node.getShardingInfo() != null;
+      int shardId = node.getShardingInfo().shardId(token);
+
+      System.out.println(
+          "Hardcoded partition key should belong to shard number "
+              + shardId
+              + " (on Node: "
+              + node
+              + ")");
+
+      System.out.println("You can compare it with SELECT query trace:");
+      // If there is only 1 node, then the SELECT has to hit the one we did shardId calculation for.
+      SimpleStatement statement = SimpleStatement.builder(SELECT_COLUMN).setTracing(true).build();
+      ResultSet rs = session.execute(statement);
+
+      for (TraceEvent event : rs.getExecutionInfo().getQueryTrace().getEvents()) {
+        System.out.println(event);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds ShardingInfo field to DefaultNode and getShardingInfo() to Node interface. Adds NodeShardingInfo interface as public API.

With this change, having a token and having determined the Node it belongs to, users can further use NodeShardingInfo to determine the shard it belongs to.

Fixes #232.