### PR TITLE
Fix ControlConnection log message

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -433,7 +433,9 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                         // We were reconnecting: make sure previous channel gets closed (it may
                         // still be open if reconnection was forced)
                         LOG.debug(
-                            "[{}] Forcefully closing previous channel {}", logPrefix, channel);
+                            "[{}] Forcefully closing previous channel {}",
+                            logPrefix,
+                            previousChannel);
                         previousChannel.forceClose();
                       }
                       context.getEventBus().fire(ChannelEvent.channelOpened(node));


### PR DESCRIPTION
Log message notifying of closing the previous ControlConnection's channel wrongly mentions current channel. Switch it to the previous instead.