### PR TITLE
Upgrade mockito-core to 3.4.6

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -247,6 +247,8 @@
               <threadCountClasses>8</threadCountClasses>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
               <skipITs>${skipParallelizableITs}</skipITs>
+              <parallel>methods</parallel>
+              <threadCount>4</threadCount>
             </configuration>
           </execution>
           <execution>

--- a/metrics/micrometer/pom.xml
+++ b/metrics/micrometer/pom.xml
@@ -97,6 +97,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.28.2</version>
+        <version>3.4.6</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>


### PR DESCRIPTION
Upgrades mockito version. Version 3.4.6 was chosen because 3.4.0 is the first one providing mocking of static methods that we possibly want to use. Does not switch to mockito-inline yet.