### PR TITLE
3.x dependencies bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <netty-tcnative.artifact>netty-tcnative</netty-tcnative.artifact>
         <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
-        <snappy.version>1.1.2.6</snappy.version>
+        <snappy.version>1.1.10.5</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
         <jackson.version>2.15.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
-        <netty.version>4.1.94.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty-tcnative.artifact>netty-tcnative</netty-tcnative.artifact>
         <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>


### PR DESCRIPTION
Upgrades netty and snappy since both got marked by CVE scanner.