### PR TITLE
Make ScyllaSniProxyTest tests to wait before checking on events API calls

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScyllaSniProxyTest.java
@@ -69,6 +69,10 @@ public class ScyllaSniProxyTest extends CCMTestsSupport {
 
     // Sometimes (probably due to reconnection) both events can be read twice
     // assertingListener ensures we deal with the same keyspace and table
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException ignored) {
+    }
     verify(listener, atLeast(1)).onTableAdded(any(TableMetadata.class));
     verify(listener, atMost(2)).onTableAdded(any(TableMetadata.class));
     verify(listener, atLeast(1)).onKeyspaceAdded(any(KeyspaceMetadata.class));


### PR DESCRIPTION
Closes https://github.com/scylladb/java-driver/issues/358

ScyllaSniProxyTest tests creates a table and right away check of listener APIs.
Since listener API is called asynchronously it can fail.

