### PR TITLE
4.x: Change driver.name to ScyllaDB Java Driver

### DIFF
--- a/core/src/main/resources/com/datastax/oss/driver/Driver.properties
+++ b/core/src/main/resources/com/datastax/oss/driver/Driver.properties
@@ -25,4 +25,4 @@ driver.version=${project.version}
 # It would be better to use ${project.parent.name} here, but for some reason the bundle plugin
 # prevents that from being resolved correctly (unlike the project-level properties above).
 # The value is not likely to change, so we simply hard-code it:
-driver.name=Apache Cassandra Java Driver
+driver.name=ScyllaDB Java Driver


### PR DESCRIPTION
Changes the driver.name in Driver.properties file.

Fixes #300.