### PR TITLE
3.x: Change DRIVER_NAME to ScyllaDB Java Driver

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -42,7 +42,7 @@ class Requests {
     private static final String CQL_VERSION = "3.0.0";
     private static final String DRIVER_VERSION_OPTION = "DRIVER_VERSION";
     private static final String DRIVER_NAME_OPTION = "DRIVER_NAME";
-    private static final String DRIVER_NAME = "DataStax Java Driver";
+    private static final String DRIVER_NAME = "ScyllaDB Java Driver";
 
     static final String COMPRESSION_OPTION = "COMPRESSION";
     static final String NO_COMPACT_OPTION = "NO_COMPACT";


### PR DESCRIPTION
Fixes #300.