### PR TITLE
ci: Set python version to 3.11

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Fetch Scylla and Cassandra versions
         id: fetch-versions
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Setup environment
         run: |
@@ -192,7 +192,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Setup environment
         run: |


### PR DESCRIPTION
Python 3.12 has some compatability issues with scylla-ccm. Setting the python version to 3.11 should workaround the issue for now.