### PR TITLE
4.x: Increase version requirement for ZeroTokenNodesIT

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -27,12 +27,12 @@ public class ZeroTokenNodesIT {
   @Before
   public void checkScyllaVersion() {
     // minOSS = "6.2.0",
-    // minEnterprise = "2024.2.2",
+    // minEnterprise = "2024.2.3",
     // Zero-token nodes introduced in scylladb/scylladb#19684
     assumeTrue(CcmBridge.SCYLLA_ENABLEMENT);
     if (CcmBridge.SCYLLA_ENTERPRISE) {
       assumeTrue(
-          CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("2024.2.2"))) >= 0);
+          CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("2024.2.3"))) >= 0);
     } else {
       assumeTrue(CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("6.2.0"))) >= 0);
     }


### PR DESCRIPTION
CI started picking up 2024.2.2 but the feature is not there yet. This causes test failures.
Increasing minEnterprise to 2024.2.3.

Fixes #413