### PR TITLE
fix: 4.x can't connect to the cluster when first node is non responsive

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          pip3 install https://github.com/scylladb/scylla-ccm/archive/81076bce792a0fb3f2050e4c209a93e4a62ab55f.zip
+          pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
 
       - name: Get cassandra version
         id: cassandra-version

--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.java
@@ -21,6 +21,7 @@ import com.datastax.dse.driver.api.core.auth.BaseDseAuthenticator;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.shaded.guava.common.base.Charsets;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.InetSocketAddress;
@@ -29,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
@@ -169,6 +171,12 @@ public abstract class PlainTextAuthProviderBase implements AuthProvider {
           @Override
           public SocketAddress resolve() {
             return new InetSocketAddress("127.0.0.1", 9042);
+          }
+
+          @NonNull
+          @Override
+          public List<EndPoint> resolveAll() {
+            return ImmutableList.of(this);
           }
 
           @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/EndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/EndPoint.java
@@ -20,6 +20,7 @@ package com.datastax.oss.driver.api.core.metadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 
 /**
  * Encapsulates the information needed to open connections to a node.
@@ -40,6 +41,13 @@ public interface EndPoint {
   @NonNull
   SocketAddress resolve();
 
+  /**
+   * Resolves this instance to a list of {@link EndPoint}.
+   *
+   * <p>This is called occasionally to resolve unresolved endpoints to their resolved counterparts.
+   */
+  @NonNull
+  List<EndPoint> resolveAll();
   /**
    * Returns an alternate string representation for use in node-level metric names.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultEndPoint.java
@@ -18,9 +18,11 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Objects;
 
 public class DefaultEndPoint implements EndPoint, Serializable {
@@ -39,6 +41,12 @@ public class DefaultEndPoint implements EndPoint, Serializable {
   @Override
   public InetSocketAddress resolve() {
     return address;
+  }
+
+  @NonNull
+  @Override
+  public List<EndPoint> resolveAll() {
+    return ImmutableList.of(this);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
@@ -72,20 +72,26 @@ class InitialNodeListRefresh extends NodesRefresh {
                 + "keeping only the first one",
             logPrefix,
             hostId);
+        continue;
+      }
+      EndPoint endPoint = nodeInfo.getEndPoint();
+      DefaultNode node = findIn(contactPoints, endPoint);
+      if (node == null) {
+        node = new DefaultNode(endPoint, context);
+        LOG.debug("[{}] Adding new node {}", logPrefix, node);
       } else {
-        EndPoint endPoint = nodeInfo.getEndPoint();
-        DefaultNode node = findIn(contactPoints, endPoint);
-        if (node == null) {
-          node = new DefaultNode(endPoint, context);
-          LOG.debug("[{}] Adding new node {}", logPrefix, node);
-        } else {
-          LOG.debug("[{}] Copying contact point {}", logPrefix, node);
-        }
-        if (tokenMapEnabled && tokenFactory == null && nodeInfo.getPartitioner() != null) {
+        LOG.debug("[{}] Copying contact point {}", logPrefix, node);
+      }
+      copyInfos(nodeInfo, node, context);
+      newNodes.put(hostId, node);
+    }
+
+    if (tokenMapEnabled) {
+      for (NodeInfo nodeInfo : nodeInfos) {
+        if (nodeInfo.getPartitioner() != null) {
           tokenFactory = tokenFactoryRegistry.tokenFactoryFor(nodeInfo.getPartitioner());
+          break;
         }
-        copyInfos(nodeInfo, node, context);
-        newNodes.put(hostId, node);
       }
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetAddress;
@@ -25,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -70,6 +72,12 @@ public class SniEndPoint implements EndPoint {
       throw new IllegalArgumentException(
           "Could not resolve proxy address " + proxyAddress.getHostName(), e);
     }
+  }
+
+  @NonNull
+  @Override
+  public List<EndPoint> resolveAll() {
+    return ImmutableList.of(this);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/UnresolvedEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/UnresolvedEndPoint.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UnresolvedEndPoint implements EndPoint, Serializable {
+  private final String metricPrefix;
+  String host;
+  int port;
+
+  private final List<EndPoint> EMPTY = new ArrayList<>();
+
+  public UnresolvedEndPoint(String host, int port) {
+    this.host = host;
+    this.port = port;
+    this.metricPrefix = buildMetricPrefix(host, port);
+  }
+
+  @NonNull
+  @Override
+  public SocketAddress resolve() {
+    throw new RuntimeException(
+        String.format(
+            "This endpoint %s should never been resolved, but it happened, it somehow leaked to downstream code.",
+            this));
+  }
+
+  @NonNull
+  @Override
+  public List<EndPoint> resolveAll() {
+    try {
+      InetAddress[] inetAddresses = InetAddress.getAllByName(host);
+      Set<EndPoint> result = new HashSet<>();
+      for (InetAddress inetAddress : inetAddresses) {
+        result.add(new DefaultEndPoint(new InetSocketAddress(inetAddress, port)));
+      }
+      return new ArrayList<>(result);
+    } catch (UnknownHostException e) {
+      return EMPTY;
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (other instanceof UnresolvedEndPoint) {
+      UnresolvedEndPoint that = (UnresolvedEndPoint) other;
+      return this.host.equals(that.host) && this.port == that.port;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return host.toLowerCase().hashCode() + port;
+  }
+
+  @Override
+  public String toString() {
+    return host + ":" + port;
+  }
+
+  @NonNull
+  @Override
+  public String asMetricPrefix() {
+    return metricPrefix;
+  }
+
+  private static String buildMetricPrefix(String host, int port) {
+    // Append the port since Cassandra 4 supports nodes with different ports
+    return host.replace('.', '_') + ':' + port;
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
@@ -29,6 +29,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.metadata.UnresolvedEndPoint;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.net.InetAddress;
@@ -94,9 +95,7 @@ public class ContactPointsTest {
     Set<EndPoint> endPoints =
         ContactPoints.merge(Collections.emptySet(), ImmutableList.of("localhost:9042"), false);
 
-    assertThat(endPoints)
-        .containsExactly(
-            new DefaultEndPoint(InetSocketAddress.createUnresolved("localhost", 9042)));
+    assertThat(endPoints).containsExactly(new UnresolvedEndPoint("localhost", 9042));
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/EmbeddedEndPoint.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/EmbeddedEndPoint.java
@@ -20,6 +20,7 @@ package com.datastax.oss.driver.internal.core.channel;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.SocketAddress;
+import java.util.List;
 
 /** Endpoint implementation for unit tests that use an embedded Netty channel. */
 public class EmbeddedEndPoint implements EndPoint {
@@ -27,6 +28,12 @@ public class EmbeddedEndPoint implements EndPoint {
   @NonNull
   @Override
   public SocketAddress resolve() {
+    throw new UnsupportedOperationException("This should not get called from unit tests");
+  }
+
+  @NonNull
+  @Override
+  public List<EndPoint> resolveAll() {
     throw new UnsupportedOperationException("This should not get called from unit tests");
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/LocalEndPoint.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/LocalEndPoint.java
@@ -18,9 +18,11 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.netty.channel.local.LocalAddress;
 import java.net.SocketAddress;
+import java.util.List;
 
 /** Endpoint implementation for unit tests that use the local Netty transport. */
 public class LocalEndPoint implements EndPoint {
@@ -35,6 +37,12 @@ public class LocalEndPoint implements EndPoint {
   @Override
   public SocketAddress resolve() {
     return localAddress;
+  }
+
+  @NonNull
+  @Override
+  public List<EndPoint> resolveAll() {
+    return ImmutableList.of(this);
   }
 
   @NonNull


### PR DESCRIPTION
Closes #356

Since netty `bootstrap.connect` uses only first address of unresolved InetSocketAddress 4.x does not even try to connect to other when it fails.
This PR makes driver resolve unresolved endpoint itself and only then handing it over `bootstrap.connect`
