### PR TITLE
Switch to using Python 3.11 in CI

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Fetch Scylla and Cassandra versions
         id: fetch-versions
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Setup environment
         run: |
@@ -192,7 +192,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Setup environment
         run: |


### PR DESCRIPTION
scylla-ccm, which we use in integration tests does not support Python 3.12 (refs scylladb/scylla-ccm#537). Switch to using Python 3.11 specifically to fix the compatibility problem.