### PR TITLE
Tablets 4.x

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/KeyspaceTableNamePair.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/KeyspaceTableNamePair.java
@@ -1,0 +1,51 @@
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/** Simple keyspace name and table name pair. */
+public class KeyspaceTableNamePair {
+  @NonNull private final CqlIdentifier keyspace;
+  @NonNull private final CqlIdentifier tableName;
+
+  public KeyspaceTableNamePair(@NonNull CqlIdentifier keyspace, @NonNull CqlIdentifier tableName) {
+    this.keyspace = keyspace;
+    this.tableName = tableName;
+  }
+
+  @NonNull
+  public CqlIdentifier getKeyspace() {
+    return keyspace;
+  }
+
+  @NonNull
+  public CqlIdentifier getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public String toString() {
+    return "KeyspaceTableNamePair{"
+        + "keyspace='"
+        + keyspace
+        + '\''
+        + ", tableName='"
+        + tableName
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || !(o instanceof KeyspaceTableNamePair)) return false;
+    KeyspaceTableNamePair that = (KeyspaceTableNamePair) o;
+    return keyspace.equals(that.keyspace) && tableName.equals(that.tableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keyspace, tableName);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Metadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Metadata.java
@@ -116,6 +116,14 @@ public interface Metadata {
   Optional<TokenMap> getTokenMap();
 
   /**
+   * The tablet map for this cluster.
+   *
+   * <p>Starts as an empty map that will gradually receive updates on each query of a yet unknown
+   * tablet.
+   */
+  TabletMap getTabletMap();
+
+  /**
    * The cluster name to which this session is connected. The Optional returned should contain the
    * value from the server for <b>system.local.cluster_name</b>.
    *

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Tablet.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Tablet.java
@@ -1,0 +1,37 @@
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.shaded.guava.common.annotations.Beta;
+import java.util.Set;
+
+/**
+ * Represents a tablet as described in tablets-routing-v1 protocol extension with some additional
+ * fields for ease of use.
+ */
+@Beta
+public interface Tablet extends Comparable<Tablet> {
+  /**
+   * Returns left endpoint of an interval. This interval is left-open, meaning the tablet does not
+   * own the token equal to the first token.
+   *
+   * @return {@code long} value representing first token.
+   */
+  public long getFirstToken();
+
+  /**
+   * Returns right endpoint of an interval. This interval is right-closed, which means that last
+   * token is owned by this tablet.
+   *
+   * @return {@code long} value representing last token.
+   */
+  public long getLastToken();
+
+  public Set<Node> getReplicaNodes();
+
+  /**
+   * Looks up the shard number for specific replica Node.
+   *
+   * @param node one of the replica nodes of this tablet.
+   * @return Shard number for the replica or -1 if no such Node found.
+   */
+  public int getShardForNode(Node node);
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/TabletMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/TabletMap.java
@@ -1,0 +1,37 @@
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.shaded.guava.common.annotations.Beta;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/** Holds all currently known tablet metadata. */
+@Beta
+public interface TabletMap {
+  /**
+   * Returns mapping from tables to the sets of their tablets.
+   *
+   * @return the Map keyed by (keyspace,table) pairs with Set of tablets as value type.
+   */
+  public ConcurrentMap<KeyspaceTableNamePair, ConcurrentSkipListSet<Tablet>> getMapping();
+
+  /**
+   * Adds a single tablet to the map. Handles removal of overlapping tablets.
+   *
+   * @param keyspace target keyspace
+   * @param table target table
+   * @param tablet tablet instance to add
+   */
+  public void addTablet(CqlIdentifier keyspace, CqlIdentifier table, Tablet tablet);
+
+  /**
+   * Returns {@link Tablet} instance
+   *
+   * @param keyspace tablet's keyspace
+   * @param table tablet's table
+   * @param token target token
+   * @return {@link Tablet} responsible for provided token or {@code null} if no such tablet is
+   *     present.
+   */
+  public Tablet getTablet(CqlIdentifier keyspace, CqlIdentifier table, long token);
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/Request.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/Request.java
@@ -96,6 +96,17 @@ public interface Request {
   CqlIdentifier getRoutingKeyspace();
 
   /**
+   * The table to use for tablet-aware routing. Infers the table from available ColumnDefinitions or
+   * {@code null} if it is not possible.
+   *
+   * @return
+   */
+  @Nullable
+  default CqlIdentifier getRoutingTable() {
+    return null;
+  }
+
+  /**
    * The partition key to use for token-aware routing.
    *
    * <p>For each request, the driver tries to determine a <em>routing keyspace</em> and a

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
@@ -472,6 +472,17 @@ public class DefaultBatchStatement implements BatchStatement {
     return null;
   }
 
+  @Override
+  public CqlIdentifier getRoutingTable() {
+    for (BatchableStatement<?> statement : statements) {
+      CqlIdentifier ks = statement.getRoutingTable();
+      if (ks != null) {
+        return ks;
+      }
+    }
+    return null;
+  }
+
   @NonNull
   @Override
   public BatchStatement setRoutingKeyspace(CqlIdentifier newRoutingKeyspace) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -301,6 +301,12 @@ public class DefaultBoundStatement implements BoundStatement {
     }
   }
 
+  @Override
+  public CqlIdentifier getRoutingTable() {
+    ColumnDefinitions definitions = preparedStatement.getVariableDefinitions();
+    return (definitions.size() == 0) ? null : definitions.get(0).getTable();
+  }
+
   @NonNull
   @Override
   public BoundStatement setRoutingKeyspace(@Nullable CqlIdentifier newRoutingKeyspace) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddTabletRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddTabletRefresh.java
@@ -1,0 +1,26 @@
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.Tablet;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+
+/** Updates tablet metadata by adding provided Tablet to the TabletMap. */
+public class AddTabletRefresh implements MetadataRefresh {
+
+  final CqlIdentifier keyspace;
+  final CqlIdentifier table;
+  final Tablet tablet;
+
+  public AddTabletRefresh(CqlIdentifier keyspace, CqlIdentifier table, Tablet tablet) {
+    this.keyspace = keyspace;
+    this.table = table;
+    this.tablet = tablet;
+  }
+
+  @Override
+  public Result compute(
+      DefaultMetadata oldMetadata, boolean tokenMapEnabled, InternalDriverContext context) {
+    oldMetadata.tabletMap.addTablet(keyspace, table, tablet);
+    return new Result(oldMetadata);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMap.java
@@ -1,0 +1,245 @@
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.data.TupleValue;
+import com.datastax.oss.driver.api.core.metadata.KeyspaceTableNamePair;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.Tablet;
+import com.datastax.oss.driver.api.core.metadata.TabletMap;
+import com.datastax.oss.driver.shaded.guava.common.annotations.Beta;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds currently known tablet mappings. Updated lazily through received custom payloads described
+ * in Scylla's CQL protocol extensions (tablets-routing-v1).
+ *
+ * <p>Thread-safety notes: This class uses ConcurrentMap and ConcurrentSkipListSet underneath. It is
+ * safe to have multiple threads accessing it. However, multiple modifications i.e. multiple calls
+ * of {@link DefaultTabletMap#addTablet(CqlIdentifier, CqlIdentifier, Tablet) will race with each
+ * other. This may result in unexpected state of this structure when used in a vacuum. For example
+ * it may end up containing overlapping tablet ranges.</p> <p>In actual use by the driver {@link
+ * MetadataManager} solves this by running modifications sequentially. It schedules them on {@link
+ * MetadataManager#adminExecutor}}'s thread.
+ */
+@Beta
+public class DefaultTabletMap implements TabletMap {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultTabletMap.class);
+
+  @NonNull
+  private final ConcurrentMap<KeyspaceTableNamePair, ConcurrentSkipListSet<Tablet>> mapping;
+
+  private DefaultTabletMap(
+      @NonNull ConcurrentMap<KeyspaceTableNamePair, ConcurrentSkipListSet<Tablet>> mapping) {
+    this.mapping = mapping;
+  }
+
+  public static DefaultTabletMap emptyMap() {
+    return new DefaultTabletMap(new ConcurrentHashMap<>());
+  }
+
+  @Override
+  @NonNull
+  public ConcurrentMap<KeyspaceTableNamePair, ConcurrentSkipListSet<Tablet>> getMapping() {
+    return mapping;
+  }
+
+  @Override
+  public Tablet getTablet(CqlIdentifier keyspace, CqlIdentifier table, long token) {
+    KeyspaceTableNamePair key = new KeyspaceTableNamePair(keyspace, table);
+    NavigableSet<Tablet> set = mapping.get(key);
+    if (set == null) {
+      LOG.trace(
+          "There is no tablets for {}.{} in current mapping. Returning null.", keyspace, table);
+      return null;
+    }
+    Tablet result = mapping.get(key).ceiling(DefaultTablet.malformedTablet(token));
+    if (result == null || result.getFirstToken() >= token) {
+      LOG.trace(
+          "Could not find tablet for {}.{} that owns token {}. Returning null.",
+          keyspace,
+          table,
+          token);
+      return null;
+    }
+    return result;
+  }
+
+  @Override
+  public void addTablet(CqlIdentifier keyspace, CqlIdentifier table, Tablet tablet) {
+    LOG.trace("Adding tablet for {}.{} with contents {}", keyspace, table, tablet);
+    KeyspaceTableNamePair ktPair = new KeyspaceTableNamePair(keyspace, table);
+
+    // Get existing tablets for given table
+    NavigableSet<Tablet> existingTablets =
+        mapping.computeIfAbsent(ktPair, k -> new ConcurrentSkipListSet<>());
+    // Single tablet token range is represented by (firstToken, lastToken] interval
+    // We need to do two sweeps: remove overlapping tablets by looking at lastToken of existing
+    // tablets
+    // and then by looking at firstToken of existing tablets. Currently, the tablets are sorted
+    // according
+    // to their lastTokens.
+
+    // First sweep: remove all tablets whose lastToken is inside this interval
+    Iterator<Tablet> it = existingTablets.headSet(tablet, true).descendingIterator();
+    while (it.hasNext()) {
+      Tablet nextTablet = it.next();
+      if (nextTablet.getLastToken() <= tablet.getFirstToken()) {
+        break;
+      }
+      it.remove();
+    }
+
+    // Second sweep: remove all tablets that have their lastToken greater than that of
+    // the tablet that is being added AND their firstToken is smaller than lastToken of new
+    // addition.
+    // After the first sweep, this theoretically should remove at most 1 tablet.
+    it = existingTablets.tailSet(tablet, true).iterator();
+    while (it.hasNext()) {
+      Tablet nextTablet = it.next();
+      if (nextTablet.getFirstToken() >= tablet.getLastToken()) {
+        break;
+      }
+      it.remove();
+    }
+
+    // Add new (now) non-overlapping tablet
+    existingTablets.add(tablet);
+  }
+
+  /**
+   * Represents a single tablet created from tablets-routing-v1 custom payload. Its {@code
+   * compareTo} implementation intentionally relies solely on {@code lastToken} in order to allow
+   * for quick lookup on sorted Collections based just on the token value. Its token range is
+   * (firstToken, lastToken], meaning firstToken is not included.
+   */
+  public static class DefaultTablet implements Tablet {
+    private final long firstToken;
+    private final long lastToken;
+    @NonNull private final Set<Node> replicaNodes;
+    @NonNull private final Map<Node, Integer> replicaShards;
+
+    @VisibleForTesting
+    DefaultTablet(
+        long firstToken,
+        long lastToken,
+        @NonNull Set<Node> replicaNodes,
+        @NonNull Map<Node, Integer> replicaShards) {
+      this.firstToken = firstToken;
+      this.lastToken = lastToken;
+      this.replicaNodes = replicaNodes;
+      this.replicaShards = replicaShards;
+    }
+
+    /**
+     * Creates a new instance of DefaultTablet based on provided decoded payload.
+     *
+     * @param tupleValue Decoded tablets-routing-v1 payload
+     * @param nodes Mapping of UUIDs to Node instances.
+     * @return the new DefaultTablet
+     */
+    public static DefaultTablet parseTabletPayloadV1(TupleValue tupleValue, Map<UUID, Node> nodes) {
+
+      long firstToken = tupleValue.getLong(0);
+      long lastToken = tupleValue.getLong(1);
+
+      Set<Node> replicaNodes = new HashSet<>();
+      Map<Node, Integer> replicaShards = new HashMap<>();
+      List<TupleValue> list = tupleValue.getList(2, TupleValue.class);
+      assert list != null;
+      for (TupleValue tuple : list) {
+        Node node = nodes.get(tuple.getUuid(0));
+        if (node != null) {
+          int shard = tuple.getInt(1);
+          replicaNodes.add(node);
+          replicaShards.put(node, shard);
+        }
+      }
+
+      return new DefaultTablet(firstToken, lastToken, replicaNodes, replicaShards);
+    }
+
+    /**
+     * Creates a {@link DefaultTablet} instance with given {@code lastToken}, identical {@code
+     * firstToken} and unspecified other fields. Used for lookup of sorted collections of proper
+     * {@link DefaultTablet}.
+     *
+     * @param lastToken
+     * @return New {@link DefaultTablet} object
+     */
+    public static DefaultTablet malformedTablet(long lastToken) {
+      return new DefaultTablet(
+          lastToken, lastToken, Collections.emptySet(), Collections.emptyMap());
+    }
+
+    @Override
+    public long getFirstToken() {
+      return firstToken;
+    }
+
+    @Override
+    public long getLastToken() {
+      return lastToken;
+    }
+
+    @Override
+    public Set<Node> getReplicaNodes() {
+      return replicaNodes;
+    }
+
+    @Override
+    public int getShardForNode(Node n) {
+      return replicaShards.getOrDefault(n, -1);
+    }
+
+    @Override
+    public String toString() {
+      return "DefaultTablet{"
+          + "firstToken="
+          + firstToken
+          + ", lastToken="
+          + lastToken
+          + ", replicaNodes="
+          + replicaNodes
+          + ", replicaShards="
+          + replicaShards
+          + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof DefaultTablet)) return false;
+      DefaultTablet that = (DefaultTablet) o;
+      return firstToken == that.firstToken
+          && lastToken == that.lastToken
+          && replicaNodes.equals(that.replicaNodes)
+          && replicaShards.equals(that.replicaShards);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(firstToken, lastToken, replicaNodes, replicaShards);
+    }
+
+    @Override
+    public int compareTo(Tablet tablet) {
+      return Long.compare(this.lastToken, tablet.getLastToken());
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefresh.java
@@ -65,8 +65,10 @@ public class RemoveNodeRefresh extends NodesRefresh {
       return new Result(oldMetadata);
     } else {
       LOG.debug("[{}] Removing node {}", logPrefix, removedNode);
+      LOG.debug("[{}] Tablet metadata will be wiped and rebuilt due to node removal.", logPrefix);
+      DefaultMetadata newerMetadata = oldMetadata.withTabletMap(DefaultTabletMap.emptyMap());
       return new Result(
-          oldMetadata.withNodes(newNodesBuilder.build(), tokenMapEnabled, false, null, context),
+          newerMetadata.withNodes(newNodesBuilder.build(), tokenMapEnabled, false, null, context),
           ImmutableList.of(NodeStateEvent.removed((DefaultNode) removedNode)));
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/TabletInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/TabletInfo.java
@@ -1,0 +1,33 @@
+package com.datastax.oss.driver.internal.core.protocol;
+
+import java.util.List;
+import java.util.Map;
+
+public class TabletInfo {
+  private static final String SCYLLA_TABLETS_STARTUP_OPTION_KEY = "TABLETS_ROUTING_V1";
+  private static final String SCYLLA_TABLETS_STARTUP_OPTION_VALUE = "";
+  public static final String TABLETS_ROUTING_V1_CUSTOM_PAYLOAD_KEY = "tablets-routing-v1";
+
+  private boolean enabled = false;
+
+  private TabletInfo(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  // Currently pertains only to TABLETS_ROUTING_V1
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public static TabletInfo parseTabletInfo(Map<String, List<String>> supported) {
+    List<String> values = supported.get(SCYLLA_TABLETS_STARTUP_OPTION_KEY);
+    return new TabletInfo(
+        values != null
+            && values.size() == 1
+            && values.get(0).equals(SCYLLA_TABLETS_STARTUP_OPTION_VALUE));
+  }
+
+  public static void addOption(Map<String, String> options) {
+    options.put(SCYLLA_TABLETS_STARTUP_OPTION_KEY, SCYLLA_TABLETS_STARTUP_OPTION_VALUE);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -239,18 +239,27 @@ public class DefaultSession implements CqlSession {
 
   @Nullable
   public DriverChannel getChannel(@NonNull Node node, @NonNull String logPrefix) {
-    return getChannel(node, logPrefix, null);
+    return getChannel(node, logPrefix, null, null);
   }
 
   @Nullable
   public DriverChannel getChannel(
       @NonNull Node node, @NonNull String logPrefix, @Nullable Token routingKey) {
+    return getChannel(node, logPrefix, routingKey, null);
+  }
+
+  @Nullable
+  public DriverChannel getChannel(
+      @NonNull Node node,
+      @NonNull String logPrefix,
+      @Nullable Token routingKey,
+      @Nullable Integer shardSuggestion) {
     ChannelPool pool = poolManager.getPools().get(node);
     if (pool == null) {
       LOG.trace("[{}] No pool to {}, skipping", logPrefix, node);
       return null;
     } else {
-      DriverChannel channel = pool.next(routingKey);
+      DriverChannel channel = pool.next(routingKey, shardSuggestion);
       if (channel == null) {
         LOG.trace("[{}] Pool returned no channel for {}, skipping", logPrefix, node);
         return null;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMapTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMapTest.java
@@ -1,0 +1,115 @@
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.mockito.Mockito.mock;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.KeyspaceTableNamePair;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.Tablet;
+import com.datastax.oss.driver.api.core.metadata.TabletMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.testng.Assert;
+
+public class DefaultTabletMapTest {
+
+  @Test
+  public void should_remove_overlapping_tablets() {
+    TabletMap tabletMap = DefaultTabletMap.emptyMap();
+    Tablet tablet1 =
+        new DefaultTabletMap.DefaultTablet(0, 1, Collections.emptySet(), Collections.emptyMap());
+    Tablet tablet2 =
+        new DefaultTabletMap.DefaultTablet(1, 2, Collections.emptySet(), Collections.emptyMap());
+    Tablet tablet3 =
+        new DefaultTabletMap.DefaultTablet(2, 3, Collections.emptySet(), Collections.emptyMap());
+    Tablet tablet4 =
+        new DefaultTabletMap.DefaultTablet(
+            -100, 100, Collections.emptySet(), Collections.emptyMap());
+
+    Tablet tablet5 =
+        new DefaultTabletMap.DefaultTablet(-10, 10, Collections.emptySet(), Collections.emptyMap());
+    Tablet tablet6 =
+        new DefaultTabletMap.DefaultTablet(9, 20, Collections.emptySet(), Collections.emptyMap());
+
+    KeyspaceTableNamePair key1 =
+        new KeyspaceTableNamePair(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"));
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet1);
+    Assert.assertEquals(tabletMap.getMapping().size(), 1);
+    Assert.assertEquals(tabletMap.getMapping().get(key1).size(), 1);
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet2);
+    Assert.assertEquals(tabletMap.getMapping().size(), 1);
+    Assert.assertEquals(tabletMap.getMapping().get(key1).size(), 2);
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet3);
+    Assert.assertEquals(tabletMap.getMapping().size(), 1);
+    Assert.assertEquals(tabletMap.getMapping().get(key1).size(), 3);
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet4);
+    Assert.assertEquals(tabletMap.getMapping().size(), 1);
+    Assert.assertEquals(tabletMap.getMapping().get(key1).size(), 1);
+
+    KeyspaceTableNamePair key2 =
+        new KeyspaceTableNamePair(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab2"));
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab2"), tablet5);
+    Assert.assertEquals(tabletMap.getMapping().size(), 2);
+    Assert.assertEquals(tabletMap.getMapping().get(key2).size(), 1);
+
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab2"), tablet6);
+    Assert.assertEquals(tabletMap.getMapping().size(), 2);
+    Assert.assertEquals(tabletMap.getMapping().get(key2).size(), 1);
+    Assert.assertTrue(tabletMap.getMapping().get(key2).contains(tablet6));
+    Assert.assertEquals(
+        tablet6,
+        tabletMap.getTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab2"), 10L));
+  }
+
+  @Test
+  public void tablet_range_should_not_include_first_token() {
+    TabletMap tabletMap = DefaultTabletMap.emptyMap();
+    Tablet tablet1 =
+        new DefaultTabletMap.DefaultTablet(
+            -123, 123, Collections.emptySet(), Collections.emptyMap());
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet1);
+    Tablet result =
+        tabletMap.getTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), -123);
+    Assert.assertEquals(result, null);
+  }
+
+  @Test
+  public void tablet_range_should_include_last_token() {
+    TabletMap tabletMap = DefaultTabletMap.emptyMap();
+    Tablet tablet1 =
+        new DefaultTabletMap.DefaultTablet(
+            -123, 456, Collections.emptySet(), Collections.emptyMap());
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet1);
+    Tablet result =
+        tabletMap.getTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), 456);
+    Assert.assertEquals(result, tablet1);
+  }
+
+  @Test
+  public void should_return_correct_shard() {
+    Node node1 = mock(DefaultNode.class);
+    Node node2 = mock(DefaultNode.class);
+    Set<Node> replicaNodes = new HashSet<Node>();
+    replicaNodes.add(node1);
+    replicaNodes.add(node2);
+    Map<Node, Integer> replicaShards = new HashMap<>();
+    replicaShards.put(node1, 1);
+    replicaShards.put(node2, 2);
+    TabletMap tabletMap = DefaultTabletMap.emptyMap();
+    Tablet tablet1 = new DefaultTabletMap.DefaultTablet(-123, 456, replicaNodes, replicaShards);
+    tabletMap.addTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), tablet1);
+    Tablet result =
+        tabletMap.getTablet(CqlIdentifier.fromCql("ks"), CqlIdentifier.fromCql("tab"), 456);
+    Assert.assertEquals(result.getShardForNode(node1), 1);
+    Assert.assertEquals(result.getShardForNode(node2), 2);
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DefaultMetadataTabletMapIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DefaultMetadataTabletMapIT.java
@@ -1,0 +1,151 @@
+package com.datastax.oss.driver.core.metadata;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.KeyspaceTableNamePair;
+import com.datastax.oss.driver.api.core.metadata.Tablet;
+import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.internal.core.protocol.TabletInfo;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ScyllaRequirement(
+    minOSS = "6.0.0",
+    minEnterprise = "2024.2",
+    description = "Needs to support tablets")
+@CassandraSkip(description = "Tablets are ScyllaDB-only extension")
+public class DefaultMetadataTabletMapIT {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultMetadataTabletMapIT.class);
+  private static final CustomCcmRule CCM_RULE =
+      CustomCcmRule.builder()
+          .withNodes(2)
+          .withCassandraConfiguration(
+              "experimental_features", "['consistent-topology-changes','tablets']")
+          .build();
+  private static final SessionRule<CqlSession> SESSION_RULE =
+      SessionRule.builder(CCM_RULE)
+          .withConfigLoader(
+              SessionUtils.configLoaderBuilder()
+                  .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(5))
+                  .build())
+          .build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  private static final int INITIAL_TABLETS = 32;
+  private static final int QUERIES = 1600;
+  private static final int REPLICATION_FACTOR = 2;
+  private static String KEYSPACE_NAME = "tabletsTest";
+  private static String TABLE_NAME = "tabletsTable";
+  private static String CREATE_KEYSPACE_QUERY =
+      "CREATE KEYSPACE IF NOT EXISTS "
+          + KEYSPACE_NAME
+          + " WITH replication = {'class': "
+          + "'NetworkTopologyStrategy', "
+          + "'replication_factor': '"
+          + REPLICATION_FACTOR
+          + "'}  AND durable_writes = true AND tablets = "
+          + "{'initial': "
+          + INITIAL_TABLETS
+          + "};";
+  private static String CREATE_TABLE_QUERY =
+      "CREATE TABLE IF NOT EXISTS "
+          + KEYSPACE_NAME
+          + "."
+          + TABLE_NAME
+          + " (pk int, ck int, PRIMARY KEY(pk, ck));";
+
+  @Test
+  public void should_receive_each_tablet_exactly_once() {
+    CqlSession session = SESSION_RULE.session();
+
+    session.execute(CREATE_KEYSPACE_QUERY);
+    session.execute(CREATE_TABLE_QUERY);
+
+    for (int i = 1; i <= QUERIES; i++) {
+      session.execute(
+          "INSERT INTO "
+              + KEYSPACE_NAME
+              + "."
+              + TABLE_NAME
+              + " (pk,ck) VALUES ("
+              + i
+              + ","
+              + i
+              + ");");
+    }
+
+    PreparedStatement preparedStatement =
+        session.prepare(
+            SimpleStatement.builder(
+                    "select pk,ck from "
+                        + KEYSPACE_NAME
+                        + "."
+                        + TABLE_NAME
+                        + " WHERE pk = ? AND ck = ?")
+                .setTracing(true)
+                .build());
+    // preparedStatement.enableTracing();
+    int counter = 0;
+    for (int i = 1; i <= QUERIES; i++) {
+      ResultSet rs = session.execute(preparedStatement.bind(i, i).setTracing(true));
+      Map<String, ByteBuffer> payload = rs.getExecutionInfo().getIncomingPayload();
+      if (payload.containsKey(TabletInfo.TABLETS_ROUTING_V1_CUSTOM_PAYLOAD_KEY)) {
+        counter++;
+      }
+    }
+
+    LOG.debug("Ran first set of queries");
+
+    // With enough queries we should hit a wrong node for each tablet exactly once.
+    Assert.assertEquals(INITIAL_TABLETS, counter);
+
+    ConcurrentMap<KeyspaceTableNamePair, ConcurrentSkipListSet<Tablet>> tabletMapping =
+        session.getMetadata().getTabletMap().getMapping();
+    KeyspaceTableNamePair ktPair =
+        new KeyspaceTableNamePair(
+            CqlIdentifier.fromCql(KEYSPACE_NAME), CqlIdentifier.fromCql(TABLE_NAME));
+    Assert.assertTrue(tabletMapping.containsKey(ktPair));
+
+    Set<Tablet> tablets = tabletMapping.get(ktPair);
+    Assert.assertEquals(INITIAL_TABLETS, tablets.size());
+
+    for (Tablet tab : tablets) {
+      Assert.assertEquals(REPLICATION_FACTOR, tab.getReplicaNodes().size());
+    }
+
+    // All tablet information should be available by now (unless for some reason cluster did sth on
+    // its own)
+    // We should not receive any tablet payloads now, since they are sent only on mismatch.
+    for (int i = 1; i <= QUERIES; i++) {
+
+      ResultSet rs = session.execute(preparedStatement.bind(i, i));
+      Map<String, ByteBuffer> payload = rs.getExecutionInfo().getIncomingPayload();
+
+      if (payload.containsKey(TabletInfo.TABLETS_ROUTING_V1_CUSTOM_PAYLOAD_KEY)) {
+        throw new RuntimeException(
+            "Received non empty payload with tablets routing information: " + payload);
+      }
+    }
+  }
+}


### PR DESCRIPTION
(Copied over from commit message)
Introduces basic tablets support for version 4.x of the driver.
Metadata about tablets will be kept in TabletMap that gets continuously updated
through the tablets-routing-v1 extension. Each time the BoundStatement targets 
the wrong node and shard combination the server supporting tablets should
respond with tablet metadata inside custom payload of its response. 
This metadata will be transparently processed and used for future queries.

Tablets metadata will by enabled by default. Until now driver was using
TokenMaps to choose replicas and appropriate shards. Having a token was enough
information to do that. Now driver will first attempt tablet-based lookup
and only after failing to find corresponding tablet it will defer to TokenMap
lookup. Since to find a correct tablet besides the token we need the keyspace
and table names, many of the methods were extended to also accept those
as parameters.

RequestHandlerTestHarness was adjusted to mock also MetadataManager.
Before it used to mock only `session.getMetadata()` call but the same can
be obtained by `context.getMetadataManager().getMetadata()`. Using the
second method was causing test failures.

Fixes #268