### PR TITLE
Remove System.out.println.

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -822,7 +822,6 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
    */
   @NonNull
   public CompletionStage<SessionT> buildAsync() {
-    System.out.println("Using Scylla optimized driver!!!");
     LOG.info("Using Scylla optimized driver!!!");
     CompletionStage<CqlSession> buildStage = buildDefaultSessionAsync();
     CompletionStage<SessionT> wrapStage = buildStage.thenApply(this::wrap);


### PR DESCRIPTION
Motivation:

Applications are improperly printing messages to the log, causing overload in certain situations. There is no need for a println since the log is already being managed by slf4j.

Modifications:

Remove println from buildAsync method

Result:

No improper messages are displayed in the log, and there is no more overload.