### PR TITLE
[dtest]: test_connectivity_with_cassandra_stress failed with java.lang.NoSuchMethodError

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ScyllaCloudDatacenter.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ScyllaCloudDatacenter.java
@@ -74,7 +74,8 @@ class ScyllaCloudDatacenter {
 
   public InetSocketAddress getServer() {
     HostAndPort parsedServer = HostAndPort.fromString(server);
-    return InetSocketAddress.createUnresolved(parsedServer.getHostText(), parsedServer.getPort());
+    return InetSocketAddress.createUnresolved(
+        GuavaCompatibility.INSTANCE.getHost(parsedServer), parsedServer.getPort());
   }
 
   public String getNodeDomain() {


### PR DESCRIPTION


Following the changes made in
https://github.com/scylladb/scylla-tools-java/pull/369, dtest is now failing during `test_connectivity_with_cassandra_stress` with the following error:
```
stderr: java.lang.NoSuchMethodError: 'java.lang.String com.google.common.net.HostAndPort.getHostText()'
	at com.datastax.driver.core.ScyllaCloudDatacenter.getServer(ScyllaCloudDatacenter.java:77)
	at com.datastax.driver.core.Cluster$Builder.withScyllaCloudConnectionConfig(Cluster.java:1404)
	at com.datastax.driver.core.Cluster$Builder.withScyllaCloudConnectionConfig(Cluster.java:1397)
	at com.datastax.driver.core.Cluster$Builder.withScyllaCloudConnectionConfig(Cluster.java:1393)
	at com.datastax.driver.core.Cluster$Builder.withScyllaCloudConnectionConfig(Cluster.java:1389)
	at org.apache.cassandra.stress.util.JavaDriverClient.connect(JavaDriverClient.java:181)
	at org.apache.cassandra.stress.settings.StressSettings.getJavaDriverClient(StressSettings.java:213)
	at org.apache.cassandra.stress.settings.SettingsSchema.createKeySpacesNative(SettingsSchema.java:84)
	at org.apache.cassandra.stress.settings.SettingsSchema.createKeySpaces(SettingsSchema.java:74)
	at org.apache.cassandra.stress.settings.StressSettings.maybeCreateKeyspaces(StressSettings.java:230)
	at org.apache.cassandra.stress.StressAction.run(StressAction.java:58)
	at org.apache.cassandra.stress.Stress.run(Stress.java:143)
	at org.apache.cassandra.stress.Stress.main(Stress.java:62)
```