### PR TITLE
3.x: Expose `scyllaVersion` in additional classes, interfaces

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -54,6 +54,13 @@ public interface CCMAccess extends Closeable {
    */
   VersionNumber getDSEVersion();
 
+  /**
+   * Returns the Scylla version of this CCM cluster if this is a Scylla cluster, otherwise null.
+   *
+   * @return The version of this CCM cluster.
+   */
+  VersionNumber getScyllaVersion();
+
   /** @return The config directory for this CCM cluster. */
   File getCcmDir();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -65,6 +65,11 @@ public class CCMCache {
     }
 
     @Override
+    public VersionNumber getScyllaVersion() {
+      return ccm.getScyllaVersion();
+    }
+
+    @Override
     public File getCcmDir() {
       return ccm.getCcmDir();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -111,6 +111,11 @@ public class CCMTestsSupport {
     }
 
     @Override
+    public VersionNumber getScyllaVersion() {
+      return delegate.getScyllaVersion();
+    }
+
+    @Override
     public InetSocketAddress addressOfNode(int n) {
       return delegate.addressOfNode(n);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -52,7 +52,15 @@ public class StateListenerTest extends CCMTestsSupport {
     ccm().start(1);
     listener.waitForEvent();
 
-    listener.setExpectedEvent(REMOVE);
+    // Different expectation for Scylla versions since 6.0.0 and 2024.2, both included
+    VersionNumber scyllaVer = ccm().getScyllaVersion();
+    if (scyllaVer != null
+        && ((scyllaVer.getMajor() >= 6 && scyllaVer.getMajor() <= 9)
+            || (scyllaVer.getMajor() >= 2024 && scyllaVer.getMinor() >= 2))) {
+      listener.setExpectedEvent(DOWN);
+    } else {
+      listener.setExpectedEvent(REMOVE);
+    }
     ccm().decommission(2);
     listener.waitForEvent();
   }


### PR DESCRIPTION
Adds `getScyllaVersion()` to CCMAccess, CCMCache, ReadOnlyCCMAccess.
Adds `scyllaVersion` field to CCMBridge.Builder class.

Some tests for Scylla and Cassandra can have very high code overlap.
This change will make it possible to adjust a few lines in a method instead
of repeating the whole test method with different cluster version requirements.

This is bundled with adjustment to StateListenerTest:
In newer Scylla versions ccm node decomission first causes DOWN event
to be sent and then REMOVE. This change adjusts the expected event so that
the test passes.