### PR TITLE
docs: compatiblity with sphinx-scylladb-theme 1.7.3

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -14,7 +14,6 @@ sphinx-sitemap = "2.5.1"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "7.2.6"
 sphinx-multiversion-scylla = "~0.3.1"
-setuptools = "^65.6.3"
 wheel = "^0.38.4"
 sphinx-scylladb-markdown = "^0.1.2"
 


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/pull/1123

Make the documentation project compatible with the latest version of sphinx-scylladb-theme. Now, the specific version of setuptool is already defined by the theme.

## Note for maintaners

It would be beneficial to backport this change to the scylla-4.x branch to ensure that future branches include this modification.
