### PR TITLE
Remove System.out.println.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -191,7 +191,6 @@ public class Cluster implements Closeable {
       List<EndPoint> contactPoints,
       Configuration configuration,
       Collection<Host.StateListener> listeners) {
-    System.out.println("===== Using optimized driver!!! =====");
     logger.info("===== Using optimized driver!!! =====");
     this.manager = new Manager(name, contactPoints, configuration, listeners);
   }


### PR DESCRIPTION
Motivation:

Applications are improperly printing messages to the log, causing overload in certain situations. There is no need for a println since the log is already being managed by slf4j.

Modifications:

Remove println from Cluster Class

Result:

No improper messages are displayed in the log, and there is no more overload.