### PR TITLE
fix(metadata): reduce registration log messages of tabletMap listener

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -156,12 +156,12 @@ public class Metadata {
               new TabletMapListener(tabletMap) {
                 @Override
                 public void onRegister(Cluster cluster) {
-                  logger.info("Registered event listener for tablet map.");
+                  logger.debug("Registered event listener for tablet map.");
                 }
 
                 @Override
                 public void onUnregister(Cluster cluster) {
-                  logger.info("Unregistered tablet map's event listener.");
+                  logger.debug("Unregistered tablet map's event listener.");
                 }
               });
     }


### PR DESCRIPTION
There is no reason for it to be `INFO`, let's drop it to `DEBUG`.