### PR TITLE
3.x: Clean up the mocks after DnsEndpointTest

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTest.java
@@ -7,11 +7,17 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-public class DnsEndpointTests {
+public class DnsEndpointTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(DnsEndpointTests.class);
+  private static final Logger logger = LoggerFactory.getLogger(DnsEndpointTest.class);
+
+  @AfterClass(alwaysRun = true)
+  public void clearMocks() {
+    MappedHostResolverProvider.unsetResolver();
+  }
 
   @Test(groups = "long")
   public void replace_cluster_test() {

--- a/driver-core/src/test/java/com/datastax/driver/core/MappedHostResolverProvider.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MappedHostResolverProvider.java
@@ -18,6 +18,15 @@ public class MappedHostResolverProvider {
     return true;
   }
 
+  public static synchronized boolean unsetResolver() {
+    if (resolver == null) {
+      return false;
+    }
+    resolver = null;
+    HostResolutionRequestInterceptor.INSTANCE.uninstall();
+    return true;
+  }
+
   public static synchronized void addResolverEntry(String hostname, String address) {
     if (resolver == null) {
       setResolver(new MappedHostResolver());


### PR DESCRIPTION
Adds an `@AfterClass` method that cleans up the custom resolver.
Previously it was possible that the mocked hostname would still be associated
with the same ip in another test, causing it to fail in certain cases.