### PR TITLE
Bump jnr-posix version to 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <!-- Note:  When upgrading either jnr-ffi or jnr-posix, ensure that the versions are compatible.
              JNR has broken compatibility between minor versions in the past. -->
-        <jnr-ffi.version>2.1.7</jnr-ffi.version>
-        <jnr-posix.version>3.0.44</jnr-posix.version>
+        <jnr-ffi.version>2.2.5</jnr-ffi.version>
+        <jnr-posix.version>3.1.8</jnr-posix.version>
         <groovy.version>2.4.7</groovy.version>
         <jax-rs.version>2.0.1</jax-rs.version>
         <jersey.version>2.23.1</jersey.version>


### PR DESCRIPTION
fix CWE-416 https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422