### PR TITLE
docs 4.x: Remove setuptools from docs/pyproject.toml

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -14,7 +14,6 @@ sphinx-sitemap = "2.5.1"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "7.2.6"
 sphinx-multiversion-scylla = "~0.3.1"
-setuptools = "^65.6.3"
 wheel = "^0.38.4"
 sphinx-scylladb-markdown = "^0.1.2"
 


### PR DESCRIPTION
Setuptools seem to be included on theme level instead

Port of #313