### PR TITLE
4.x: Add config for zero-token nodes & ZeroTokenNodesIT

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -589,6 +589,12 @@ public enum DefaultDriverOption implements DriverOption {
   HEARTBEAT_TIMEOUT("advanced.heartbeat.timeout"),
 
   /**
+   * Whether zero token peers should be considered valid.
+   *
+   * <p>Value-type: boolean
+   */
+  METADATA_ALLOW_ZERO_TOKEN_PEERS("advanced.metadata.allow-zero-token-peers"),
+  /**
    * How long the driver waits to propagate a Topology event.
    *
    * <p>Value-type: {@link java.time.Duration Duration}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -345,6 +345,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.SOCKET_TCP_NODELAY, true);
     map.put(TypedDriverOption.HEARTBEAT_INTERVAL, Duration.ofSeconds(30));
     map.put(TypedDriverOption.HEARTBEAT_TIMEOUT, initQueryTimeout);
+    map.put(TypedDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, false);
     map.put(TypedDriverOption.METADATA_TOPOLOGY_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_SCHEMA_ENABLED, true);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -519,6 +519,10 @@ public class TypedDriverOption<ValueT> {
   /** How long the driver waits for the response to a heartbeat. */
   public static final TypedDriverOption<Duration> HEARTBEAT_TIMEOUT =
       new TypedDriverOption<>(DefaultDriverOption.HEARTBEAT_TIMEOUT, GenericType.DURATION);
+  /** Whether zero token peers are allowed */
+  public static final TypedDriverOption<Boolean> METADATA_ALLOW_ZERO_TOKEN_PEERS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, GenericType.BOOLEAN);
   /** How long the driver waits to propagate a Topology event. */
   public static final TypedDriverOption<Duration> METADATA_TOPOLOGY_WINDOW =
       new TypedDriverOption<>(DefaultDriverOption.METADATA_TOPOLOGY_WINDOW, GenericType.DURATION);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -541,7 +541,12 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
    * node's broadcast RPC address and host ID; otherwise the driver may not work properly.
    */
   protected boolean isPeerValid(AdminRow peerRow) {
-    if (PeerRowValidator.isValid(peerRow)) {
+    if (PeerRowValidator.isValid(
+        peerRow,
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS))) {
       return true;
     } else {
       LOG.warn(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/PeerRowValidator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/PeerRowValidator.java
@@ -26,7 +26,7 @@ import net.jcip.annotations.ThreadSafe;
 public class PeerRowValidator {
 
   /** Returns {@code true} if the given peer row is valid, and {@code false} otherwise. */
-  public static boolean isValid(@NonNull AdminRow peerRow) {
+  public static boolean isValid(@NonNull AdminRow peerRow, boolean allowZeroTokenPeers) {
 
     boolean hasPeersRpcAddress = !peerRow.isNull("rpc_address");
     boolean hasPeersV2RpcAddress =
@@ -37,7 +37,11 @@ public class PeerRowValidator {
         && !peerRow.isNull("host_id")
         && !peerRow.isNull("data_center")
         && !peerRow.isNull("rack")
-        && !peerRow.isNull("tokens")
+        && (allowZeroTokenPeers || !peerRow.isNull("tokens"))
         && !peerRow.isNull("schema_version");
+  }
+
+  public static boolean isValid(@NonNull AdminRow peerRow) {
+    return isValid(peerRow, false);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementChecker.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementChecker.java
@@ -190,7 +190,12 @@ class SchemaAgreementChecker {
   }
 
   protected boolean isPeerValid(AdminRow peerRow, Map<UUID, Node> nodes) {
-    if (PeerRowValidator.isValid(peerRow)) {
+    if (PeerRowValidator.isValid(
+        peerRow,
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS))) {
       UUID hostId = peerRow.getUuid("host_id");
       Node node = nodes.get(hostId);
       if (node == null) {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1939,6 +1939,16 @@ datastax-java-driver {
   }
 
   advanced.metadata {
+    # Driver learns about other nodes through system.peers table on the node ControlConnection
+    # has reached. By default, the nodes represented by rows that have their `tokens` column empty
+    # are considered invalid. This option allows you to modify that since it is possible to
+    # have valid zero-token nodes in the cluster.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes
+    # Overridable in a profile: no
+    allow-zero-token-peers = false
+
     # Topology events are external signals that inform the driver of the state of Cassandra nodes
     # (by default, they correspond to gossip events received on the control connection).
     # The debouncer helps smoothen out oscillations if conflicting events are sent out in short

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -1,0 +1,218 @@
+package com.datastax.oss.driver.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.Version;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ZeroTokenNodesIT {
+
+  @Before
+  public void checkScyllaVersion() {
+    // minOSS = "6.2.0",
+    // minEnterprise = "2024.2.2",
+    // Zero-token nodes introduced in scylladb/scylladb#19684
+    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT);
+    if (CcmBridge.SCYLLA_ENTERPRISE) {
+      assumeTrue(
+          CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("2024.2.2"))) >= 0);
+    } else {
+      assumeTrue(CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("6.2.0"))) >= 0);
+    }
+  }
+
+  @Test
+  public void should_not_ignore_zero_token_peer_when_option_is_enabled() {
+    CqlSession session = null;
+    CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
+    try (CcmBridge ccmBridge = ccmBridgeBuilder.withNodes(3).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.startWithArgs("--wait-for-binary-proto");
+      ccmBridge.addWithoutStart(4, "dc1");
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.startWithArgs(4, "--wait-for-binary-proto");
+      DriverConfigLoader loader =
+          SessionUtils.configLoaderBuilder()
+              .withBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, true)
+              .build();
+      session =
+          CqlSession.builder()
+              .withConfigLoader(loader)
+              .addContactPoint(new InetSocketAddress(ccmBridge.getNodeIpAddress(1), 9042))
+              .build();
+
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      Set<String> toStrings =
+          nodes.stream().map(Node::getEndPoint).map(EndPoint::toString).collect(Collectors.toSet());
+      assertThat(toStrings)
+          .containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042", "/127.0.1.4:9042");
+    } finally {
+      if (session != null) session.close();
+    }
+  }
+
+  @Test
+  public void should_not_discover_zero_token_DC_when_option_is_disabled() {
+    CqlSession session = null;
+    CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
+    try (CcmBridge ccmBridge = ccmBridgeBuilder.withNodes(2, 2).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.startWithArgs("--wait-for-binary-proto");
+
+      // Not adding .withBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, false)
+      // It is implicitly false
+      DriverConfigLoader loader = SessionUtils.configLoaderBuilder().build();
+      session =
+          CqlSession.builder()
+              .withLocalDatacenter("dc1")
+              .withConfigLoader(loader)
+              .addContactPoint(new InetSocketAddress(ccmBridge.getNodeIpAddress(1), 9042))
+              .build();
+
+      Set<String> landedOn = new HashSet<>();
+      for (int i = 0; i < 30; i++) {
+        ResultSet rs = session.execute("SELECT * FROM system.local");
+        InetAddress broadcastRpcInetAddress =
+            Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
+        landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());
+      }
+      assertThat(landedOn).containsOnly("/127.0.1.1", "/127.0.1.2");
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      Set<String> toStrings =
+          nodes.stream().map(Node::getEndPoint).map(EndPoint::toString).collect(Collectors.toSet());
+      assertThat(toStrings).containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042");
+    } finally {
+      if (session != null) session.close();
+    }
+  }
+
+  @Test
+  public void should_discover_zero_token_DC_when_option_is_enabled() {
+    CqlSession session = null;
+    CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
+    try (CcmBridge ccmBridge = ccmBridgeBuilder.withNodes(2, 2).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.startWithArgs("--wait-for-binary-proto");
+
+      DriverConfigLoader loader =
+          SessionUtils.configLoaderBuilder()
+              .withBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, true)
+              .build();
+      session =
+          CqlSession.builder()
+              .withLocalDatacenter("dc1")
+              .withConfigLoader(loader)
+              .addContactPoint(new InetSocketAddress(ccmBridge.getNodeIpAddress(1), 9042))
+              .build();
+
+      Set<String> landedOn = new HashSet<>();
+      for (int i = 0; i < 30; i++) {
+        ResultSet rs = session.execute("SELECT * FROM system.local");
+        InetAddress broadcastRpcInetAddress =
+            Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
+        landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());
+      }
+      // LBP should still target local datacenter:
+      assertThat(landedOn).containsOnly("/127.0.1.1", "/127.0.1.2");
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      Set<String> toStrings =
+          nodes.stream().map(Node::getEndPoint).map(EndPoint::toString).collect(Collectors.toSet());
+      // Metadata should have all nodes:
+      assertThat(toStrings)
+          .containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042", "/127.0.1.4:9042");
+    } finally {
+      if (session != null) session.close();
+    }
+  }
+
+  @Test
+  public void should_connect_to_zero_token_contact_point() {
+    CqlSession session = null;
+    CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
+    try (CcmBridge ccmBridge = ccmBridgeBuilder.withNodes(2).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.startWithArgs("--wait-for-binary-proto");
+      ccmBridge.addWithoutStart(3, "dc1");
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.startWithArgs(3, "--wait-for-binary-proto");
+      // DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS is implicitly false
+      DriverConfigLoader loader = SessionUtils.configLoaderBuilder().build();
+      session =
+          CqlSession.builder()
+              .withConfigLoader(loader)
+              .addContactPoint(new InetSocketAddress(ccmBridge.getNodeIpAddress(3), 9042))
+              .build();
+
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      Set<String> toStrings =
+          nodes.stream().map(Node::getEndPoint).map(EndPoint::toString).collect(Collectors.toSet());
+      assertThat(toStrings).containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042");
+    } finally {
+      if (session != null) session.close();
+    }
+  }
+
+  @Test
+  public void should_connect_to_zero_token_DC() {
+    // This test is similar but not exactly the same as should_connect_to_zero_token_contact_point.
+    // In the future we may want to have different behavior for arbiter DCs and adjust this test
+    // method.
+    CqlSession session = null;
+    CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
+    try (CcmBridge ccmBridge = ccmBridgeBuilder.withNodes(2, 2).withIpPrefix("127.0.1.").build()) {
+      ccmBridge.create();
+      ccmBridge.updateNodeConfig(3, "join_ring", false);
+      ccmBridge.updateNodeConfig(4, "join_ring", false);
+      ccmBridge.startWithArgs("--wait-for-binary-proto");
+
+      DriverConfigLoader loader =
+          SessionUtils.configLoaderBuilder()
+              .withBoolean(DefaultDriverOption.METADATA_ALLOW_ZERO_TOKEN_PEERS, false)
+              .build();
+      session =
+          CqlSession.builder()
+              .withLocalDatacenter("dc1")
+              .withConfigLoader(loader)
+              .addContactPoint(new InetSocketAddress(ccmBridge.getNodeIpAddress(3), 9042))
+              .build();
+
+      Set<String> landedOn = new HashSet<>();
+      for (int i = 0; i < 30; i++) {
+        ResultSet rs = session.execute("SELECT * FROM system.local");
+        InetAddress broadcastRpcInetAddress =
+            Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
+        landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());
+      }
+      // LBP should still target local datacenter:
+      assertThat(landedOn).containsOnly("/127.0.1.1", "/127.0.1.2");
+      Collection<Node> nodes = session.getMetadata().getNodes().values();
+      Set<String> toStrings =
+          nodes.stream().map(Node::getEndPoint).map(EndPoint::toString).collect(Collectors.toSet());
+      // Metadata should have valid ordinary peers plus zero-token contact point:
+      assertThat(toStrings).containsOnly("/127.0.1.1:9042", "/127.0.1.2:9042", "/127.0.1.3:9042");
+    } finally {
+      if (session != null) session.close();
+    }
+  }
+}


### PR DESCRIPTION
Add ZeroTokenNodesIT:

Adds a test class verifying the behavior of the driver when dealing with
zero-token Scylla nodes.

Adds a configurable option which controls whether to allow zero-token nodes as
valid peers. Until now such nodes were considered invalid. Default value of
this option does not change the driver behavior.


Bundled with CcmBridge adjustments:

Adds `startWithArgs` methods that allow avoiding the default arguments like
"--wait-other-notice". This wait causes timeout in multi-dc test
utilizing `join_ring: false` so it needs to be avoided.

Adds `addWithoutStart(n, dc)`. As the name suggests it's an add that does not
immediately start the node.

Adds `updateNodeConfig` in order to allow adding new nodes with different
configurations.