### PR TITLE
Update regex in MapperUDTTest

### DIFF
--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -560,8 +560,9 @@ public class MapperUDTTest extends CCMTestsSupport {
     } catch (InvalidQueryException e) {
       // Error message varies by C* version.
       assertThat(e.getMessage())
+          // "Unrecognized name mainaddress" since scylla-5.4.0-rc0 and scylla-2024.1.0-rc1
           .matches(
-              "(Undefined name mainaddress in selection clause|Undefined column name mainaddress.*)");
+              "(Unrecognized name mainaddress|Undefined name mainaddress in selection clause|Undefined column name mainaddress.*)");
     }
     // trying to use a new mapper
     try {


### PR DESCRIPTION
The test method `should_throw_error_when_table_is_altered_and_is_not_compatible_anymore()` fails due to Scylla using different error message since 5.4.0 and 2024.1.0. This change adjusts the test regex accordingly.