### PR TITLE
3.x: Allow additional `scylla.version` formats

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTests.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTests.java
@@ -47,8 +47,7 @@ public class DnsEndpointTests {
       logger.info("Queried node has broadcast_address: {}}", address);
       System.out.flush();
     } finally {
-      assert bridgeA != null;
-      bridgeA.close();
+      if (bridgeA != null) bridgeA.close();
     }
 
     CCMBridge bridgeB = null;
@@ -72,8 +71,7 @@ public class DnsEndpointTests {
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     } finally {
-      assert bridgeB != null;
-      bridgeB.close();
+      if (bridgeB != null) bridgeB.close();
     }
   }
 


### PR DESCRIPTION
Modifies version parsing logic to try passing the `scylla.version` to the
CCM when it can't be parsed as VersionNumber. If CCM manages to run `create`
with it, then the usual version number is fetched from
`ccm node versionfrombuild` output.

To do that we introduce a static version of `execute`. The method body is
nearly the same. Functionally should be the same. Previous version now calls
the static one.