### PR TITLE
Deps: update org.bouncycastle components from 1.76 to 1.78.1

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -180,19 +180,19 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.78.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.78.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcutil-jdk15on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.78.1</version>
         </dependency>
 
 


### PR DESCRIPTION
Fixes: https://github.com/scylladb/java-driver/issues/286