### PR TITLE
3.x: Add `usesTablets` to `KeyspaceMetadata`

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -53,6 +53,9 @@ public class KeyspaceMetadata {
   final Map<String, AggregateMetadata> aggregates =
       new ConcurrentHashMap<String, AggregateMetadata>();
 
+  // Scylla feature
+  private boolean usesTablets = false;
+
   @VisibleForTesting
   @Deprecated
   KeyspaceMetadata(String name, boolean durableWrites, Map<String, String> replication) {
@@ -457,5 +460,13 @@ public class KeyspaceMetadata {
 
   ReplicationStrategy replicationStrategy() {
     return strategy;
+  }
+
+  void setUsesTablets(boolean predicate) {
+    this.usesTablets = predicate;
+  }
+
+  public boolean usesTablets() {
+    return this.usesTablets;
   }
 }


### PR DESCRIPTION
Adds the field to `KeyspaceMetadata` that informs if the keyspace has tablets
enabled. It is initialized with value `false` and updated to `true` only if
the keyspace is discovered in `system_schema.scylla_keyspaces` and its entry
has non-null value in `initial_tablets` column. The update happens on schema
refresh.

Updates `Metadata#getReplicas` to use this keyspace metadata information to
decide whether to look for replicas in the token map or tablet map.

Fixes https://github.com/scylladb/java-driver/issues/380.