### PR TITLE
Update default value and documentation of `advanced.metadata.schema.r…

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -352,7 +352,7 @@ public class OptionsMap implements Serializable {
     map.put(
         TypedDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES,
         ImmutableList.of("!system", "!/^system_.*/", "!/^dse_.*/", "!solr_admin", "!OpsCenter"));
-    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, requestTimeout);
+    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, Duration.ofSeconds(20));
     map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, requestPageSize);
     map.put(TypedDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_SCHEMA_MAX_EVENTS, 20);

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2025,11 +2025,19 @@ datastax-java-driver {
 
       # The timeout for the requests to the schema tables.
       #
+      # For Scylla clusters this functions as both driver and server-side timeout.
+      # Schema queries for Scylla will have "using timeout <duration>" clause added, overriding the default
+      # server-side timeout for queries.
+      # For other clusters, this is a driver-side timeout.
+      #
+      # The default value is set very high, however in regular cases schema queries should
+      # only take a small fraction of that.
+      #
       # Required: yes
       # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
       #   change.
       # Overridable in a profile: no
-      request-timeout = ${datastax-java-driver.basic.request.timeout}
+      request-timeout = 20 seconds
 
       # The page size for the requests to the schema tables.
       #


### PR DESCRIPTION
…equest-timeout`

Updates the default value of `advanced.metadata.schema.request-timeout` corresponding to `METADATA_SCHEMA_REQUEST_TIMEOUT` TypedDriverOption to 20 seconds.

Extends the documentation with information about additional function in Scylla clusters.