### PR TITLE
3.x: Add config for allowing zero-token nodes

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -1008,7 +1008,11 @@ class ControlConnection implements Connection.Owner {
               && peerRow.getColumnDefinitions().contains("rack")
               && !peerRow.isNull("rack")
               && peerRow.getColumnDefinitions().contains("tokens")
-              && !peerRow.isNull("tokens");
+              && (!peerRow.isNull("tokens")
+                  || cluster
+                      .configuration
+                      .getQueryOptions()
+                      .shouldConsiderZeroTokenNodesValidPeers());
     }
     if (!isValid && logIfInvalid)
       logger.warn(

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
@@ -73,6 +73,7 @@ public class QueryOptions {
   private volatile boolean schemaQueriesPaged = true;
 
   private volatile boolean addOriginalContactsToReconnectionPlan = false;
+  private volatile boolean considerZeroTokenNodesValidPeers = false;
 
   /**
    * Creates a new {@link QueryOptions} instance using the {@link #DEFAULT_CONSISTENCY_LEVEL},
@@ -519,6 +520,21 @@ public class QueryOptions {
 
   public boolean shouldAddOriginalContactsToReconnectionPlan() {
     return this.addOriginalContactsToReconnectionPlan;
+  }
+
+  /**
+   * Recently introduced in Scylla zero-token nodes have null value in "tokens" column in their
+   * system.peers rows. By default extended peer check considers such rows as invalid. Enabling this
+   * option will exclude this field from the check, and allow such rows from system.peers queries to
+   * be used when refreshing metadata.
+   */
+  public QueryOptions setConsiderZeroTokenNodesValidPeers(boolean enabled) {
+    this.considerZeroTokenNodesValidPeers = enabled;
+    return this;
+  }
+
+  public boolean shouldConsiderZeroTokenNodesValidPeers() {
+    return this.considerZeroTokenNodesValidPeers;
   }
 
   @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesIT.java
@@ -1,0 +1,287 @@
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.datastax.driver.core.utils.ScyllaVersion;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ZeroTokenNodesIT {
+
+  @DataProvider(name = "loadBalancingPolicies")
+  public static Object[][] loadBalancingPolicies() {
+    return new Object[][] {
+      {DCAwareRoundRobinPolicy.builder().build()},
+      {new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().build())},
+      {new TokenAwarePolicy(new RoundRobinPolicy())}
+    };
+  }
+
+  @Test(groups = "short")
+  @ScyllaVersion(
+      minOSS = "6.2.0",
+      minEnterprise = "2024.2.2",
+      description = "Zero-token nodes introduced in scylladb/scylladb#19684")
+  public void should_not_ignore_zero_token_peer_when_option_is_enabled() {
+    Cluster cluster = null;
+    Session session = null;
+    CCMBridge ccmBridge = null;
+    try {
+      ccmBridge =
+          CCMBridge.builder().withNodes(3).withIpPrefix("127.0.1.").withBinaryPort(9042).build();
+      ccmBridge.start();
+      ccmBridge.add(4);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.start(4);
+      ccmBridge.waitForUp(4);
+
+      cluster =
+          Cluster.builder()
+              .withQueryOptions(new QueryOptions().setConsiderZeroTokenNodesValidPeers(true))
+              .addContactPointsWithPorts(new InetSocketAddress(ccmBridge.ipOfNode(1), 9042))
+              .withPort(9042)
+              .withoutAdvancedShardAwareness()
+              .build();
+      session = cluster.connect();
+
+      assertThat(cluster.manager.controlConnection.connectedHost().getEndPoint().resolve())
+          .isEqualTo(ccmBridge.addressOfNode(1));
+      Set<Host> hosts = cluster.getMetadata().getAllHosts();
+      Set<String> toStrings = hosts.stream().map(Host::toString).collect(Collectors.toSet());
+      assertThat(toStrings)
+          .containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042", "/127.0.1.4:9042");
+    } finally {
+      if (ccmBridge != null) ccmBridge.close();
+      if (session != null) session.close();
+      if (cluster != null) cluster.close();
+    }
+  }
+
+  @Test(groups = "short")
+  @ScyllaVersion(
+      minOSS = "6.2.0",
+      minEnterprise = "2024.2.2",
+      description = "Zero-token nodes introduced in scylladb/scylladb#19684")
+  public void should_not_discover_zero_token_DC_when_option_is_disabled() {
+    Cluster cluster = null;
+    Session session = null;
+    CCMBridge ccmBridge = null;
+    try {
+      ccmBridge =
+          CCMBridge.builder().withNodes(2).withIpPrefix("127.0.1.").withBinaryPort(9042).build();
+      ccmBridge.start();
+      ccmBridge.add(2, 3);
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.start(3);
+      ccmBridge.add(2, 4);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.start(4);
+      ccmBridge.waitForUp(3);
+      ccmBridge.waitForUp(4);
+
+      cluster =
+          Cluster.builder()
+              .withQueryOptions(new QueryOptions().setConsiderZeroTokenNodesValidPeers(false))
+              .addContactPointsWithPorts(new InetSocketAddress(ccmBridge.ipOfNode(1), 9042))
+              .withPort(9042)
+              .withoutAdvancedShardAwareness()
+              .build();
+      session = cluster.connect();
+
+      assertThat(cluster.manager.controlConnection.connectedHost().getEndPoint().resolve())
+          .isEqualTo(ccmBridge.addressOfNode(1));
+
+      // Queries should not land on any of the zero-token DC nodes
+      session.execute("DROP KEYSPACE IF EXISTS ZeroTokenNodesIT");
+      session.execute(
+          "CREATE KEYSPACE ZeroTokenNodesIT WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};");
+      session.execute("CREATE TABLE ZeroTokenNodesIT.tab (id INT PRIMARY KEY)");
+      for (int i = 0; i < 30; i++) {
+        ResultSet rs = session.execute("INSERT INTO ZeroTokenNodesIT.tab (id) VALUES (" + i + ")");
+        assertThat(rs.getExecutionInfo().getQueriedHost().getEndPoint().resolve())
+            .isNotIn(ccmBridge.addressOfNode(3), ccmBridge.addressOfNode(4));
+        assertThat(rs.getExecutionInfo().getQueriedHost().getEndPoint().resolve())
+            .isIn(ccmBridge.addressOfNode(1), ccmBridge.addressOfNode(2));
+      }
+
+      Set<Host> hosts = cluster.getMetadata().getAllHosts();
+      Set<String> toStrings = hosts.stream().map(Host::toString).collect(Collectors.toSet());
+      assertThat(toStrings).containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042");
+    } finally {
+      if (ccmBridge != null) ccmBridge.close();
+      if (session != null) session.close();
+      if (cluster != null) cluster.close();
+    }
+  }
+
+  @Test(groups = "short", dataProvider = "loadBalancingPolicies")
+  @ScyllaVersion(
+      minOSS = "6.2.0",
+      minEnterprise = "2024.2.2",
+      description = "Zero-token nodes introduced in scylladb/scylladb#19684")
+  public void should_discover_zero_token_DC_when_option_is_enabled(
+      LoadBalancingPolicy loadBalancingPolicy) {
+    // Makes sure that with QueryOptions.setConsiderZeroTokenNodesValidPeers(true)
+    // the zero-token peers will be discovered and added to metadata
+    Cluster cluster = null;
+    Session session = null;
+    CCMBridge ccmBridge = null;
+    try {
+      ccmBridge =
+          CCMBridge.builder().withNodes(2).withIpPrefix("127.0.1.").withBinaryPort(9042).build();
+      ccmBridge.start();
+      ccmBridge.add(2, 3);
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.start(3);
+      ccmBridge.add(2, 4);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.start(4);
+      ccmBridge.waitForUp(3);
+      ccmBridge.waitForUp(4);
+
+      cluster =
+          Cluster.builder()
+              .withQueryOptions(new QueryOptions().setConsiderZeroTokenNodesValidPeers(true))
+              .addContactPointsWithPorts(new InetSocketAddress(ccmBridge.ipOfNode(1), 9042))
+              .withPort(9042)
+              .withLoadBalancingPolicy(loadBalancingPolicy)
+              .withoutAdvancedShardAwareness()
+              .build();
+      session = cluster.connect();
+
+      assertThat(cluster.manager.controlConnection.connectedHost().getEndPoint().resolve())
+          .isEqualTo(ccmBridge.addressOfNode(1));
+
+      // Currently zero-token nodes are treated as normal nodes if allowed.
+      // Later on we may want to adjust the LBP behavior to be more sophisticated.
+      session.execute("DROP KEYSPACE IF EXISTS ZeroTokenNodesIT");
+      session.execute(
+          "CREATE KEYSPACE ZeroTokenNodesIT WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};");
+      session.execute("CREATE TABLE ZeroTokenNodesIT.tab (id INT PRIMARY KEY)");
+      Set<InetSocketAddress> queriedNodes = new HashSet<>();
+      for (int i = 0; i < 30; i++) {
+        ResultSet rs = session.execute("INSERT INTO ZeroTokenNodesIT.tab (id) VALUES (" + i + ")");
+        queriedNodes.add(rs.getExecutionInfo().getQueriedHost().getEndPoint().resolve());
+      }
+      assertThat(queriedNodes)
+          .containsExactly(
+              ccmBridge.addressOfNode(1),
+              ccmBridge.addressOfNode(2),
+              ccmBridge.addressOfNode(3),
+              ccmBridge.addressOfNode(4));
+
+      Set<Host> hosts = cluster.getMetadata().getAllHosts();
+      Set<String> toStrings = hosts.stream().map(Host::toString).collect(Collectors.toSet());
+      assertThat(toStrings)
+          .containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042", "/127.0.1.4:9042");
+    } finally {
+      if (ccmBridge != null) ccmBridge.close();
+      if (session != null) session.close();
+      if (cluster != null) cluster.close();
+    }
+  }
+
+  @Test(groups = "short")
+  @ScyllaVersion(
+      minOSS = "6.2.0",
+      minEnterprise = "2024.2.2",
+      description = "Zero-token nodes introduced in scylladb/scylladb#19684")
+  public void should_connect_to_zero_token_contact_point() {
+    Cluster cluster = null;
+    Session session = null;
+    CCMBridge ccmBridge = null;
+
+    try {
+      ccmBridge =
+          CCMBridge.builder().withNodes(2).withIpPrefix("127.0.1.").withBinaryPort(9042).build();
+      ccmBridge.start();
+      ccmBridge.add(3);
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.start(3);
+      ccmBridge.waitForUp(3);
+
+      cluster =
+          Cluster.builder()
+              .withQueryOptions(
+                  new QueryOptions()
+                      // Already implicitly false, but making sure
+                      .setConsiderZeroTokenNodesValidPeers(false))
+              .addContactPointsWithPorts(new InetSocketAddress(ccmBridge.ipOfNode(3), 9042))
+              .withPort(9042)
+              .withoutAdvancedShardAwareness()
+              .build();
+      session = cluster.connect();
+
+      assertThat(cluster.manager.controlConnection.connectedHost().getEndPoint().resolve())
+          .isEqualTo(ccmBridge.addressOfNode(3));
+
+      Set<Host> hosts = cluster.getMetadata().getAllHosts();
+      Set<String> toStrings = hosts.stream().map(Host::toString).collect(Collectors.toSet());
+      assertThat(toStrings).containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042");
+    } finally {
+      if (ccmBridge != null) ccmBridge.close();
+      if (session != null) session.close();
+      if (cluster != null) cluster.close();
+    }
+  }
+
+  @Test(groups = "short")
+  @ScyllaVersion(
+      minOSS = "6.2.0",
+      minEnterprise = "2024.2.2",
+      description = "Zero-token nodes introduced in scylladb/scylladb#19684")
+  public void should_connect_to_zero_token_DC() {
+    // This test is similar but not exactly the same as should_connect_to_zero_token_contact_point.
+    // In the future we may want to have different behavior for arbiter DCs and adjust this test
+    // method.
+    Cluster cluster = null;
+    Session session = null;
+    CCMBridge ccmBridge = null;
+
+    try {
+      ccmBridge =
+          CCMBridge.builder().withNodes(2).withIpPrefix("127.0.1.").withBinaryPort(9042).build();
+      ccmBridge.start();
+      ccmBridge.add(2, 3);
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.start(3);
+      ccmBridge.add(2, 4);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.start(4);
+      ccmBridge.waitForUp(3);
+      ccmBridge.waitForUp(4);
+
+      cluster =
+          Cluster.builder()
+              .withQueryOptions(new QueryOptions().setConsiderZeroTokenNodesValidPeers(false))
+              .addContactPointsWithPorts(new InetSocketAddress(ccmBridge.ipOfNode(3), 9042))
+              .withPort(9042)
+              .withoutAdvancedShardAwareness()
+              .build();
+      session = cluster.connect();
+
+      assertThat(cluster.manager.controlConnection.connectedHost().getEndPoint().resolve())
+          .isEqualTo(ccmBridge.addressOfNode(3));
+
+      Set<Host> hosts = cluster.getMetadata().getAllHosts();
+      Set<String> toStrings = hosts.stream().map(Host::toString).collect(Collectors.toSet());
+      assertThat(toStrings)
+          // node 3 will be discovered because it's a contact point. Node 4 will not because it's a
+          // peer
+          // and the setting is disabled
+          .containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042");
+    } finally {
+      if (ccmBridge != null) ccmBridge.close();
+      if (session != null) session.close();
+      if (cluster != null) cluster.close();
+    }
+  }
+}


### PR DESCRIPTION
Adds an option that controls if `system.peers` rows without tokens should
be considered valid. Enabling this option will allow discovering zero-token
peers with extended_peer_check enabled (it is enabled by default).

Adds ZeroTokenNodesIT that verifies the driver behavior. It also contains
some test methods relating to zero-token DCs. The special driver behavior for
arbiter DCs is not yet fully decided so those methods can change in the future.