### PR TITLE
ci: Stop fetching Scylla RC releases for CI tests

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -104,7 +104,7 @@ jobs:
         id: fetch-versions
         run: |
           pip3 install -r ci/requirements.txt
-          echo "scylla-integration-tests-versions=$(python3 ci/version_fetch.py scylla-oss-stable:2 scylla-oss-rc scylla-enterprise-stable:2 scylla-enterprise-rc)" >> $GITHUB_OUTPUT
+          echo "scylla-integration-tests-versions=$(python3 ci/version_fetch.py scylla-oss-stable:2 scylla-enterprise-stable:2 scylla-enterprise-rc)" >> $GITHUB_OUTPUT
           echo "cassandra-integration-tests-versions=$(python3 ci/version_fetch.py cassandra3-stable:1)" >> $GITHUB_OUTPUT
 
     outputs:


### PR DESCRIPTION
Change CI version fetcher to pull only released versions as the RC releases may be unstable to be tested with. These releases should be tested as part of driver-matrix tests of those release cycle.

Fixes: #290