### PR TITLE
docs: fix changelog headings

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -632,21 +632,21 @@ changelog](https://docs.datastax.com/en/developer/java-driver-dse/latest/changel
 - [bug] JAVA-1499: Wait for load balancing policy at cluster initialization
 - [new feature] JAVA-1495: Add prepared statements
 
-## 3.11.3
+### 3.11.3
 
 - [improvement] JAVA-3023: Upgrade Netty to 4.1.77, 3.x edition
 
-## 3.11.2
+### 3.11.2
 
 - [improvement] JAVA-3008: Upgrade Netty to 4.1.75, 3.x edition
 - [improvement] JAVA-2984: Upgrade Jackson to resolve high-priority CVEs
 
-## 3.11.1
+### 3.11.1
 
 - [bug] JAVA-2967: Support native transport peer information for DSE 6.8.
 - [bug] JAVA-2976: Support missing protocol v5 error codes CAS_WRITE_UNKNOWN, CDC_WRITE_FAILURE.
 
-## 3.11.0
+### 3.11.0
 
 - [improvement] JAVA-2705: Remove protocol v5 beta status, add v6-beta.
 - [bug] JAVA-2923: Detect and use Guava's new HostAndPort.getHost method.


### PR DESCRIPTION
Ensure the changelog headings are formatted properly to prevent them from appearing in the right-side navigation. This

![image](https://github.com/scylladb/java-driver/assets/9107969/e188e3b4-42eb-4dbd-b177-ad33d23ca8b0)

## Next steps

Consider applying this fix to the latest stable documentation branch `scylla-4.15.0.x`.
