### PR TITLE
3.x: CcmBridge version logging; StateListenerTest bugfix

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -258,6 +258,14 @@ public class CCMBridge implements CCMAccess {
           GLOBAL_DSE_VERSION_NUMBER,
           GLOBAL_CASSANDRA_VERSION_NUMBER,
           CASSANDRA_INSTALL_ARGS);
+    } else if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+      GLOBAL_CASSANDRA_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+      GLOBAL_DSE_VERSION_NUMBER = null;
+      logger.info(
+          "Tests requiring CCM will by default use Scylla version {} and report Cassandra version {} when asked specifically for it (install arguments: {})",
+          GLOBAL_SCYLLA_VERSION_NUMBER,
+          GLOBAL_CASSANDRA_VERSION_NUMBER,
+          CASSANDRA_INSTALL_ARGS);
     } else {
       GLOBAL_CASSANDRA_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
       GLOBAL_DSE_VERSION_NUMBER = null;
@@ -358,6 +366,10 @@ public class CCMBridge implements CCMAccess {
           "Failed to parse scylla.version: " + versionString + ". Trying to get it through CCM.",
           e);
       parsedScyllaVersionNumber = getScyllaVersionThroughCcm(versionString);
+      logger.info(
+          String.format(
+              "Version string %s corresponds here to version number %s",
+              versionString, parsedScyllaVersionNumber));
     }
     return parsedScyllaVersionNumber;
   }

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -53,10 +53,12 @@ public class StateListenerTest extends CCMTestsSupport {
     listener.waitForEvent();
 
     // Different expectation for Scylla versions since 6.0.0 and 2024.2, both included
+    VersionNumber minOss = VersionNumber.parse("6.0.0");
+    VersionNumber minEnterprise = VersionNumber.parse("2024.2");
     VersionNumber scyllaVer = ccm().getScyllaVersion();
-    if (scyllaVer != null
-        && ((scyllaVer.getMajor() >= 6 && scyllaVer.getMajor() <= 9)
-            || (scyllaVer.getMajor() >= 2024 && scyllaVer.getMinor() >= 2))) {
+    boolean isEnterprise = scyllaVer.getMajor() >= 2017;
+    if ((isEnterprise && scyllaVer.compareTo(minEnterprise) >= 0)
+        || (!isEnterprise && scyllaVer.compareTo(minOss) >= 0)) {
       listener.setExpectedEvent(DOWN);
     } else {
       listener.setExpectedEvent(REMOVE);


### PR DESCRIPTION
CCMBridge changes:
CCMBridge will now report correct Scylla version in use when configured
for Scylla, instead of listing the Cassandra version.
When using custom cluster version string CCMBridge will output what version
number it resolves to.

StateListenerTest changes:
Recently introduced change has an incorrect version check logic
that skips 2025.1.x versions. They won't be skipped anymore.