### PR TITLE
CI: cache java dependencies

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -28,8 +28,34 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
 
+      - name: Get POM hash
+        id: get-pom-hash
+        run: echo "value=${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@v4
+        id: java-cache
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ steps.get-pom-hash.outputs.value }}
+
       - name: Compile source and tests
         run: mvn -B compile test-compile -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+
+      - name: Download test dependencies
+        if: steps.java-cache.outputs.cache-hit != 'true'
+        run: mvn -B test -Dtest=TestThatDoesNotExists -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true || true
+
+      - name: Download verify dependencies
+        if: steps.java-cache.outputs.cache-hit != 'true'
+        run: mvn -B verify -DskipTests || true
+
+      - name: Save maven repository cache
+        uses: actions/cache/save@v4
+        if: steps.java-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ steps.get-pom-hash.outputs.value }}
 
   verify:
     name: Full verify
@@ -51,6 +77,12 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
 
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
+
       - name: Full verify
         run: mvn -B verify -DskipTests
 
@@ -60,6 +92,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        java-version: [8]
+      fail-fast: false
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -67,8 +104,14 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Run unit tests
         run: mvn -B test -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
@@ -79,6 +122,7 @@ jobs:
           shopt -s globstar
           mkdir unit
           cp --parents ./**/target/*-reports/*.xml unit/
+
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: success() || failure()
@@ -119,6 +163,7 @@ jobs:
     strategy:
       matrix:
         cassandra-version: ${{ fromJson(needs.setup-integration-tests.outputs.cassandra-integration-tests-versions) }}
+        java-version: [8]
       fail-fast: false
 
     steps:
@@ -128,8 +173,14 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Setup Python 3
         uses: actions/setup-python@v2
@@ -139,8 +190,23 @@ jobs:
       - name: Setup environment
         run: |
           pip3 install https://github.com/scylladb/scylla-ccm/archive/a93125bc6ad7dd5c9694331e89dc1fb212431ffe.zip
+
+      - name: Restore CCM image cache
+        uses: actions/cache/restore@v4
+        id: ccm-cache
+        with:
+          path: ~/.ccm/repository
+          key: ccm-cassandra-${{ runner.os }}-${{ matrix.cassandra-version }}
+
       - name: Run integration tests on Cassandra (${{ matrix.cassandra-version }})
         run: mvn -B -e verify -Dccm.version=${{ matrix.cassandra-version }} -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+
+      - name: Save CCM image cache
+        uses: actions/cache/save@v4
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.ccm/repository
+          key: ccm-cassandra-${{ runner.os }}-${{ matrix.cassandra-version }}
 
       - name: Copy test results
         if: success() || failure()
@@ -148,6 +214,7 @@ jobs:
           shopt -s globstar
           mkdir cassandra-${{ matrix.cassandra-version }}
           cp --parents ./**/target/*-reports/*.xml cassandra-${{ matrix.cassandra-version }}/
+
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: success() || failure()
@@ -171,6 +238,7 @@ jobs:
     strategy:
       matrix:
         scylla-version: ${{ fromJson(needs.setup-integration-tests.outputs.scylla-integration-tests-versions) }}
+        java-version: [8]
       fail-fast: false
 
     steps:
@@ -180,8 +248,14 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Setup Python 3
         uses: actions/setup-python@v2
@@ -192,8 +266,23 @@ jobs:
         run: |
           pip3 install https://github.com/scylladb/scylla-ccm/archive/a93125bc6ad7dd5c9694331e89dc1fb212431ffe.zip
           sudo sh -c "echo 2097152 > /proc/sys/fs/aio-max-nr"
+
+      - name: Restore CCM image cache
+        uses: actions/cache/restore@v4
+        id: ccm-cache
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-scylla-${{ runner.os }}-${{ matrix.scylla-version }}
+
       - name: Run integration tests on Scylla (${{ matrix.scylla-version }})
         run: mvn -B verify -Dccm.version=${{ matrix.scylla-version }} -Dccm.scylla=true -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+
+      - name: Save CCM image cache
+        uses: actions/cache/save@v4
+        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.ccm/repository
+          key: ccm-scylla-${{ runner.os }}-${{ matrix.scylla-version }}
 
       - name: Copy test results
         if: success() || failure()
@@ -201,6 +290,7 @@ jobs:
           shopt -s globstar
           mkdir scylla-${{ matrix.scylla-version }}
           cp --parents ./**/target/*-reports/*.xml scylla-${{ matrix.scylla-version }}/
+
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: success() || failure()


### PR DESCRIPTION
To speedup pipeline let's start caching `maven deps` and ccm images