### PR TITLE
Add CI release for scylla java-driver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release ScyllaDB Java Driver
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        type: boolean
+        description: 'dryrun: run without pushing SCM changes to upstream'
+        default: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+
+    env:
+      MVNCMD: mvn -B -X -ntp
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+        server-id: ossrh
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        server-username: OSSRH_USERNAME
+        server-password: OSSRH_PASSWORD
+
+    - name: Configure Git user
+      run: |
+        git config user.name "ScyllaDB Promoter"
+        git config user.email "github-promoter@scylladb.com"
+
+    - name: Clean project
+      run: $MVNCMD clean
+
+    - name: Clean release
+      run: $MVNCMD release:clean
+
+    - name: Prepare release
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      run: $MVNCMD release:prepare -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Perform release
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      run: $MVNCMD release:perform -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Push changes to SCM
+      if: ${{ github.event.inputs.dryrun == 'false' }}
+      run: |
+        git status && git log -3
+        git push origin --follow-tags -v

--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,8 @@
                         <!-- useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
                         <goals>deploy</goals-->
+                        <localCheckout>true</localCheckout>
+                        <deployAtEnd>true</deployAtEnd>
                         <pushChanges>${pushChanges}</pushChanges>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <ipprefix>127.0.1.</ipprefix>
         <!-- defaults below are overridden by profiles and/or submodules -->
         <test.groups>unit</test.groups>
+        <pushChanges>false</pushChanges>
         <test.osgi.skip>true</test.osgi.skip>
         <javadoc.opts />
         <!-- Append "-fedora" to os.detected.classifier for Fedora systems
@@ -621,7 +622,7 @@
                         <!-- useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
                         <goals>deploy</goals-->
-                        <pushChanges>true</pushChanges>
+                        <pushChanges>${pushChanges}</pushChanges>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
                     </configuration>


### PR DESCRIPTION
This PR is about adding CI release for scylla java-driver

The PR includes two pre-conf commits to adjust the pom.xml to support the CI,
 -and the CI workflow which includes the required steps for preparing, performing, and pushing the artifacts to nexus staging repository, 

The new workflow should be triggered manually upon request to release a new version,
The workflow supports `dryrun` mode which runs all actions but without pushing the changes back to the SCM - it's useful for debugging when we want to see the project promoted to the staging repository but without dirty the SCM with version-commit & tag


The last step of promoting the release from staging to production is still manual and will be automated later, as I need to investigate an issue with the `nexus-staging:release` command


Ref https://github.com/scylladb/scylla-pkg/issues/3792
