### PR TITLE
4.x: Adjust `BasicLoadBalancingPolicy#getReplicas`

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/KeyspaceMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/KeyspaceMetadata.java
@@ -40,6 +40,12 @@ public interface KeyspaceMetadata extends Describable {
   /** Whether this keyspace is virtual */
   boolean isVirtual();
 
+  default boolean isUsingTablets() {
+    return false;
+  }
+
+  default void setUsingTablets(boolean predicate) {}
+
   /** The replication options defined for this keyspace. */
   @NonNull
   Map<String, String> getReplication();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultKeyspaceMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultKeyspaceMetadata.java
@@ -45,6 +45,7 @@ public class DefaultKeyspaceMetadata implements KeyspaceMetadata, Serializable {
   @NonNull private final Map<CqlIdentifier, ViewMetadata> views;
   @NonNull private final Map<FunctionSignature, FunctionMetadata> functions;
   @NonNull private final Map<FunctionSignature, AggregateMetadata> aggregates;
+  private boolean usingTablets = false;
 
   public DefaultKeyspaceMetadata(
       @NonNull CqlIdentifier name,
@@ -117,6 +118,16 @@ public class DefaultKeyspaceMetadata implements KeyspaceMetadata, Serializable {
   @Override
   public Map<FunctionSignature, AggregateMetadata> getAggregates() {
     return aggregates;
+  }
+
+  @Override
+  public boolean isUsingTablets() {
+    return this.usingTablets;
+  }
+
+  @Override
+  public void setUsingTablets(boolean predicate) {
+    this.usingTablets = predicate;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/CassandraSchemaParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/CassandraSchemaParser.java
@@ -75,6 +75,12 @@ public class CassandraSchemaParser implements SchemaParser {
     ImmutableMap.Builder<CqlIdentifier, KeyspaceMetadata> keyspacesBuilder = ImmutableMap.builder();
     for (AdminRow row : rows.keyspaces()) {
       KeyspaceMetadata keyspace = parseKeyspace(row);
+      AdminRow scyllaRow = rows.scyllaKeyspaces().getOrDefault(keyspace.getName(), null);
+      if (scyllaRow != null
+          && scyllaRow.contains("initial_tablets")
+          && !scyllaRow.isNull("initial_tablets")) {
+        keyspace.setUsingTablets(true);
+      }
       keyspacesBuilder.put(keyspace.getName(), keyspace);
     }
     for (AdminRow row : rows.virtualKeyspaces()) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
@@ -94,4 +94,9 @@ public class Cassandra21SchemaQueries extends CassandraSchemaQueries {
   protected Optional<String> selectVerticiesQuery() {
     return Optional.empty();
   }
+
+  @Override
+  protected Optional<String> selectScyllaKeyspacesQuery() {
+    return Optional.empty();
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
@@ -94,4 +94,9 @@ public class Cassandra22SchemaQueries extends CassandraSchemaQueries {
   protected Optional<String> selectVerticiesQuery() {
     return Optional.empty();
   }
+
+  @Override
+  protected Optional<String> selectScyllaKeyspacesQuery() {
+    return Optional.empty();
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
@@ -94,4 +94,9 @@ public class Cassandra3SchemaQueries extends CassandraSchemaQueries {
   protected Optional<String> selectVerticiesQuery() {
     return Optional.empty();
   }
+
+  @Override
+  protected Optional<String> selectScyllaKeyspacesQuery() {
+    return Optional.of("SELECT * FROM system_schema.scylla_keyspaces");
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaRows.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaRows.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.metadata.schema.parsing.DataTypeParser;
 import com.datastax.oss.driver.shaded.guava.common.collect.Multimap;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,5 +70,9 @@ public interface SchemaRows {
 
   default Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> edges() {
     return new LinkedHashMap<>();
+  }
+
+  default Map<CqlIdentifier, AdminRow> scyllaKeyspaces() {
+    return new HashMap<>();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
@@ -93,6 +93,12 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
     call.result.complete(
         mockResult(mockRow("keyspace_name", "ks1"), mockRow("keyspace_name", "ks2")));
 
+    // Scylla keyspaces
+    call = queries.calls.poll();
+    assertThat(call.query)
+        .isEqualTo("SELECT * FROM system_schema.scylla_keyspaces" + whereClause + usingClause);
+    call.result.complete(mockResult());
+
     // Types
     call = queries.calls.poll();
     assertThat(call.query)
@@ -217,6 +223,11 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
     assertThat(call.query).isEqualTo("SELECT * FROM system_schema.keyspaces");
     call.result.complete(mockResult(mockRow("keyspace_name", "ks1")));
 
+    // Scylla keyspaces
+    call = queries.calls.poll();
+    assertThat(call.query).isEqualTo("SELECT * FROM system_schema.scylla_keyspaces");
+    call.result.complete(mockResult());
+
     // No types
     call = queries.calls.poll();
     assertThat(call.query).isEqualTo("SELECT * FROM system_schema.types");
@@ -280,6 +291,11 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
     Call call = queries.calls.poll();
     assertThat(call.query).isEqualTo("SELECT * FROM system_schema.keyspaces");
     call.result.complete(mockResult(mockRow("keyspace_name", "ks1")));
+
+    // Scylla keyspaces
+    call = queries.calls.poll();
+    assertThat(call.query).isEqualTo("SELECT * FROM system_schema.scylla_keyspaces");
+    call.result.complete(mockResult());
 
     // No types
     call = queries.calls.poll();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.connection.ConstantReconnectionPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.common.stubbing.PrimeDsl;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.RejectScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -70,6 +71,10 @@ public class ConnectIT {
             // loaded at startup).
             when("SELECT * FROM system_schema.keyspaces")
                 .then(rows().row("keyspace_name", "system").row("keyspace_name", "test")));
+    SIMULACRON_RULE
+        .cluster()
+        .prime(
+            PrimeDsl.when("SELECT * FROM system_schema.scylla_keyspaces").then(PrimeDsl.noRows()));
   }
 
   @Test

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
@@ -115,6 +115,10 @@ public class SessionLeakIT {
     SIMULACRON_RULE
         .cluster()
         .prime(PrimeDsl.when("USE \"non_existent_keyspace\"").then(PrimeDsl.invalid("irrelevant")));
+    SIMULACRON_RULE
+        .cluster()
+        .prime(
+            PrimeDsl.when("SELECT * FROM system_schema.scylla_keyspaces").then(PrimeDsl.noRows()));
     int threshold = 4;
     // Set the config option explicitly, in case it gets overridden in the test application.conf:
     DriverConfigLoader configLoader =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/AllLoadBalancingPoliciesSimulacronIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/AllLoadBalancingPoliciesSimulacronIT.java
@@ -78,6 +78,10 @@ public class AllLoadBalancingPoliciesSimulacronIT {
         .prime(
             PrimeDsl.when("SELECT * FROM system_schema.keyspaces")
                 .then(new RowBuilder().columnTypes(KEYSPACE_COLUMNS).row(KEYSPACE_ROW).build()));
+    SIMULACRON_RULE
+        .cluster()
+        .prime(
+            PrimeDsl.when("SELECT * FROM system_schema.scylla_keyspaces").then(PrimeDsl.noRows()));
   }
 
   @Test


### PR DESCRIPTION
Unlike in 3.x this `getReplicas` is located in `BasicLoadBalancingPolicy`.
The keyspace and table information is passed through the `Request` argument, so there is no need to extend that part.
Those things aside, the behavior should be now in line with the description of #379 .