### PR TITLE
Add Resolver interface and implementations

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
@@ -19,6 +19,8 @@ package com.datastax.oss.driver.internal.core;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import com.datastax.oss.driver.internal.core.resolver.ResolverProvider;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import java.net.InetAddress;
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
 /** Utility class to handle the initial contact points passed to the driver. */
 public class ContactPoints {
   private static final Logger LOG = LoggerFactory.getLogger(ContactPoints.class);
+  private static Resolver RESOLVER = ResolverProvider.getResolver(ContactPoints.class);
 
   public static Set<EndPoint> merge(
       Set<EndPoint> programmaticContactPoints, List<String> configContactPoints, boolean resolve) {
@@ -72,7 +75,7 @@ public class ContactPoints {
       return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
     } else {
       try {
-        InetAddress[] inetAddresses = InetAddress.getAllByName(host);
+        InetAddress[] inetAddresses = RESOLVER.getAllByName(host);
         if (inetAddresses.length > 1) {
           LOG.info(
               "Contact point {} resolves to multiple addresses, will use them all ({})",

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
@@ -19,6 +19,8 @@ package com.datastax.oss.driver.internal.core.addresstranslation;
 
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import com.datastax.oss.driver.internal.core.resolver.ResolverProvider;
 import com.datastax.oss.driver.internal.core.util.Loggers;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -57,6 +59,8 @@ import org.slf4j.LoggerFactory;
 public class Ec2MultiRegionAddressTranslator implements AddressTranslator {
 
   private static final Logger LOG = LoggerFactory.getLogger(Ec2MultiRegionAddressTranslator.class);
+  private static Resolver RESOLVER =
+      ResolverProvider.getResolver(Ec2MultiRegionAddressTranslator.class);
 
   private final DirContext ctx;
   private final String logPrefix;
@@ -94,7 +98,7 @@ public class Ec2MultiRegionAddressTranslator implements AddressTranslator {
         return socketAddress;
       }
 
-      InetAddress translatedAddress = InetAddress.getByName(domainName);
+      InetAddress translatedAddress = RESOLVER.getByName(domainName);
       LOG.debug("[{}] Resolved {} to {}", logPrefix, address, translatedAddress);
       return new InetSocketAddress(translatedAddress, socketAddress.getPort());
     } catch (Exception e) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -42,6 +42,8 @@ import com.datastax.oss.driver.internal.core.metrics.NoopNodeMetricUpdater;
 import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.protocol.FrameDecoder;
 import com.datastax.oss.driver.internal.core.protocol.FrameEncoder;
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import com.datastax.oss.driver.internal.core.resolver.ResolverProvider;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
@@ -67,6 +69,8 @@ import org.slf4j.LoggerFactory;
 public class ChannelFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(ChannelFactory.class);
+
+  private static Resolver RESOLVER = ResolverProvider.getResolver(ChannelFactory.class);
 
   /**
    * A value for {@link #productType} that indicates that we are connected to DataStax Cloud. This
@@ -204,7 +208,7 @@ public class ChannelFactory {
 
     nettyOptions.afterBootstrapInitialized(bootstrap);
 
-    ChannelFuture connectFuture = bootstrap.connect(endPoint.resolve());
+    ChannelFuture connectFuture = bootstrap.connect(RESOLVER.resolve(endPoint.resolve()));
 
     connectFuture.addListener(
         cf -> {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
@@ -18,6 +18,8 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import com.datastax.oss.driver.internal.core.resolver.ResolverProvider;
 import com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetAddress;
@@ -30,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SniEndPoint implements EndPoint {
   private static final AtomicLong OFFSET = new AtomicLong();
+  private static Resolver RESOLVER = ResolverProvider.getResolver(SniEndPoint.class);
 
   private final InetSocketAddress proxyAddress;
   private final String serverName;
@@ -55,7 +58,7 @@ public class SniEndPoint implements EndPoint {
   @Override
   public InetSocketAddress resolve() {
     try {
-      InetAddress[] aRecords = InetAddress.getAllByName(proxyAddress.getHostName());
+      InetAddress[] aRecords = RESOLVER.getAllByName(proxyAddress.getHostName());
       if (aRecords.length == 0) {
         // Probably never happens, but the JDK docs don't explicitly say so
         throw new IllegalArgumentException(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/AbstractResolverFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/AbstractResolverFactory.java
@@ -1,0 +1,5 @@
+package com.datastax.oss.driver.internal.core.resolver;
+
+public interface AbstractResolverFactory {
+  public Resolver getResolver(Class<?> clazz);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/Resolver.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/Resolver.java
@@ -1,0 +1,48 @@
+package com.datastax.oss.driver.internal.core.resolver;
+
+import com.datastax.oss.driver.internal.core.resolver.defaultResolver.DefaultResolver;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Resolver is a "middleman" class that is meant to serve as a hook point for testing.
+ * Any time core driver tries to resolve a host defined by hostname, such attempt will
+ * go through the Resolver first. At that moment Resolver may return custom result it
+ * was configured to return or simply forward the call to the corresponding InetAddress class
+ * method.
+ *
+ * Some classes are exempt from running through the Resolver and they still call InetAddress directly
+ * (e.g. {@link com.datastax.dse.driver.internal.core.insights.InsightsClient}).
+ * By default, driver should use {@link DefaultResolver}
+ * which should introduce no change in behaviour and redirect all calls to {@link InetAddress).
+ */
+public interface Resolver {
+
+  /**
+   * Replaces calls to {@link InetAddress#getByName(String)}.
+   *
+   * @param host host to resolve.
+   * @return an IP address for the given host name.
+   * @throws UnknownHostException
+   */
+  InetAddress getByName(String host) throws UnknownHostException;
+
+  /**
+   * Replaces calls to {@link InetAddress#getAllByName(String)}
+   *
+   * @param host host to resolve.
+   * @return an array of all the IP addresses for a given host name.
+   * @throws UnknownHostException
+   */
+  InetAddress[] getAllByName(String host) throws UnknownHostException;
+
+  /**
+   * Resolves {@link SocketAddress} returning {@link SocketAddress} To be called just before passing
+   * {@link SocketAddress}, that may be unresolved, to an another library that is going resolve it.
+   *
+   * @param addr SocketAddress with host details
+   * @return SocketAddress instance with possibly modified contents
+   */
+  SocketAddress resolve(SocketAddress addr);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/ResolverProvider.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/ResolverProvider.java
@@ -1,0 +1,32 @@
+package com.datastax.oss.driver.internal.core.resolver;
+
+import com.datastax.oss.driver.internal.core.resolver.defaultResolver.DefaultResolverFactory;
+
+/**
+ * Entry point for driver components to getting the {@link Resolver} instances. By default returns
+ * instances of {@link DefaultResolverFactory}.
+ */
+public class ResolverProvider {
+
+  private static AbstractResolverFactory defaultResolverFactoryImpl = new DefaultResolverFactory();
+
+  /**
+   * Asks factory for new {@link Resolver}.
+   *
+   * @param clazz Class that is requesting the {@link Resolver}.
+   * @return new {@link Resolver}.
+   */
+  public static Resolver getResolver(Class<?> clazz) {
+    return defaultResolverFactoryImpl.getResolver(clazz);
+  }
+
+  /**
+   * Replaces resolver factory with another, possibly producing different implementation of {@link
+   * Resolver}.
+   *
+   * @param resolverFactoryImpl new {@link Resolver} factory.
+   */
+  public static void setDefaultResolverFactory(AbstractResolverFactory resolverFactoryImpl) {
+    defaultResolverFactoryImpl = resolverFactoryImpl;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/defaultResolver/DefaultResolver.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/defaultResolver/DefaultResolver.java
@@ -1,0 +1,47 @@
+package com.datastax.oss.driver.internal.core.resolver.defaultResolver;
+
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Resolver implementation that forwards all calls to {@link InetAddress} or returns the arguments
+ * unmodified.
+ */
+public class DefaultResolver implements Resolver {
+
+  DefaultResolver() {}
+
+  /**
+   * Equivalent to {@link InetAddress#getByName(String)}.
+   *
+   * @throws UnknownHostException
+   */
+  @Override
+  public InetAddress getByName(String host) throws UnknownHostException {
+    return InetAddress.getByName(host);
+  }
+
+  /**
+   * Equivalent to {@link InetAddress#getAllByName(String)}.
+   *
+   * @throws UnknownHostException
+   */
+  @Override
+  public InetAddress[] getAllByName(String host) throws UnknownHostException {
+    return InetAddress.getAllByName(host);
+  }
+
+  /**
+   * Returns {@link SocketAddress} as is. No reason to resolve it here, it is supposed to be done by
+   * a library that is going to consume the result.
+   *
+   * @param addr {@link SocketAddress}.
+   * @return the very same addr.
+   */
+  @Override
+  public SocketAddress resolve(SocketAddress addr) {
+    return addr;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/defaultResolver/DefaultResolverFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/defaultResolver/DefaultResolverFactory.java
@@ -1,0 +1,23 @@
+package com.datastax.oss.driver.internal.core.resolver.defaultResolver;
+
+import com.datastax.oss.driver.internal.core.resolver.AbstractResolverFactory;
+
+/**
+ * Produces instances of {@link
+ * com.datastax.oss.driver.internal.core.resolver.defaultResolver.DefaultResolver}.
+ */
+public class DefaultResolverFactory implements AbstractResolverFactory {
+
+  /**
+   * Returns new {@link
+   * com.datastax.oss.driver.internal.core.resolver.defaultResolver.DefaultResolver} instance.
+   *
+   * @param clazz Class for which the instance is being created.
+   * @return new {@link
+   *     com.datastax.oss.driver.internal.core.resolver.defaultResolver.DefaultResolver} instance.
+   */
+  @Override
+  public DefaultResolver getResolver(Class<?> clazz) {
+    return new DefaultResolver();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolver.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolver.java
@@ -1,0 +1,81 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+
+/** Resolver implementation that allows returning custom results. */
+public class MockResolver implements Resolver {
+  private final MockResolverResultSource resultSource;
+
+  MockResolver(MockResolverResultSource resultSource) {
+    this.resultSource = resultSource;
+  }
+
+  /**
+   * Returns first {@link InetAddress} from overrided results {@link Response} if one is present.
+   * Otherwise forwards the call to {@link InetAddress#getByName(String)}
+   *
+   * @param host host to resolve.
+   * @return address.
+   * @throws UnknownHostException
+   */
+  @Override
+  public InetAddress getByName(String host) throws UnknownHostException {
+    Response response = this.resultSource.getResponse(host);
+    if (response == null) {
+      return InetAddress.getByName(host);
+    }
+    return response.result()[0];
+  }
+
+  /**
+   * Returns overrided results for provided {@code host}, if one is present, otherwise the call to
+   * Otherwise forwards the call to {@link InetAddress#getAllByName(String)}
+   *
+   * @param host host to resolve.
+   * @return address.
+   * @throws UnknownHostException
+   */
+  @Override
+  public InetAddress[] getAllByName(String host) throws UnknownHostException {
+    Response response = this.resultSource.getResponse(host);
+    if (response == null) {
+      return InetAddress.getAllByName(host);
+    }
+    return response.result();
+  }
+
+  /**
+   * If {@code addr} is an resolved {@link InetSocketAddress}, or there is no response overriding
+   * for the it's host, or {@code addr} is something else, it returns {@code addr} as is. Otherwise
+   * it returns overrided response, if overrided response throws {@link UnknownHostException}, it
+   * emulates it by returning unresolved {@link InetSocketAddress} with bogus host.
+   *
+   * @param addr SocketAddress to modify.
+   * @return possibly new SocketAddress.
+   */
+  @Override
+  public SocketAddress resolve(SocketAddress addr) {
+    if (!(addr instanceof InetSocketAddress)) {
+      return addr;
+    }
+    InetSocketAddress inetSockAddr = ((InetSocketAddress) addr);
+    if (!inetSockAddr.isUnresolved()) {
+      return addr;
+    }
+    String hostname = inetSockAddr.getHostName();
+    int port = inetSockAddr.getPort();
+    Response response = this.resultSource.getResponse(hostname);
+    if (response == null) {
+      return addr;
+    }
+    try {
+      return new InetSocketAddress(response.result()[0], port);
+    } catch (UnknownHostException e) {
+      return InetSocketAddress.createUnresolved(hostname + ".bad.host.115t87", port);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolverFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolverFactory.java
@@ -1,0 +1,64 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+import com.datastax.oss.driver.internal.core.resolver.AbstractResolverFactory;
+import com.datastax.oss.driver.internal.core.resolver.Resolver;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Produces instances of {@link MockResolver}. All {@link Resolver} instances produced by instance
+ * of this class return results sourced by the factory. if {@code defaultResponse} is not set, it
+ * produces same results as `DefaultResolver` for hosts that are not in the {@code responses}
+ */
+public class MockResolverFactory implements AbstractResolverFactory, MockResolverResultSource {
+  private final ConcurrentMap<String, Response> responses = new ConcurrentHashMap<>();
+  private Response defaultResponse;
+
+  @Override
+  public Response getResponse(String hostname) {
+    return responses.getOrDefault(hostname, defaultResponse);
+  }
+
+  /**
+   * Set the result for calls to {@link MockResolverFactory#getResponse(String)} for hostnames that
+   * do not have custom mappings.
+   *
+   * @param response new default response.
+   */
+  @SuppressWarnings("unused")
+  public void setDefaultResponse(Response response) {
+    this.defaultResponse = response;
+  }
+
+  /**
+   * Add provided mappings to the current mappings.
+   *
+   * @param map mappings to merge in.
+   */
+  @SuppressWarnings("unused")
+  public void updateResponses(Map<String, Response> map) {
+    responses.putAll(map);
+  }
+
+  /**
+   * Adds a single response to the current mappings.
+   *
+   * @param address host - key of the mapping.
+   * @param response value of the mapping.
+   */
+  public void updateResponse(String address, Response response) {
+    responses.put(address, response);
+  }
+
+  /**
+   * Returns new {@link MockResolver} instance.
+   *
+   * @param clazz Class for which the instance is being created.
+   * @return new {@link MockResolver} instance.
+   */
+  @Override
+  public MockResolver getResolver(Class<?> clazz) {
+    return new MockResolver(this);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolverResultSource.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/MockResolverResultSource.java
@@ -1,0 +1,5 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+public interface MockResolverResultSource {
+  Response getResponse(String hostname);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/Response.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/Response.java
@@ -1,0 +1,18 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Represents results returned by {@link
+ * com.datastax.oss.driver.internal.core.resolver.mockResolver.MockResolverFactory}.
+ */
+public interface Response {
+  /**
+   * Underlying result of this Response.
+   *
+   * @return result of this Response.
+   * @throws UnknownHostException
+   */
+  InetAddress[] result() throws UnknownHostException;
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/UnknownHostResponse.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/UnknownHostResponse.java
@@ -1,0 +1,20 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/** Unsuccessful response. Throws on {@code result()} calls. */
+@SuppressWarnings("unused")
+public class UnknownHostResponse implements Response {
+  private final String message;
+
+  @SuppressWarnings("unused")
+  public UnknownHostResponse(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public InetAddress[] result() throws UnknownHostException {
+    throw new UnknownHostException(message);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/ValidResponse.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/resolver/mockResolver/ValidResponse.java
@@ -1,0 +1,18 @@
+package com.datastax.oss.driver.internal.core.resolver.mockResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/** Successful response with an array of valid IPs. */
+public class ValidResponse implements Response {
+  private final InetAddress[] list;
+
+  public ValidResponse(InetAddress[] list) {
+    this.list = list;
+  }
+
+  @Override
+  public InetAddress[] result() throws UnknownHostException {
+    return list;
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2022 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.categories.IsolatedTests;
+import com.datastax.oss.driver.internal.core.config.typesafe.DefaultProgrammaticDriverConfigLoaderBuilder;
+import com.datastax.oss.driver.internal.core.resolver.ResolverProvider;
+import com.datastax.oss.driver.internal.core.resolver.mockResolver.MockResolverFactory;
+import com.datastax.oss.driver.internal.core.resolver.mockResolver.ValidResponse;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category(IsolatedTests.class)
+public class MockResolverIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MockResolverIT.class);
+
+  @ClassRule
+  public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(1).build();
+
+  @Test
+  public void should_connect_with_mocked_hostname() {
+    CcmBridge ccmBridge = CCM_RULE.getCcmBridge();
+
+    MockResolverFactory resolverFactory = new MockResolverFactory();
+    resolverFactory.updateResponse(
+        "node-1.cluster.fake",
+        new ValidResponse(new InetAddress[] {getNodeInetAddress(ccmBridge, 1)}));
+    ResolverProvider.setDefaultResolverFactory(resolverFactory);
+
+    DriverConfigLoader loader =
+        new DefaultProgrammaticDriverConfigLoaderBuilder()
+            .withBoolean(TypedDriverOption.RESOLVE_CONTACT_POINTS.getRawOption(), false)
+            .withBoolean(TypedDriverOption.RECONNECT_ON_INIT.getRawOption(), true)
+            .withStringList(
+                TypedDriverOption.CONTACT_POINTS.getRawOption(),
+                Collections.singletonList("node-1.cluster.fake:9042"))
+            .build();
+
+    CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
+    try (CqlSession session = builder.build()) {
+      ResultSet rs = session.execute("SELECT * FROM system.local");
+      List<Row> rows = rs.all();
+      assertThat(rows).hasSize(1);
+      LOG.trace("system.local contents: {}", rows.get(0).getFormattedContents());
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      for (Node node : nodes) {
+        LOG.trace("Found metadata node: {}", node);
+      }
+      Set<Node> filteredNodes;
+      filteredNodes =
+          nodes.stream()
+              .filter(x -> x.toString().contains("node-1.cluster.fake"))
+              .collect(Collectors.toSet());
+      assertThat(filteredNodes).hasSize(1);
+      InetSocketAddress address =
+          (InetSocketAddress) filteredNodes.iterator().next().getEndPoint().resolve();
+      assertTrue(address.isUnresolved());
+    }
+  }
+
+  private InetAddress getNodeInetAddress(CcmBridge ccmBridge, int nodeid) {
+    try {
+      return InetAddress.getByName(ccmBridge.getNodeIpAddress(nodeid));
+    } catch (UnknownHostException e) {
+      return null;
+    }
+  }
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -517,6 +517,10 @@ public class CcmBridge implements AutoCloseable {
     return f;
   }
 
+  public String getNodeIpAddress(int nodeId) {
+    return ipPrefix + nodeId;
+  }
+
   public static Builder builder() {
     return new Builder();
   }


### PR DESCRIPTION
Requested modification to allow for more control over hostname resolution when testing.
Adds a set of Resolver classes and factories and hooks them into necessary places.
See commit messages and javadoc for more details.