### PR TITLE
Add "WHERE key='local'" to accelerate queries against system.local

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
 class ProtocolInitHandler extends ConnectInitHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ProtocolInitHandler.class);
   private static final Query CLUSTER_NAME_QUERY =
-      new Query("SELECT cluster_name FROM system.local");
+      new Query("SELECT cluster_name FROM system.local WHERE key='local'");
 
   private final InternalDriverContext context;
   private final long timeoutMillis;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -170,7 +170,8 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
 
     savePort(channel);
 
-    CompletionStage<AdminResult> localQuery = query(channel, "SELECT * FROM system.local");
+    CompletionStage<AdminResult> localQuery =
+        query(channel, "SELECT * FROM system.local WHERE key='local'");
     CompletionStage<AdminResult> peersV2Query = query(channel, "SELECT * FROM system.peers_v2");
     CompletableFuture<AdminResult> peersQuery = new CompletableFuture<>();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
@@ -434,7 +434,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     requestFrame = readOutboundFrame();
     assertThat(requestFrame.message).isInstanceOf(Query.class);
     Query query = (Query) requestFrame.message;
-    assertThat(query.query).isEqualTo("SELECT cluster_name FROM system.local");
+    assertThat(query.query).isEqualTo("SELECT cluster_name FROM system.local WHERE key='local'");
     assertThat(connectFuture).isNotDone();
 
     writeInboundFrame(requestFrame, TestResponses.clusterNameResponse("expectedClusterName"));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -337,7 +337,7 @@ public class DefaultTopologyMonitorTest {
     AdminRow peer3 = mockPeersRow(3, UUID.randomUUID());
     AdminRow peer2 = mockPeersRow(2, node2.getHostId());
     topologyMonitor.stubQueries(
-        new StubbedQuery("SELECT * FROM system.local", mockResult(local)),
+        new StubbedQuery("SELECT * FROM system.local WHERE key='local'", mockResult(local)),
         new StubbedQuery("SELECT * FROM system.peers_v2", Collections.emptyMap(), null, true),
         new StubbedQuery("SELECT * FROM system.peers", mockResult(peer3, peer2)));
 
@@ -447,7 +447,7 @@ public class DefaultTopologyMonitorTest {
     AdminRow peer2 = mockPeersRow(2, node2.getHostId());
     AdminRow peer1 = mockPeersRow(1, node2.getHostId()); // invalid
     topologyMonitor.stubQueries(
-        new StubbedQuery("SELECT * FROM system.local", mockResult(local)),
+        new StubbedQuery("SELECT * FROM system.local WHERE key='local'", mockResult(local)),
         new StubbedQuery("SELECT * FROM system.peers_v2", Collections.emptyMap(), null, true),
         new StubbedQuery("SELECT * FROM system.peers", mockResult(peer3, peer2, peer1)));
 
@@ -478,7 +478,7 @@ public class DefaultTopologyMonitorTest {
     AdminRow peer2 = mockPeersRow(2, node2.getHostId());
     AdminRow peer1 = mockPeersRow(1, node2.getHostId()); // invalid
     topologyMonitor.stubQueries(
-        new StubbedQuery("SELECT * FROM system.local", mockResult(local)),
+        new StubbedQuery("SELECT * FROM system.local WHERE key='local'", mockResult(local)),
         new StubbedQuery("SELECT * FROM system.peers_v2", mockResult(peer3, peer2, peer1)));
 
     // When

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
@@ -76,8 +76,8 @@ public class ProtocolVersionMixedClusterIT {
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
-              "SELECT cluster_name FROM system.local",
-              "SELECT * FROM system.local",
+              "SELECT cluster_name FROM system.local WHERE key='local'",
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
     }
@@ -104,8 +104,8 @@ public class ProtocolVersionMixedClusterIT {
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
-              "SELECT cluster_name FROM system.local",
-              "SELECT * FROM system.local",
+              "SELECT cluster_name FROM system.local WHERE key='local'",
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
     }
@@ -155,8 +155,8 @@ public class ProtocolVersionMixedClusterIT {
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
-              "SELECT cluster_name FROM system.local",
-              "SELECT * FROM system.local",
+              "SELECT cluster_name FROM system.local WHERE key='local'",
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -92,7 +92,7 @@ public class ZeroTokenNodesIT {
 
       Set<String> landedOn = new HashSet<>();
       for (int i = 0; i < 30; i++) {
-        ResultSet rs = session.execute("SELECT * FROM system.local");
+        ResultSet rs = session.execute("SELECT * FROM system.local WHERE key='local'");
         InetAddress broadcastRpcInetAddress =
             Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
         landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());
@@ -130,7 +130,7 @@ public class ZeroTokenNodesIT {
 
       Set<String> landedOn = new HashSet<>();
       for (int i = 0; i < 30; i++) {
-        ResultSet rs = session.execute("SELECT * FROM system.local");
+        ResultSet rs = session.execute("SELECT * FROM system.local WHERE key='local'");
         InetAddress broadcastRpcInetAddress =
             Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
         landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());
@@ -201,7 +201,7 @@ public class ZeroTokenNodesIT {
 
       Set<String> landedOn = new HashSet<>();
       for (int i = 0; i < 30; i++) {
-        ResultSet rs = session.execute("SELECT * FROM system.local");
+        ResultSet rs = session.execute("SELECT * FROM system.local WHERE key='local'");
         InetAddress broadcastRpcInetAddress =
             Objects.requireNonNull(rs.one()).getInetAddress("rpc_address");
         landedOn.add(Objects.requireNonNull(broadcastRpcInetAddress).toString());


### PR DESCRIPTION
Just like other drivers (Python, GoCQL), the Java 4.x driver can query with this simple WHERE clause added, to improve query performance.

Fixes: https://github.com/scylladb/java-driver/issues/282

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>


(Untested!)