### PR TITLE
Add BYPASS CACHE and USING TIMEOUT capabilities to mapper

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectBypassCacheIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectBypassCacheIT.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.MapperBuilder;
+import com.datastax.oss.driver.api.mapper.annotations.ClusteringColumn;
+import com.datastax.oss.driver.api.mapper.annotations.Computed;
+import com.datastax.oss.driver.api.mapper.annotations.CqlName;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.Insert;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.Objects;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+@CassandraSkip(description = "BYPASS CACHE clause is a ScyllaDB CQL Extension")
+@ScyllaRequirement(
+    minOSS = "3.1.0",
+    minEnterprise = "2020.1.0",
+    description = "Based on labels attached to ecf3f92ec7")
+public class SelectBypassCacheIT {
+
+  private static final CcmRule CCM_RULE = CcmRule.getInstance();
+  private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  private static SimpleDao dao;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = SESSION_RULE.session();
+
+    for (String query :
+        ImmutableList.of("CREATE TABLE simple (k int, cc int, v int, PRIMARY KEY (k, cc))")) {
+      session.execute(
+          SimpleStatement.builder(query).setExecutionProfile(SESSION_RULE.slowProfile()).build());
+    }
+
+    TestMapper mapper = TestMapper.builder(session).build();
+    dao = mapper.simpleDao(SESSION_RULE.keyspace());
+
+    for (int k = 0; k < 2; k++) {
+      for (int cc = 0; cc < 10; cc++) {
+        dao.insert(new Simple(k, cc, 1));
+      }
+    }
+  }
+
+  @Test
+  public void should_select_with_limit() {
+    PagingIterable<Simple> elements = dao.selectWithLimit(10);
+    assertThat(elements.isFullyFetched()).isTrue();
+    assertThat(elements.getAvailableWithoutFetching()).isEqualTo(10);
+
+    elements = dao.selectWithLimit(0, 5);
+    assertThat(elements.isFullyFetched()).isTrue();
+    assertThat(elements.getAvailableWithoutFetching()).isEqualTo(5);
+
+    elements = dao.selectWithLimit(0, 0, 1);
+    assertThat(elements.isFullyFetched()).isTrue();
+    assertThat(elements.getAvailableWithoutFetching()).isEqualTo(1);
+  }
+
+  @Test
+  public void should_select_with_order_by() {
+    PagingIterable<Simple> elements = dao.selectByCcDesc(0);
+    int previousCc = Integer.MAX_VALUE;
+    for (Simple element : elements) {
+      assertThat(element.getCc()).isLessThan(previousCc);
+      previousCc = element.getCc();
+    }
+  }
+
+  @Test
+  public void should_select_with_group_by() {
+    PagingIterable<Sum> sums = dao.selectSumByK();
+    assertThat(sums.all()).hasSize(2).containsOnly(new Sum(0, 10), new Sum(1, 10));
+  }
+
+  @Test
+  public void should_select_with_allow_filtering() {
+    PagingIterable<Simple> elements = dao.selectByCc(1);
+    assertThat(elements.all()).hasSize(2).containsOnly(new Simple(0, 1, 1), new Simple(1, 1, 1));
+  }
+
+  @Test
+  public void should_select_with_bypass_cache() {
+    // BYPASS CACHE is transparent for the driver - this just checks for exceptions
+    PagingIterable<Simple> result = dao.selectWithBypassCache(0, 0);
+    assertThat(result.all()).hasSize(1).containsOnly(new Simple(0, 0, 1));
+    System.out.println(result.getExecutionInfo().getRequest());
+  }
+
+  @Mapper
+  public interface TestMapper {
+    @DaoFactory
+    SimpleDao simpleDao(@DaoKeyspace CqlIdentifier keyspace);
+
+    static MapperBuilder<TestMapper> builder(CqlSession session) {
+      return new SelectBypassCacheIT_TestMapperBuilder(session);
+    }
+  }
+
+  @Dao
+  public interface SimpleDao {
+    @Insert
+    void insert(Simple simple);
+
+    @Select(limit = ":l")
+    PagingIterable<Simple> selectWithLimit(@CqlName("l") int l);
+
+    @Select(limit = ":l")
+    PagingIterable<Simple> selectWithLimit(int k, @CqlName("l") int l);
+
+    /**
+     * Contrived since the query will return at most a single row, but this is just to check that
+     * {@code l} doesn't need an explicit name when the full primary key is provided.
+     */
+    @Select(limit = ":l", bypassCache = true)
+    PagingIterable<Simple> selectWithLimit(int k, int cc, int l);
+
+    @Select(orderBy = "cc DESC", bypassCache = true)
+    PagingIterable<Simple> selectByCcDesc(int k);
+
+    @Select(groupBy = "k", bypassCache = true)
+    PagingIterable<Sum> selectSumByK();
+
+    @Select(customWhereClause = "cc = :cc", allowFiltering = true, bypassCache = true)
+    PagingIterable<Simple> selectByCc(int cc);
+
+    @Select(bypassCache = true)
+    PagingIterable<Simple> selectWithBypassCache(int k, int cc);
+  }
+
+  @Entity
+  public static class Simple {
+    @PartitionKey private int k;
+    @ClusteringColumn private int cc;
+    private int v;
+
+    public Simple() {}
+
+    public Simple(int k, int cc, int v) {
+      this.k = k;
+      this.cc = cc;
+      this.v = v;
+    }
+
+    public int getK() {
+      return k;
+    }
+
+    public void setK(int k) {
+      this.k = k;
+    }
+
+    public int getCc() {
+      return cc;
+    }
+
+    public void setCc(int cc) {
+      this.cc = cc;
+    }
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(int v) {
+      this.v = v;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) {
+        return true;
+      } else if (other instanceof Simple) {
+        Simple that = (Simple) other;
+        return this.k == that.k && this.cc == that.cc && this.v == that.v;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(k, cc, v);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Simple(%d, %d, %d)", k, cc, v);
+    }
+  }
+
+  @Entity
+  @CqlName("simple")
+  public static class Sum {
+    private int k;
+
+    @Computed("sum(v)")
+    private int value;
+
+    public Sum() {}
+
+    public Sum(int k, int value) {
+      this.k = k;
+      this.value = value;
+    }
+
+    public int getK() {
+      return k;
+    }
+
+    public void setK(int k) {
+      this.k = k;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+    public void setValue(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) {
+        return true;
+      } else if (other instanceof Sum) {
+        Sum that = (Sum) other;
+        return this.k == that.k && this.value == that.value;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(k, value);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Sum(%d, %d)", k, value);
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UsingTimeoutIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UsingTimeoutIT.java
@@ -1,0 +1,178 @@
+package com.datastax.oss.driver.mapper;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
+import com.datastax.oss.driver.api.core.servererrors.ReadTimeoutException;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.Insert;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.mapper.annotations.Update;
+import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+@CassandraSkip(description = "USING TIMEOUT is a ScyllaDB CQL Extension")
+@ScyllaRequirement(
+    minOSS = "4.4.0",
+    minEnterprise = "2022.1.0",
+    description = "According to labels attached to 39afe14ad4")
+public class UsingTimeoutIT {
+  private static final CcmRule CCM_RULE = CcmRule.getInstance();
+  private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  private static TimeoutTestEntityDao dao;
+  private static TimeoutTestMapper mapper;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = SESSION_RULE.session();
+
+    session.execute(
+        SimpleStatement.newInstance(
+                "CREATE TABLE timeout_test_entity(id int, col int, PRIMARY KEY (id))")
+            .setExecutionProfile(SESSION_RULE.slowProfile()));
+
+    mapper = new UsingTimeoutIT_TimeoutTestMapperBuilder(session).build();
+    dao = mapper.timeoutTestEntityDao(SESSION_RULE.keyspace());
+  }
+
+  @Test
+  public void should_throw_when_negative_timeouts() {
+    assertThrows(
+        "Timeout values must be non-negative",
+        InvalidQueryException.class,
+        () -> dao.saveNegative(new TimeoutTestEntity(1, 1)));
+    assertThrows(
+        "Timeout values must be non-negative",
+        InvalidQueryException.class,
+        () -> dao.findByIdNegative(1));
+    assertThrows(
+        "Timeout values must be non-negative",
+        InvalidQueryException.class,
+        () -> dao.updateNegative(new TimeoutTestEntity(1, 2)));
+  }
+
+  @Test
+  public void should_pass_when_valid_timeouts() {
+    ResultSet saveResult = dao.save(new TimeoutTestEntity(2, 1));
+    assertTrue(saveResult.getExecutionInfo().getErrors().isEmpty());
+    assertTrue(saveResult.getExecutionInfo().getWarnings().isEmpty());
+
+    PagingIterable<TimeoutTestEntity> selectResult = dao.findById(2);
+    assertTrue(selectResult.getExecutionInfo().getErrors().isEmpty());
+    assertTrue(selectResult.getExecutionInfo().getWarnings().isEmpty());
+
+    ResultSet updateResult = dao.update(new TimeoutTestEntity(2, 2));
+    assertTrue(updateResult.getExecutionInfo().getErrors().isEmpty());
+    assertTrue(updateResult.getExecutionInfo().getWarnings().isEmpty());
+  }
+
+  @Test
+  public void should_time_out_when_set_to_millisecond() {
+    for (int i = 0; i < 10004; i++) {
+      dao.save(new TimeoutTestEntity(i, 1));
+    }
+    assertThrows(ReadTimeoutException.class, () -> dao.allInMillisecond());
+  }
+
+  @Test
+  public void should_fail_with_too_low_granularity() {
+    assertThrows(
+        "Timeout values cannot have granularity finer than milliseconds",
+        InvalidQueryException.class,
+        () -> dao.allInNanosecond());
+    assertThrows(
+        "Timeout values cannot have granularity finer than milliseconds",
+        InvalidQueryException.class,
+        () -> dao.allInMicrosecond());
+  }
+
+  @Entity
+  public static class TimeoutTestEntity {
+    @PartitionKey private Integer id;
+    private Integer col;
+
+    public TimeoutTestEntity() {}
+
+    public TimeoutTestEntity(Integer id, Integer col) {
+      this.id = id;
+      this.col = col;
+    }
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public Integer getCol() {
+      return col;
+    }
+
+    public void setCol(Integer col) {
+      this.col = col;
+    }
+  }
+
+  @Dao
+  public interface TimeoutTestEntityDao {
+    @Select(usingTimeout = "-5s")
+    PagingIterable<TimeoutTestEntity> findByIdNegative(Integer id);
+
+    @Insert(usingTimeout = "-5s")
+    ResultSet saveNegative(TimeoutTestEntity timeoutTestEntity);
+
+    @Update(usingTimeout = "-5s")
+    ResultSet updateNegative(TimeoutTestEntity timeoutTestEntity);
+
+    @Select(usingTimeout = "5m")
+    PagingIterable<TimeoutTestEntity> findById(Integer id);
+
+    @Insert(usingTimeout = "5m")
+    ResultSet save(TimeoutTestEntity timeoutTestEntity);
+
+    @Update(usingTimeout = "5m")
+    ResultSet update(TimeoutTestEntity timeoutTestEntity);
+
+    @Select(usingTimeout = "1ns")
+    PagingIterable<TimeoutTestEntity> allInNanosecond();
+
+    @Select(usingTimeout = "1us")
+    PagingIterable<TimeoutTestEntity> allInMicrosecond();
+
+    @Select(usingTimeout = "1ms")
+    PagingIterable<TimeoutTestEntity> allInMillisecond();
+  }
+
+  @Mapper
+  public interface TimeoutTestMapper {
+    @DaoFactory
+    TimeoutTestEntityDao timeoutTestEntityDao(@DaoKeyspace CqlIdentifier keyspace);
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
@@ -193,6 +193,7 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
 
     maybeAddTtl(annotation.ttl(), methodBuilder);
     maybeAddTimestamp(annotation.timestamp(), methodBuilder);
+    maybeAddTimeout(annotation.usingTimeout(), methodBuilder);
 
     methodBuilder.addCode(".build()$];\n");
   }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGenerator.java
@@ -239,6 +239,7 @@ public class DaoSelectMethodGenerator extends DaoMethodGenerator {
         "perPartitionLimit",
         "perPartitionLimit",
         methodBuilder);
+    maybeAddTimeout(annotation.usingTimeout(), methodBuilder);
     for (String orderingSpec : annotation.orderBy()) {
       addOrdering(orderingSpec, methodBuilder);
     }
@@ -247,6 +248,9 @@ public class DaoSelectMethodGenerator extends DaoMethodGenerator {
     }
     if (annotation.allowFiltering()) {
       methodBuilder.addCode(".allowFiltering()");
+    }
+    if (annotation.bypassCache()) {
+      methodBuilder.addCode(".bypassCache()");
     }
     methodBuilder.addCode(".build();$]\n");
   }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
@@ -202,6 +202,7 @@ public class DaoUpdateMethodGenerator extends DaoMethodGenerator {
         methodBuilder, requestName, helperFieldName, annotation.customWhereClause());
     maybeAddTtl(annotation.ttl(), methodBuilder);
     maybeAddTimestamp(annotation.timestamp(), methodBuilder);
+    maybeAddTimeout(annotation.usingTimeout(), methodBuilder);
     methodBuilder.addCode(")");
     maybeAddIfClause(methodBuilder, annotation);
 

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
@@ -15,8 +15,12 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
+import static org.mockito.Mockito.mock;
+
 import com.datastax.oss.driver.api.mapper.annotations.Insert;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
 import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
@@ -64,6 +68,20 @@ public class DaoInsertMethodGeneratorTest extends DaoMethodGeneratorTest {
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
             .addParameter(ParameterSpec.builder(ENTITY_CLASS_NAME, "entity").build())
             .returns(TypeName.INT)
+            .build(),
+      },
+      {
+        "Invalid "
+            + "USING TIMEOUT"
+            + " value: "
+            + "'15zz' is not a bind marker name and can't be parsed as a CqlDuration "
+            + "either",
+        MethodSpec.methodBuilder("select")
+            .addAnnotation(
+                AnnotationSpec.builder(Insert.class).addMember("usingTimeout", "\"15zz\"").build())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addParameter(ParameterSpec.builder(ENTITY_CLASS_NAME, "entity").build())
+            .returns(TypeName.VOID)
             .build(),
       },
     };
@@ -124,5 +142,15 @@ public class DaoInsertMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
     };
+  }
+
+  @Test
+  @UseDataProvider("usingTimeoutProvider") // superclass method
+  public void should_process_timeout(String timeout, CodeBlock expected) {
+    // given
+    ProcessorContext processorContext = mock(ProcessorContext.class);
+    DaoMethodGenerator daoInsertMethodGenerator =
+        new DaoInsertMethodGenerator(null, null, null, null, processorContext);
+    super.should_process_timeout(daoInsertMethodGenerator, timeout, expected);
   }
 }

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGeneratorTest.java
@@ -15,12 +15,18 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
+import static org.mockito.Mockito.mock;
+
 import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import javax.lang.model.element.Modifier;
 import org.junit.Test;
@@ -70,6 +76,42 @@ public class DaoSelectMethodGeneratorTest extends DaoMethodGeneratorTest {
             .returns(ENTITY_CLASS_NAME)
             .build(),
       },
+      {
+        "Invalid "
+            + "USING TIMEOUT"
+            + " value: "
+            + "'15zz' is not a bind marker name and can't be parsed as a CqlDuration "
+            + "either",
+        MethodSpec.methodBuilder("select")
+            .addAnnotation(
+                AnnotationSpec.builder(Select.class).addMember("usingTimeout", "\"15zz\"").build())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addParameter(UUID.class, "id")
+            .returns(ENTITY_CLASS_NAME)
+            .build(),
+      },
     };
+  }
+
+  @Test
+  @UseDataProvider("usingTimeoutProvider") // superclass method
+  public void should_process_timeout(String timeout, CodeBlock expected) {
+    // given
+    ProcessorContext processorContext = mock(ProcessorContext.class);
+    DaoMethodGenerator daoSelectMethodGenerator =
+        new DaoSelectMethodGenerator(null, null, null, null, processorContext);
+    super.should_process_timeout(daoSelectMethodGenerator, timeout, expected);
+  }
+
+  @Test
+  public void should_process_bypass_cache() {
+    System.out.println("aaa");
+    System.out.println(
+        MethodSpec.methodBuilder("select")
+            .addAnnotation(
+                AnnotationSpec.builder(Select.class).addMember("bypassCache", "true").build())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .returns(ParameterizedTypeName.get(CompletionStage.class, Integer.class))
+            .build());
   }
 }

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
@@ -89,6 +89,20 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
             .returns(TypeName.VOID)
             .build(),
       },
+      {
+        "Invalid "
+            + "USING TIMEOUT"
+            + " value: "
+            + "'15zz' is not a bind marker name and can't be parsed as a CqlDuration "
+            + "either",
+        MethodSpec.methodBuilder("select")
+            .addAnnotation(
+                AnnotationSpec.builder(Update.class).addMember("usingTimeout", "\"15zz\"").build())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addParameter(ParameterSpec.builder(ENTITY_CLASS_NAME, "entity").build())
+            .returns(TypeName.VOID)
+            .build(),
+      },
     };
   }
 
@@ -150,6 +164,16 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
 
     // then
     assertThat(builder.build().code).isEqualTo(expected);
+  }
+
+  @Test
+  @UseDataProvider("usingTimeoutProvider") // superclass method
+  public void should_process_timeout(String timeout, CodeBlock expected) {
+    // given
+    ProcessorContext processorContext = mock(ProcessorContext.class);
+    DaoMethodGenerator daoUpdateMethodGenerator =
+        new DaoUpdateMethodGenerator(null, null, null, null, processorContext);
+    super.should_process_timeout(daoUpdateMethodGenerator, timeout, expected);
   }
 
   @DataProvider

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
@@ -151,6 +151,21 @@ public @interface Insert {
   String ttl() default "";
 
   /**
+   * The timeout to use in the generated INSERT query. Equivalent to {@code USING TIMEOUT
+   * <duration>} clause.
+   *
+   * <p>If this starts with ":", it is interpreted as a named placeholder (that must have a
+   * corresponding parameter in the method signature). Otherwise, it must be a String representing a
+   * valid CqlDuration.
+   *
+   * <p>If the placeholder name is invalid or the literal can't be parsed as a CqlDuration
+   * (according to the rules of {@link
+   * com.datastax.oss.driver.api.core.data.CqlDuration#from(String)}), the mapper will issue a
+   * compile-time error.
+   */
+  String usingTimeout() default "";
+
+  /**
    * The timestamp to use in the generated INSERT query.
    *
    * <p>If this starts with ":", it is interpreted as a named placeholder (that must have a

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
@@ -66,13 +66,13 @@ import java.util.function.UnaryOperator;
  * </pre>
  *
  * The generated SELECT query can be further customized with {@link #limit()}, {@link
- * #perPartitionLimit()}, {@link #orderBy()}, {@link #groupBy()} and {@link #allowFiltering()}. Some
- * of these clauses can also contain placeholders whose values will be provided through additional
- * method parameters. Note that it is sometimes not possible to determine if a parameter is a
- * primary key component or a placeholder value; therefore the rule is that <b>if your method takes
- * a partial primary key, the first parameter that is not a primary key component must be explicitly
- * annotated with {@link CqlName}.</b> For example if the primary key is {@code ((day int, hour int,
- * minute int), ts timestamp)}:
+ * #perPartitionLimit()}, {@link #orderBy()}, {@link #groupBy()}, {@link #allowFiltering()} and
+ * {@link #bypassCache()}. Some of these clauses can also contain placeholders whose values will be
+ * provided through additional method parameters. Note that it is sometimes not possible to
+ * determine if a parameter is a primary key component or a placeholder value; therefore the rule is
+ * that <b>if your method takes a partial primary key, the first parameter that is not a primary key
+ * component must be explicitly annotated with {@link CqlName}.</b> For example if the primary key
+ * is {@code ((day int, hour int, minute int), ts timestamp)}:
  *
  * <pre>
  * // Annotate 'l' so that it's not mistaken for the second PK component
@@ -201,4 +201,22 @@ public @interface Select {
 
   /** Whether to add an ALLOW FILTERING clause to the SELECT query. */
   boolean allowFiltering() default false;
+
+  /** Whether to add BYPASS CACHE clause to the SELECT query. */
+  boolean bypassCache() default false;
+
+  /**
+   * The timeout to use in the generated SELECT query. Equivalent to {@code USING TIMEOUT
+   * <duration>} clause.
+   *
+   * <p>If this starts with ":", it is interpreted as a named placeholder (that must have a
+   * corresponding parameter in the method signature). Otherwise, it must be a String representing a
+   * valid CqlDuration.
+   *
+   * <p>If the placeholder name is invalid or the literal can't be parsed as a CqlDuration
+   * (according to the rules of {@link
+   * com.datastax.oss.driver.api.core.data.CqlDuration#from(String)}), the mapper will issue a
+   * compile-time error.
+   */
+  String usingTimeout() default "";
 }

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
@@ -207,6 +207,21 @@ public @interface Update {
   String timestamp() default "";
 
   /**
+   * The timeout to use in the generated UPDATE query. Equivalent to {@code USING TIMEOUT
+   * <duration>} clause.
+   *
+   * <p>If this starts with ":", it is interpreted as a named placeholder (that must have a
+   * corresponding parameter in the method signature). Otherwise, it must be a String representing a
+   * valid CqlDuration.
+   *
+   * <p>If the placeholder name is invalid or the literal can't be parsed as a CqlDuration
+   * (according to the rules of {@link
+   * com.datastax.oss.driver.api.core.data.CqlDuration#from(String)}), the mapper will issue a
+   * compile-time error.
+   */
+  String usingTimeout() default "";
+
+  /**
    * How to handle null entity properties during the update.
    *
    * <p>This defaults either to the {@link DefaultNullSavingStrategy DAO-level strategy} (if set),


### PR DESCRIPTION
Now Select, Insert and Update annotations used in DAOs can specify (usingTimeout = "durationString") in order to use Scylla CQL extension timeouts.

Select queries can also use (bypassCache = true).