### PR TITLE
3.x: Disable `CCMBridgeTest#should_make_JMX_connection()` for OSS >= 6.2.0

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datastax.driver.core.utils.ScyllaVersion;
 import java.net.InetSocketAddress;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -29,6 +30,9 @@ import org.testng.annotations.Test;
 public class CCMBridgeTest extends CCMTestsSupport {
 
   @Test(groups = "short")
+  @ScyllaVersion(
+      maxOSS = "6.2.0",
+      description = "JMX was dropped in scylladb/3cd2a6173668c5a13b6e674f912ff597f76422f5")
   public void should_make_JMX_connection() throws Exception {
     InetSocketAddress addr1 = ccm().jmxAddressOfNode(1);
     InetSocketAddress addr2 = ccm().jmxAddressOfNode(2);


### PR DESCRIPTION

JMX was dropped since that version, so the test is bound to fail.