### PR TITLE
Version bump of Bouncy Castle packages

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -179,20 +179,20 @@
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.76</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.76</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcutil-jdk15on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcutil-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>1.76</version>
         </dependency>
 
 


### PR DESCRIPTION
Since we are abandoning Java 6 we are switching to jdk18on packages. This is necessary to appease security scanners.