### PR TITLE
4.x: Add `MockResolverIT#replace_cluster_test()`

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -25,6 +25,7 @@ package com.datastax.oss.driver.core.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
@@ -44,9 +45,11 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -56,19 +59,25 @@ import org.slf4j.LoggerFactory;
 public class MockResolverIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(MockResolverIT.class);
+  private static final MockResolverFactory RESOLVER_FACTORY = new MockResolverFactory();
+
+  private static final int CLUSTER_WAIT_SECONDS =
+      60; // Maximal wait time for cluster nodes to get up
+
+  @BeforeClass
+  public static void setUpResolver() {
+    ResolverProvider.setDefaultResolverFactory(RESOLVER_FACTORY);
+  }
 
   @Test
   public void should_connect_with_mocked_hostname() {
     CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder().withNodes(1).withIpPrefix("127.0.1.");
     try (CcmBridge ccmBridge = ccmBridgeBuilder.build()) {
+      RESOLVER_FACTORY.updateResponse(
+          "test.cluster.fake",
+          new ValidResponse(new InetAddress[] {getNodeInetAddress(ccmBridge, 1)}));
       ccmBridge.create();
       ccmBridge.start();
-
-      MockResolverFactory resolverFactory = new MockResolverFactory();
-      resolverFactory.updateResponse(
-          "node-1.cluster.fake",
-          new ValidResponse(new InetAddress[] {getNodeInetAddress(ccmBridge, 1)}));
-      ResolverProvider.setDefaultResolverFactory(resolverFactory);
 
       DriverConfigLoader loader =
           new DefaultProgrammaticDriverConfigLoaderBuilder()
@@ -76,7 +85,7 @@ public class MockResolverIT {
               .withBoolean(TypedDriverOption.RECONNECT_ON_INIT.getRawOption(), true)
               .withStringList(
                   TypedDriverOption.CONTACT_POINTS.getRawOption(),
-                  Collections.singletonList("node-1.cluster.fake:9042"))
+                  Collections.singletonList("test.cluster.fake:9042"))
               .build();
 
       CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
@@ -92,7 +101,7 @@ public class MockResolverIT {
         Set<Node> filteredNodes;
         filteredNodes =
             nodes.stream()
-                .filter(x -> x.toString().contains("node-1.cluster.fake"))
+                .filter(x -> x.toString().contains("test.cluster.fake"))
                 .collect(Collectors.toSet());
         assertThat(filteredNodes).hasSize(1);
         InetSocketAddress address =
@@ -102,7 +111,147 @@ public class MockResolverIT {
     }
   }
 
-  private InetAddress getNodeInetAddress(CcmBridge ccmBridge, int nodeid) {
+  @Test
+  public void replace_cluster_test() {
+    final int numberOfNodes = 3;
+    DriverConfigLoader loader =
+        new DefaultProgrammaticDriverConfigLoaderBuilder()
+            .withBoolean(TypedDriverOption.RESOLVE_CONTACT_POINTS.getRawOption(), false)
+            .withBoolean(TypedDriverOption.RECONNECT_ON_INIT.getRawOption(), true)
+            .withStringList(
+                TypedDriverOption.CONTACT_POINTS.getRawOption(),
+                Collections.singletonList("test.cluster.fake:9042"))
+            .build();
+
+    CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
+    CqlSession session;
+
+    try (CcmBridge ccmBridge =
+        CcmBridge.builder().withNodes(numberOfNodes).withIpPrefix("127.0.1.").build()) {
+      RESOLVER_FACTORY.updateResponse(
+          "test.cluster.fake",
+          new ValidResponse(
+              new InetAddress[] {
+                getNodeInetAddress(ccmBridge, 1),
+                getNodeInetAddress(ccmBridge, 2),
+                getNodeInetAddress(ccmBridge, 3)
+              }));
+      ccmBridge.create();
+      ccmBridge.start();
+      session = builder.build();
+      boolean allNodesUp = false;
+      int nodesUp = 0;
+      for (int i = 0; i < CLUSTER_WAIT_SECONDS; i++) {
+        try {
+          Collection<Node> nodes = session.getMetadata().getNodes().values();
+          nodesUp = 0;
+          for (Node node : nodes) {
+            if (node.getUpSinceMillis() > 0) {
+              nodesUp++;
+            }
+          }
+          if (nodesUp == numberOfNodes) {
+            allNodesUp = true;
+            break;
+          }
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          break;
+        }
+      }
+      if (!allNodesUp) {
+        LOG.error(
+            "Driver sees only {} nodes UP instead of {} after waiting {}s",
+            nodesUp,
+            numberOfNodes,
+            CLUSTER_WAIT_SECONDS);
+      }
+      ResultSet rs = session.execute("SELECT * FROM system.local");
+      assertThat(rs).isNotNull();
+      Row row = rs.one();
+      assertThat(row).isNotNull();
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      assertThat(nodes).hasSize(numberOfNodes);
+      Iterator<Node> iterator = nodes.iterator();
+      while (iterator.hasNext()) {
+        LOG.trace("Metadata node: " + iterator.next().toString());
+      }
+      Set<Node> filteredNodes;
+      filteredNodes =
+          nodes.stream()
+              .filter(x -> x.toString().contains("test.cluster.fake"))
+              .collect(Collectors.toSet());
+      assertThat(filteredNodes).hasSize(1);
+    }
+    try (CcmBridge ccmBridge =
+        CcmBridge.builder().withNodes(numberOfNodes).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.start();
+      boolean allNodesUp = false;
+      int nodesUp = 0;
+      for (int i = 0; i < CLUSTER_WAIT_SECONDS; i++) {
+        try {
+          Collection<Node> nodes = session.getMetadata().getNodes().values();
+          nodesUp = 0;
+          for (Node node : nodes) {
+            if (node.getUpSinceMillis() > 0) {
+              nodesUp++;
+            }
+          }
+          if (nodesUp == numberOfNodes) {
+            allNodesUp = true;
+            break;
+          }
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          break;
+        }
+      }
+      if (!allNodesUp) {
+        LOG.error(
+            "Driver sees only {} nodes UP instead of {} after waiting {}s",
+            nodesUp,
+            numberOfNodes,
+            CLUSTER_WAIT_SECONDS);
+      }
+      ResultSet rs = session.execute("SELECT * FROM system.local");
+      assertThat(rs).isNotNull();
+      Row row = rs.one();
+      assertThat(row).isNotNull();
+
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      assertThat(nodes).hasSize(numberOfNodes);
+      Iterator<Node> iterator = nodes.iterator();
+      while (iterator.hasNext()) {
+        LOG.trace("Metadata node: " + iterator.next().toString());
+      }
+      Set<Node> filteredNodes;
+      filteredNodes =
+          nodes.stream()
+              .filter(x -> x.toString().contains("test.cluster.fake"))
+              .collect(Collectors.toSet());
+      if (filteredNodes.size() == 0) {
+        LOG.error(
+            "No metadata node with \"test.cluster.fake\" substring. The unresolved endpoint socket was likely "
+                + "replaced with resolved one.");
+      } else if (filteredNodes.size() > 1) {
+        fail(
+            "Somehow there is more than 1 node in metadata with unresolved hostname. This should not ever happen.");
+      }
+    }
+    session.close();
+  }
+
+  @SuppressWarnings("unused")
+  public void run_replace_test_20_times() {
+    for (int i = 1; i <= 20; i++) {
+      LOG.info(
+          "Running ({}/20}) {}", i, MockResolverIT.class.toString() + "#replace_cluster_test()");
+      replace_cluster_test();
+    }
+  }
+
+  private static InetAddress getNodeInetAddress(CcmBridge ccmBridge, int nodeid) {
     try {
       return InetAddress.getByName(ccmBridge.getNodeIpAddress(nodeid));
     } catch (UnknownHostException e) {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -373,7 +373,7 @@ public class CcmBridge implements AutoCloseable {
   public void start() {
     if (started.compareAndSet(false, true)) {
       try {
-        execute("start", jvmArgs, "--wait-for-binary-proto");
+        execute("start", jvmArgs, "--wait-for-binary-proto", "--wait-other-notice");
       } catch (RuntimeException re) {
         // if something went wrong starting CCM, see if we can also dump the error
         executeCheckLogError();
@@ -407,9 +407,11 @@ public class CcmBridge implements AutoCloseable {
           "node" + n,
           "start",
           "--jvm_arg=-Dcassandra.allow_new_old_config_keys=true",
-          "--jvm_arg=-Dcassandra.allow_duplicate_config_keys=false");
+          "--jvm_arg=-Dcassandra.allow_duplicate_config_keys=false",
+          "--wait-other-notice",
+          "--wait-for-binary-proto");
     } else {
-      execute("node" + n, "start");
+      execute("node" + n, "start", "--wait-other-notice", "--wait-for-binary-proto");
     }
   }
 


### PR DESCRIPTION
Adds `MockResolverIT#replace_cluster_test()` as a test method that runs the replace cluster scenario and checks if driver managed to reconnect.

In the test we create three node cluster and replace it with completely new one. Hostname is mocked and points to all 3 nodes.