### PR TITLE
Fix session leak in PeersV2NodeRefreshIT test

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
@@ -56,17 +56,18 @@ public class PeersV2NodeRefreshIT {
   @Test
   public void should_successfully_send_peers_v2_node_refresh_query()
       throws InterruptedException, ExecutionException {
-    CqlSession session =
-        CqlSession.builder().addContactPoint(cluster.node(1).inetSocketAddress()).build();
-    Node node = findNonControlNode(session);
-    ((InternalDriverContext) session.getContext())
-        .getMetadataManager()
-        .refreshNode(node)
-        .toCompletableFuture()
-        .get();
-    assertThat(hasNodeRefreshQuery())
-        .describedAs("Expecting peers_v2 node refresh query to be present but it wasn't")
-        .isTrue();
+    try (CqlSession session =
+        CqlSession.builder().addContactPoint(cluster.node(1).inetSocketAddress()).build()) {
+      Node node = findNonControlNode(session);
+      ((InternalDriverContext) session.getContext())
+          .getMetadataManager()
+          .refreshNode(node)
+          .toCompletableFuture()
+          .get();
+      assertThat(hasNodeRefreshQuery())
+          .describedAs("Expecting peers_v2 node refresh query to be present but it wasn't")
+          .isTrue();
+    }
   }
 
   private Node findNonControlNode(CqlSession session) {


### PR DESCRIPTION
`PeersV2NodeRefreshIT#should_successfully_send_peers_v2_node_refresh_query` integration test does not close its test session, leading to leaks when integration tests suite is executed in CI. This affects `SessionLeakIT#should_warn_when_session_count_exceeds_threshold` test, which sees the leaked session and fails due to an unexpected number of active sessions.

The change adds post-test cleanup in `PeersV2NodeRefreshIT` to ensure that session is properly closed after the test, preventing it from affecting subsequent tests.