### PR TITLE
3.x: TokenAwarePolicy fix bad perf of ReplicaOrdering.RANDOM

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A wrapper load balancing policy that adds token awareness to a child policy.
@@ -250,7 +251,7 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
 
       if (replicaOrdering == ReplicaOrdering.RANDOM) {
         List<Host> replicasList = Lists.newArrayList(replicas);
-        Collections.shuffle(replicasList);
+        Collections.shuffle(replicasList, ThreadLocalRandom.current());
         replicasIterator = replicasList.iterator();
       } else {
         replicasIterator = replicas.iterator();


### PR DESCRIPTION
`ReplicaOrdering.RANDOM` shows up to 20% worse throughput. Switching from java.util.Random to `ThreadLocalRandom` showed 20% improvement:
After PR:
```
=======================
Results:
Op rate                   :   28,232 op/s  [WRITE: 28,232 op/s]
Partition rate            :   28,232 pk/s  [WRITE: 28,232 pk/s]
Row rate                  :   28,232 row/s [WRITE: 28,232 row/s]
Latency mean              :    0.3 ms [WRITE: 0.3 ms]
Latency median            :    0.2 ms [WRITE: 0.2 ms]
Latency 95th percentile   :    1.7 ms [WRITE: 1.7 ms]
Latency 99th percentile   :    2.2 ms [WRITE: 2.2 ms]
Latency 99.9th percentile :    3.7 ms [WRITE: 3.7 ms]
Latency max               :   29.0 ms [WRITE: 29.0 ms]
Total partitions          :  1,125,000 [WRITE: 1,125,000]
Total errors              :          0 [WRITE: 0]
Total GC count            : 0
Total GC memory           : 0.000 KiB
Total GC time             :    0.0 seconds
Avg GC time               :    NaN ms
StdDev GC time            :    0.0 ms
Total operation time      : 00:00:39
```

Before :
```
END
=======================
Results:
Op rate                   :   26,094 op/s  [WRITE: 26,094 op/s]
Partition rate            :   26,094 pk/s  [WRITE: 26,094 pk/s]
Row rate                  :   26,094 row/s [WRITE: 26,094 row/s]
Latency mean              :    0.4 ms [WRITE: 0.4 ms]
Latency median            :    0.2 ms [WRITE: 0.2 ms]
Latency 95th percentile   :    1.9 ms [WRITE: 1.9 ms]
Latency 99th percentile   :    2.5 ms [WRITE: 2.5 ms]
Latency 99.9th percentile :    4.0 ms [WRITE: 4.0 ms]
Latency max               :   22.0 ms [WRITE: 22.0 ms]
Total partitions          :  1,125,000 [WRITE: 1,125,000]
Total errors              :          0 [WRITE: 0]
Total GC count            : 0
Total GC memory           : 0.000 KiB
Total GC time             :    0.0 seconds
Avg GC time               :    NaN ms
StdDev GC time            :    0.0 ms
Total operation time      : 00:00:43
```

Fixes: https://github.com/scylladb/cassandra-stress/issues/38
