### PR TITLE
Add more information to NoNodeAvailableException and AllNodesFailedException

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
@@ -65,6 +65,7 @@ import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.session.RepreparePayload;
 import com.datastax.oss.driver.internal.core.util.Loggers;
+import com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.protocol.internal.Frame;
@@ -360,7 +361,11 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
       // We've reached the end of the query plan without finding any node to write to; abort the
       // continuous paging session.
       if (activeExecutionsCount.decrementAndGet() == 0) {
-        abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors));
+        if (queryPlan instanceof DebugQueryPlan) {
+          abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors, queryPlan));
+        } else {
+          abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors));
+        }
       }
     } else if (!chosenCallback.isDone()) {
       NodeResponseCallback nodeResponseCallback =

--- a/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
@@ -18,8 +18,10 @@
 package com.datastax.oss.driver.api.core;
 
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
+import java.util.Queue;
 
 /**
  * Specialization of {@code AllNodesFailedException} when no coordinators were tried.
@@ -32,13 +34,25 @@ public class NoNodeAvailableException extends AllNodesFailedException {
     this(null);
   }
 
-  private NoNodeAvailableException(ExecutionInfo executionInfo) {
-    super("No node was available to execute the query", executionInfo, Collections.emptySet());
+  private NoNodeAvailableException(
+      String message, ExecutionInfo executionInfo, Queue<Node> queryPlan) {
+    super(message, executionInfo, Collections.emptySet(), queryPlan);
+  }
+
+  public NoNodeAvailableException(Queue<Node> queryPlan) {
+    this(buildMessage(queryPlan), null, queryPlan);
+  }
+
+  private static String buildMessage(Queue<Node> queryPlan) {
+    if (queryPlan == null) {
+      return "No node was available to execute the query";
+    }
+    return "No node was available to execute the query. Query Plan: " + queryPlan;
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new NoNodeAvailableException(getExecutionInfo());
+    return new NoNodeAvailableException(getMessage(), getExecutionInfo(), getQueryPlan());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -142,6 +142,12 @@ public enum DefaultDriverOption implements DriverOption {
    */
   CONNECTION_WARN_INIT_ERROR("advanced.connection.warn-on-init-error"),
   /**
+   * Provide more details when query execution has failed.
+   *
+   * <p>Value-Type: boolean
+   */
+  CONNECTION_QUERY_PLAN_EXCEPTIONS("advanced.connection.detailed-query-plan-exceptions"),
+  /**
    * The number of connections in the LOCAL pool.
    *
    * <p>Value-type: int

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -381,6 +381,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC, 0);
     map.put(TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS, false);
     map.put(TypedDriverOption.METRICS_GENERATE_AGGREGABLE_HISTOGRAMS, true);
+    map.put(TypedDriverOption.CONNECTION_QUERY_PLAN_EXCEPTIONS, false);
   }
 
   @Immutable

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -889,6 +889,11 @@ public class TypedDriverOption<ValueT> {
               DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS,
               GenericType.BOOLEAN);
 
+  /** TBD. */
+  public static final TypedDriverOption<Boolean> CONNECTION_QUERY_PLAN_EXCEPTIONS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONNECTION_QUERY_PLAN_EXCEPTIONS, GenericType.BOOLEAN);
+
   private static Iterable<TypedDriverOption<?>> introspectBuiltInValues() {
     try {
       ImmutableList.Builder<TypedDriverOption<?>> result = ImmutableList.builder();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -37,6 +37,7 @@ import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
 import com.datastax.oss.driver.internal.core.metadata.TopologyEvent;
 import com.datastax.oss.driver.internal.core.util.Loggers;
+import com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.core.util.concurrent.Reconnection;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
@@ -357,7 +358,11 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       assert adminExecutor.inEventLoop();
       Node node = nodes.poll();
       if (node == null) {
-        onFailure.accept(AllNodesFailedException.fromErrors(errors));
+        if (nodes instanceof DebugQueryPlan) {
+          onFailure.accept(AllNodesFailedException.fromErrors(errors, nodes));
+        } else {
+          onFailure.accept(AllNodesFailedException.fromErrors(errors));
+        }
       } else {
         LOG.debug("[{}] Trying to establish a connection to {}", logPrefix, node);
         context

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -47,6 +47,7 @@ import com.datastax.oss.driver.internal.core.channel.ResponseCallback;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.util.Loggers;
+import com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.Message;
@@ -197,7 +198,11 @@ public class CqlPrepareHandler implements Throttled {
       }
     }
     if (channel == null) {
-      setFinalError(AllNodesFailedException.fromErrors(this.errors));
+      if (queryPlan instanceof DebugQueryPlan) {
+        setFinalError(AllNodesFailedException.fromErrors(this.errors, queryPlan));
+      } else {
+        setFinalError(AllNodesFailedException.fromErrors(this.errors));
+      }
     } else {
       InitialPrepareCallback initialPrepareCallback =
           new InitialPrepareCallback(request, node, channel, retryCount);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -72,6 +72,7 @@ import com.datastax.oss.driver.internal.core.session.RepreparePayload;
 import com.datastax.oss.driver.internal.core.tracker.NoopRequestTracker;
 import com.datastax.oss.driver.internal.core.tracker.RequestLogger;
 import com.datastax.oss.driver.internal.core.util.Loggers;
+import com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.Message;
@@ -385,7 +386,12 @@ public class CqlRequestHandler implements Throttled {
       // We've reached the end of the query plan without finding any node to write to
       if (!result.isDone() && activeExecutionsCount.decrementAndGet() == 0) {
         // We're the last execution so fail the result
-        setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
+        if (queryPlan instanceof DebugQueryPlan) {
+          setFinalError(
+              statement, AllNodesFailedException.fromErrors(this.errors, queryPlan), null, -1);
+        } else {
+          setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
+        }
       }
     } else {
       NodeResponseCallback nodeResponseCallback =

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/DcAgnosticNodeSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/DcAgnosticNodeSet.java
@@ -18,9 +18,11 @@
 package com.datastax.oss.driver.internal.core.loadbalancing.nodeset;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import net.jcip.annotations.ThreadSafe;
@@ -49,5 +51,37 @@ public class DcAgnosticNodeSet implements NodeSet {
   @Override
   public Set<String> dcs() {
     return Collections.emptySet();
+  }
+
+  @Override
+  public NodeSetInfo toInfo() {
+    return new DcAgnosticNodeSetInfo(nodes);
+  }
+
+  private static class DcAgnosticNodeSetInfo implements NodeSetInfo {
+    private final HashSet<DefaultNodeInfo> nodes;
+
+    private DcAgnosticNodeSetInfo(Set<Node> nodes) {
+      this.nodes = new HashSet<>();
+      for (Node node : nodes) {
+        this.nodes.add(new DefaultNodeInfo.Builder(node).build());
+      }
+    }
+
+    @Override
+    @NonNull
+    public Set<DefaultNodeInfo> dc(@Nullable String dc) {
+      return nodes;
+    }
+
+    @Override
+    public String toString() {
+      return "DcAgnosticNodeSet(nodes: " + nodes.toString() + ")";
+    }
+
+    @Override
+    public Set<String> dcs() {
+      return Collections.emptySet();
+    }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/LazyCopyQueryPlan.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/LazyCopyQueryPlan.java
@@ -1,0 +1,82 @@
+package com.datastax.oss.driver.internal.core.loadbalancing.nodeset;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
+import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.AbstractQueue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import jnr.ffi.annotations.Synchronized;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class LazyCopyQueryPlan extends AbstractQueue<Node> implements QueryPlan {
+  private final Queue<Node> originalPlan;
+  private final List<DefaultNodeInfo> itemsPulled = Collections.synchronizedList(new ArrayList<>());
+
+  public LazyCopyQueryPlan(@NonNull Queue<Node> originalPlan) {
+    this.originalPlan = originalPlan;
+  }
+
+  @Nullable
+  @Override
+  @Synchronized
+  public Node poll() {
+    Node node = originalPlan.poll();
+    if (node == null) {
+      return null;
+    }
+    this.itemsPulled.add(new DefaultNodeInfo.Builder(node).build());
+    return node;
+  }
+
+  @NonNull
+  @Override
+  @Synchronized
+  public Iterator<Node> iterator() {
+    return new NodeIterator();
+  }
+
+  @Override
+  @Synchronized
+  public int size() {
+    return originalPlan.size();
+  }
+
+  @Override
+  @Synchronized
+  public String toString() {
+    List<DefaultNodeInfo> inQueue = new ArrayList<>();
+    for (Node node : originalPlan) {
+      inQueue.add(new DefaultNodeInfo.Builder(node).build());
+    }
+
+    return String.format(
+        "%s(inQueue: %s, itemsPulled: %s)",
+        originalPlan.getClass().getName(), inQueue, itemsPulled);
+  }
+
+  private class NodeIterator implements Iterator<Node> {
+    @Override
+    @Synchronized
+    public boolean hasNext() {
+      return !originalPlan.isEmpty();
+    }
+
+    @Override
+    @Synchronized
+    public Node next() {
+      Node next = poll();
+      if (next == null) {
+        throw new NoSuchElementException();
+      }
+      return next;
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/NodeSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/NodeSet.java
@@ -68,4 +68,7 @@ public interface NodeSet {
    * disabled, this method returns an empty set.
    */
   Set<String> dcs();
+
+  /** Returns deep copy of the NodeSet. */
+  NodeSetInfo toInfo();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/NodeSetInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/NodeSetInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.loadbalancing.nodeset;
+
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * A thread-safe abstraction around a map of nodes per datacenter, to facilitate node management by
+ * load balancing policies.
+ */
+public interface NodeSetInfo extends Serializable {
+  /**
+   * Returns the current nodes in the given datacenter.
+   *
+   * <p>If this set was initialized with datacenter awareness, the returned set will contain only
+   * nodes pertaining to the given datacenter; otherwise, the given datacenter name is ignored and
+   * the returned set will contain all nodes in the cluster.
+   *
+   * @param dc The datacenter name, or null if the datacenter name is not known, or irrelevant.
+   * @return the current nodes in the given datacenter.
+   */
+  @NonNull
+  Set<DefaultNodeInfo> dc(@Nullable String dc);
+
+  /**
+   * Returns the current datacenter names known to this set. If datacenter awareness has been
+   * disabled, this method returns an empty set.
+   */
+  Set<String> dcs();
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/SingleDcNodeSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/SingleDcNodeSet.java
@@ -18,10 +18,12 @@
 package com.datastax.oss.driver.internal.core.loadbalancing.nodeset;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -68,5 +70,45 @@ public class SingleDcNodeSet implements NodeSet {
   @Override
   public Set<String> dcs() {
     return dcs;
+  }
+
+  @Override
+  public NodeSetInfo toInfo() {
+    return new SingleDcNodeSetInfo(dc, dcs, nodes);
+  }
+
+  private static class SingleDcNodeSetInfo implements NodeSetInfo {
+    private final Set<DefaultNodeInfo> nodes = new HashSet<>();
+
+    private final String dc;
+    private final Set<String> dcs;
+
+    private SingleDcNodeSetInfo(String dc, Set<String> dcs, Set<Node> nodes) {
+      this.dc = dc;
+      this.dcs = dcs;
+
+      for (Node node : nodes) {
+        this.nodes.add(new DefaultNodeInfo.Builder(node).build());
+      }
+    }
+
+    @Override
+    @NonNull
+    public Set<DefaultNodeInfo> dc(@Nullable String dc) {
+      if (Objects.equals(this.dc, dc)) {
+        return nodes;
+      }
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> dcs() {
+      return dcs;
+    }
+
+    @Override
+    public String toString() {
+      return "SingleDcNodeSetInfo(dc:" + dc + ", dcs: " + dcs + ", nodes: " + nodes + ")";
+    }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -17,6 +17,7 @@
  */
 package com.datastax.oss.driver.internal.core.metadata;
 
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
@@ -26,14 +27,18 @@ import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan;
+import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.driver.internal.core.util.concurrent.ReplayingEventFilter;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -75,6 +80,7 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
   private final Set<LoadBalancingPolicy> policies;
   private final Map<String, LoadBalancingPolicy> policiesPerProfile;
   private final Map<LoadBalancingPolicy, SinglePolicyDistanceReporter> reporters;
+  private final boolean detailedQueryPlanExceptions;
 
   private final Lock distancesLock = new ReentrantLock();
 
@@ -94,6 +100,13 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
     this.context = context;
 
     this.policiesPerProfile = policiesPerProfile;
+
+    detailedQueryPlanExceptions =
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(DefaultDriverOption.CONNECTION_QUERY_PLAN_EXCEPTIONS);
+
     ImmutableMap.Builder<LoadBalancingPolicy, SinglePolicyDistanceReporter> reportersBuilder =
         ImmutableMap.builder();
     // ImmutableMap.values does not remove duplicates, do it now so that we won't invoke a policy
@@ -142,13 +155,22 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
   @NonNull
   public Queue<Node> newQueryPlan(
       @Nullable Request request, @NonNull String executionProfileName, @Nullable Session session) {
-    switch (stateRef.get()) {
+    State state = stateRef.get();
+    switch (state) {
       case BEFORE_INIT:
       case DURING_INIT:
-        // The contact points are not stored in the metadata yet:
         List<Node> nodes = new ArrayList<>(context.getMetadataManager().getContactPoints());
         Collections.shuffle(nodes);
-        return new ConcurrentLinkedQueue<>(nodes);
+        Queue<Node> plan = new ConcurrentLinkedQueue<>(nodes);
+        if (!detailedQueryPlanExceptions) {
+          // The contact points are not stored in the metadata yet:
+          return plan;
+        }
+        DebugQueryPlan debugPlan = new DebugQueryPlan(plan);
+        LoadBalancingPolicyWrapperInfo wrapperInfo =
+            new LoadBalancingPolicyWrapperInfo(this, state);
+        debugPlan.setLoadBalancingPolicyWrapperInfo(wrapperInfo);
+        return debugPlan;
       case RUNNING:
         LoadBalancingPolicy policy = policiesPerProfile.get(executionProfileName);
         if (policy == null) {
@@ -156,7 +178,14 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
         }
         return policy.newQueryPlan(request, session);
       default:
-        return new ConcurrentLinkedQueue<>();
+        if (!detailedQueryPlanExceptions) {
+          return QueryPlan.EMPTY;
+        }
+        plan = QueryPlan.EMPTY;
+        debugPlan = new DebugQueryPlan(plan);
+        wrapperInfo = new LoadBalancingPolicyWrapperInfo(this, state);
+        debugPlan.setLoadBalancingPolicyWrapperInfo(wrapperInfo);
+        return debugPlan;
     }
   }
 
@@ -268,6 +297,27 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
         }
       }
       return minimum;
+    }
+  }
+
+  private static class LoadBalancingPolicyWrapperInfo implements Serializable {
+    private final InternalDriverContext context;
+    private final Set<LoadBalancingPolicy> policies;
+    private final Map<String, LoadBalancingPolicy> policiesPerProfile;
+    private final State state;
+
+    private LoadBalancingPolicyWrapperInfo(LoadBalancingPolicyWrapper wrapper, State state) {
+      this.context = wrapper.context;
+      this.policies = new HashSet<>();
+      this.policiesPerProfile = new HashMap<>();
+      this.state = state;
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "LoadBalancingPolicyWrapperInfo(state: %s, context: %s, policies: %s, policiesPerProfile: %s)",
+          state, context, policies, policiesPerProfile);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeInfo.java
@@ -158,4 +158,28 @@ public interface NodeInfo {
    */
   @Nullable
   UUID getSchemaVersion();
+
+  /**
+   * The current node distance.
+   *
+   * <p>This is not required; the driver reports it in {@link Node#getDistance()}, but for
+   * informational purposes only. It is not used anywhere internally.
+   */
+  NodeDistance getDistance();
+
+  /**
+   * The current reconnecting status.
+   *
+   * <p>This is not required; the driver reports it in {@link Node#isReconnecting()}, but for
+   * informational purposes only. It is not used anywhere internally.
+   */
+  boolean isReconnecting();
+
+  /**
+   * The current number of opened connections to the host.
+   *
+   * <p>This is not required; the driver reports it in {@link Node#getOpenConnections()}, but for
+   * informational purposes only. It is not used anywhere internally.
+   */
+  int getOpenConnections();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/DebugQueryPlan.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/DebugQueryPlan.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util.collection;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.loadbalancing.nodeset.LazyCopyQueryPlan;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Serializable;
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.Queue;
+import net.jcip.annotations.ThreadSafe;
+
+/** A query plan that attaches debug information to original query plan. */
+@ThreadSafe
+public class DebugQueryPlan extends AbstractQueue<Node> implements QueryPlan {
+  private final Queue<Node> plan;
+  private Queue<Node> localPlan;
+  private Serializable policyInfo;
+  private Serializable policyWrapperInfo;
+
+  public DebugQueryPlan(@NonNull Queue<Node> originalPlan) {
+    if (originalPlan instanceof LazyCopyQueryPlan) {
+      this.plan = originalPlan;
+    } else {
+      this.plan = new LazyCopyQueryPlan(originalPlan);
+    }
+  }
+
+  @Override
+  public Iterator<Node> iterator() {
+    return this.plan.iterator();
+  }
+
+  @Override
+  public int size() {
+    return this.plan.size();
+  }
+
+  public QueryPlan setLocalPlan(@NonNull QueryPlan plan) {
+    LazyCopyQueryPlan copyPlan = new LazyCopyQueryPlan(plan);
+    this.localPlan = copyPlan;
+    return copyPlan;
+  }
+
+  public void setLoadBalancingPolicyInfo(Serializable policyInfo) {
+    this.policyInfo = policyInfo;
+  }
+
+  public void setLoadBalancingPolicyWrapperInfo(Serializable policyWrapperInfo) {
+    this.policyWrapperInfo = policyWrapperInfo;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder result = new StringBuilder();
+    result.append(this.getClass().getName()).append("(plan: ").append(plan);
+    if (this.policyInfo != null) {
+      result.append(", policy: ").append(policyInfo);
+    }
+    if (this.policyWrapperInfo != null) {
+      result.append(", wrapper: ").append(policyWrapperInfo);
+    }
+    if (this.localPlan != null) {
+      result.append(", localPlan: ").append(localPlan);
+    }
+    result.append(")");
+    return result.toString();
+  }
+
+  @Override
+  public Node poll() {
+    return plan.poll();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/EmptyQueryPlan.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/EmptyQueryPlan.java
@@ -42,4 +42,9 @@ class EmptyQueryPlan extends AbstractQueue<Node> implements QueryPlan {
   public int size() {
     return 0;
   }
+
+  @Override
+  public String toString() {
+    return "EmptyQueryPlan";
+  }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -535,6 +535,12 @@ datastax-java-driver {
     #   change.
     # Overridable in a profile: no
     warn-on-init-error = true
+
+    # TBD: Add more details here
+    # Required: no
+    # Modifiable at runtime: no
+    # Overridable in a profile: yes
+    detailed-query-plan-exceptions = false
   }
 
   # Advanced options for the built-in load-balancing policies.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/LazyCopyQueryPlanTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/nodeset/LazyCopyQueryPlanTest.java
@@ -1,0 +1,54 @@
+package com.datastax.oss.driver.internal.core.loadbalancing.nodeset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.Test;
+
+public class LazyCopyQueryPlanTest {
+  @Test
+  public void toString_returns_proper_results_after_poll() {
+    Queue<Node> original = new ConcurrentLinkedQueue<Node>();
+    original.add(mockNode("dc1"));
+    original.add(mockNode("dc2"));
+    Queue<Node> lc = new LazyCopyQueryPlan(original);
+    assertThat(lc.toString())
+        .isEqualTo(
+            "java.util.concurrent.ConcurrentLinkedQueue(inQueue: ["
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc1, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0), "
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc2, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0)"
+                + "], itemsPulled: [])");
+    lc.poll();
+    assertThat(lc.toString())
+        .isEqualTo(
+            "java.util.concurrent.ConcurrentLinkedQueue(inQueue: ["
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc2, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0)"
+                + "], itemsPulled: ["
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc1, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0)"
+                + "])");
+    lc.poll();
+    assertThat(lc.toString())
+        .isEqualTo(
+            "java.util.concurrent.ConcurrentLinkedQueue(inQueue: [], itemsPulled: ["
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc1, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0), "
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc2, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0)])");
+
+    // Make sure that when queue is exhausted next poll does not break toString results
+    lc.poll();
+    assertThat(lc.toString())
+        .isEqualTo(
+            "java.util.concurrent.ConcurrentLinkedQueue(inQueue: [], itemsPulled: ["
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc1, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0), "
+                + "DefaultNodeInfo(hostId: null, endPoint: null, datacenter: dc2, rack: null, distance: null, schemaVersion: null, broadcastRpcAddress: null, broadcastAddress: null, listenAddress: null, partitioner: null, isReconnecting: false, openConnections: 0)])");
+  }
+
+  private Node mockNode(String dc) {
+    Node node = mock(Node.class);
+    when(node.getDatacenter()).thenReturn(dc);
+    return node;
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy.DistanceReporter;
@@ -77,6 +78,9 @@ public class LoadBalancingPolicyWrapperTest {
   @Mock protected MetricsFactory metricsFactory;
   @Captor private ArgumentCaptor<Map<UUID, Node>> initNodesCaptor;
 
+  private static final DriverConfigLoader configLoader =
+      DriverConfigLoader.programmaticBuilder().build();
+
   private LoadBalancingPolicyWrapper wrapper;
 
   @Before
@@ -103,6 +107,7 @@ public class LoadBalancingPolicyWrapperTest {
 
     eventBus = spy(new EventBus("test"));
     when(context.getEventBus()).thenReturn(eventBus);
+    when(context.getConfig()).thenReturn(configLoader.getInitialConfig());
 
     wrapper =
         new LoadBalancingPolicyWrapper(

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -186,6 +186,10 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     return ccmBridge.getCassandraVersion();
   }
 
+  public CcmBridge getCcmBridge() {
+    return ccmBridge;
+  }
+
   public Optional<Version> getDseVersion() {
     return ccmBridge.getDseVersion();
   }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
@@ -63,6 +63,7 @@ public class CustomCcmRule extends BaseCcmRule {
     }
   }
 
+  @Override
   public CcmBridge getCcmBridge() {
     return ccmBridge;
   }


### PR DESCRIPTION
Closes https://github.com/scylladb/java-driver/issues/368

## Before
###  `NoNodeAvailableException`
```
 NoNodeAvailableException(showing first 0 nodes):
com.datastax.oss.driver.api.core.NoNodeAvailableException: No node was available to execute the query
at com.datastax.oss.driver.api.core.NoNodeAvailableException.copy(NoNodeAvailableException.java:56)
at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:151)
at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:55)
at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:32)
at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:239)
at datadog.trace.instrumentation.datastax.cassandra4.TracingSession.wrapSyncRequest(TracingSession.java:65)
at datadog.trace.instrumentation.datastax.cassandra4.TracingSession.execute(TracingSession.java:47)
at com.datastax.oss.driver.api.core.cql.SyncCqlSession.execute(SyncCqlSession.java:56)
at com.datastax.oss.driver.internal.mapper.DaoBase.execute(DaoBase.java:188)
```

### `AllNodesFailedException`

## After
###  `NoNodeAvailableException`
```
com.datastax.oss.driver.api.core.NoNodeAvailableException: No node was available to execute the query. Query Plan: com.datastax.oss.driver.internal.core.util.collection.DebugQueryPlan(plan: com.datastax.oss.driver.internal.core.util.collection.EmptyQueryPlan(inQueue: [], itemsPulled: []), policy: DefaultLoadBalancingPolicyDebugInfo{localDc: dc1, localRack: null, liveNodes: SingleDcNodeSetInfo(dc:dc1, dcs: [dc1], nodes: []), replicas: null, defaultConsistencyLevel: LOCAL_ONE, allowDcFailoverForLocalCl: false, maxNodesPerRemoteDc: 0, responseTimes: {Node(endPoint=test.cluster.fake:9042, hostId=a2e2a335-7cf6-4693-a3d6-898e2496c2ee, hashCode=9e10e5a)=[20538401028950]}, upTimes: {}, avoidSlowReplicas: true}, localPlan: com.datastax.oss.driver.internal.core.loadbalancing.nodeset.LazyCopyQueryPlan(inQueue: [], itemsPulled: []))

	at com.datastax.oss.driver.api.core.NoNodeAvailableException.copy(NoNodeAvailableException.java:56)
	at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:151)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:55)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:32)
	at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:239)
	at com.datastax.oss.driver.api.core.cql.SyncCqlSession.execute(SyncCqlSession.java:56)
	at com.datastax.oss.driver.api.core.cql.SyncCqlSession.execute(SyncCqlSession.java:80)
	at com.datastax.oss.driver.core.resolver.MockResolverIT.should_connect_with_mocked_hostname(MockResolverIT.java:95)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
```

### `AllNodesFailedException`
