### PR TITLE
Bump jnr dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <!-- Note:  When upgrading either jnr-ffi or jnr-posix, ensure that the versions are compatible.
              JNR has broken compatibility between minor versions in the past. -->
-        <jnr-ffi.version>2.2.5</jnr-ffi.version>
-        <jnr-posix.version>3.1.8</jnr-posix.version>
+        <jnr-ffi.version>2.2.16</jnr-ffi.version>
+        <jnr-posix.version>3.1.15</jnr-posix.version>
         <groovy.version>2.4.7</groovy.version>
         <jax-rs.version>2.0.1</jax-rs.version>
         <jersey.version>2.23.1</jersey.version>


### PR DESCRIPTION
It seems that changes in 3eed07c68d15d60298111e5fc3161734637ec344 broke the integration testing somehow. While I don't see right now the reason why would that change break anything, it is the first moment the ITs stopped actually running. Upgrading the `jnr-ffi` version seems to bring the tests back to life. The main change that seems to happen is that in some cases maven uses now TestNG provider instead of JUnit provider which would not see the tests. It's possible that configuration itself is faulty (having some random behaviour).