### PR TITLE
3.x: Reenable TabletsIT

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/TabletsIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TabletsIT.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.exceptions.SyntaxError;
 import com.datastax.driver.core.utils.ScyllaOnly;
-import com.datastax.driver.core.utils.ScyllaSkip;
+import com.datastax.driver.core.utils.ScyllaVersion;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import org.testng.Assert;
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
       "--experimental-features=tablets"
     })
 @ScyllaOnly
-@ScyllaSkip // There is no released version with tablets-routing-v1 currently
+@ScyllaVersion(minOSS = "6.0.0", minEnterprise = "2024.2", description = "Needs to support tablets")
 public class TabletsIT extends CCMTestsSupport {
 
   private static final int INITIAL_TABLETS = 32;

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/ScyllaVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/ScyllaVersion.java
@@ -1,0 +1,32 @@
+package com.datastax.driver.core.utils;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a Class or Method that defines a Scylla Version requirement. If the Scylla version
+ * in use does not meet the version requirement, the test is skipped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ScyllaVersion {
+  /** @return The minimum Enterprise version required to execute this test, i.e. "2020.1.13" */
+  String minEnterprise() default "";
+
+  /**
+   * @return the maximum exclusive Enterprise version allowed to execute this test, i.e. "2021.1.12"
+   *     means only tests &lt; "2021.1.12" may execute this test.
+   */
+  String maxEnterprise() default "";
+
+  /** @return The minimum OSS version required to execute this test, i.e. "4.5.6" */
+  String minOSS() default "";
+
+  /**
+   * @return the maximum exclusive OSS version allowed to execute this test, i.e. "5.0.0" means only
+   *     tests &lt; "5.0.0" may execute this test.
+   */
+  String maxOSS() default "";
+
+  /** @return The description returned if this version requirement is not met. */
+  String description() default "Does not meet Scylla version requirement.";
+}


### PR DESCRIPTION
Adds ScyllaVersion annotation and reenables TabletsIT, annotated with relevant versions.