### PR TITLE
3.x: Make TabletMap return empty replica set when stale replica is found

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -570,9 +569,9 @@ public class Metadata {
       if (keyspace != null && table != null) {
         Token token = partitioner.hash(partitionKey);
         assert (token instanceof Token.TokenLong64);
-        Set<UUID> hostUuids = tabletMap.getReplicas(keyspace, table, (long) token.getValue());
-        if (!hostUuids.isEmpty()) {
-          return hostUuids.stream().map(this::getHost).collect(Collectors.toSet());
+        Set<Host> replicas = tabletMap.getReplicas(keyspace, table, (long) token.getValue());
+        if (!replicas.isEmpty()) {
+          return replicas;
         }
       }
       // Fall back to tokenMap

--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMapListener.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMapListener.java
@@ -1,5 +1,7 @@
 package com.datastax.driver.core;
 
+// This class does not handle topology changes. Node removal is covered by TabletMap#getReplicas()
+// implementation and tablet overlap is resolved when adding new tablets.
 public class TabletMapListener extends SchemaChangeListenerBase {
   private final TabletMap tabletMap;
 


### PR DESCRIPTION
Makes TabletMap return empty collection for some calls to `getReplicas(...)`. If the current replica list for a tablet turns out to contain a host that is not present in current Metadata then empty collection is returned in an effort to misroute the query. This query will cause the tablet information to be updated when the result with the up to date information is received.
It is possible that the query will be randomly routed correctly, but this case is significantly less likely with each subsequent query, although this can depend on underlying load balancing policy.

This covers the node removal/replacement case of #378.