### PR TITLE
docs: add missing utils

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copy contents
+mkdir gh-pages
+cp -r ./docs/_build/dirhtml/. gh-pages
+
+# Create gh-pages branch
+cd gh-pages
+git init
+git config --local user.email "action@scylladb.com"
+git config --local user.name "GitHub Action"
+git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -b gh-pages
+
+# Deploy
+git add .
+git commit -m "Publish docs" || true
+git push origin gh-pages --force

--- a/docs/_utils/javadoc.sh
+++ b/docs/_utils/javadoc.sh
@@ -14,4 +14,4 @@ fi
 mvn javadoc:javadoc -T 1C
 [ -d $OUTPUT_DIR ] && rm -r $OUTPUT_DIR
 mkdir -p "$OUTPUT_DIR"
-mv -f core/target/site/apidocs/* $OUTPUT_DIR
+mv -f driver-core/target/site/apidocs/* $OUTPUT_DIR


### PR DESCRIPTION
Adding some missing files when backporting contents from `scylla-3.x` to`scylla-4.x`:

Should fix https://github.com/scylladb/java-driver/actions/runs/11911923245/job/33194455158

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/2a44de98-3a41-4985-a0ed-2dba0879aa89">


