### PR TITLE
4.x: Make all queries to system.local use WHERE clause

### DIFF
--- a/examples/src/main/java/com/datastax/oss/driver/examples/astra/AstraReadCassandraVersion.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/astra/AstraReadCassandraVersion.java
@@ -64,7 +64,7 @@ public class AstraReadCassandraVersion {
 
       // We use execute to send a query to Cassandra. This returns a ResultSet, which
       // is essentially a collection of Row objects.
-      ResultSet rs = session.execute("select release_version from system.local");
+      ResultSet rs = session.execute("select release_version from system.local WHERE key='local'");
       //  Extract the first row (which is the only one in this case).
       Row row = rs.one();
 

--- a/examples/src/main/java/com/datastax/oss/driver/examples/basic/ReadCassandraVersion.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/basic/ReadCassandraVersion.java
@@ -45,7 +45,7 @@ public class ReadCassandraVersion {
     try (CqlSession session = CqlSession.builder().build()) {
       // We use execute to send a query to Cassandra. This returns a ResultSet, which
       // is essentially a collection of Row objects.
-      ResultSet rs = session.execute("select release_version from system.local");
+      ResultSet rs = session.execute("select release_version from system.local where key='local'");
       //  Extract the first row (which is the only one in this case).
       Row row = rs.one();
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderAlternateIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderAlternateIT.java
@@ -74,7 +74,7 @@ public class DseGssApiAuthProviderAlternateIT {
                         "keyTab",
                         ads.getUserKeytab().getAbsolutePath()))
                 .build())) {
-      Row row = session.execute("select * from system.local").one();
+      Row row = session.execute("select * from system.local where key='local'").one();
       assertThat(row).isNotNull();
     } finally {
       System.clearProperty(saslSystemProperty);
@@ -104,7 +104,7 @@ public class DseGssApiAuthProviderAlternateIT {
                         "keyTab",
                         ads.getUserKeytab().getAbsolutePath()))
                 .build())) {
-      Row row = session.execute("select * from system.local").one();
+      Row row = session.execute("select * from system.local where key='local'").one();
       assertThat(row).isNotNull();
     }
   }

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderIT.java
@@ -50,7 +50,7 @@ public class DseGssApiAuthProviderIT {
   @Test
   public void should_authenticate_using_kerberos_with_keytab() {
     try (CqlSession session = ads.newKeyTabSession()) {
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       assertThat(set).isNotNull();
     }
   }
@@ -67,7 +67,7 @@ public class DseGssApiAuthProviderIT {
     Assume.assumeTrue(isUnix);
     acquireTicket(ads.getUserPrincipal(), ads.getUserKeytab(), ads.getAdsServer());
     try (CqlSession session = ads.newTicketSession()) {
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       assertThat(set).isNotNull();
     } finally {
       destroyTicket(ads);
@@ -133,7 +133,7 @@ public class DseGssApiAuthProviderIT {
             .withAuthProvider(new ProgrammaticDseGssApiAuthProvider(builder.build()))
             .build()) {
 
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       assertThat(set).isNotNull();
     }
   }

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DsePlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DsePlainTextAuthProviderIT.java
@@ -73,7 +73,7 @@ public class DsePlainTextAuthProviderIT {
                 .withString(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, "cassandra")
                 .withClass(DefaultDriverOption.AUTH_PROVIDER_CLASS, PlainTextAuthProvider.class)
                 .build())) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -84,7 +84,7 @@ public class DsePlainTextAuthProviderIT {
             .addContactEndPoints(ccm.getContactPoints())
             .withAuthCredentials("cassandra", "cassandra")
             .build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseProxyAuthenticationIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseProxyAuthenticationIT.java
@@ -114,7 +114,7 @@ public class DseProxyAuthenticationIT {
             .addContactEndPoints(ads.ccm.getContactPoints())
             .withAuthCredentials("ben", "fakePasswordForBen", "alice")
             .build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cloud/CloudIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cloud/CloudIT.java
@@ -80,7 +80,7 @@ public class CloudIT {
             .withAuthCredentials("cassandra", "cassandra")
             .withCloudSecureConnectBundle(bundle)
             .build()) {
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -96,7 +96,7 @@ public class CloudIT {
             .withAuthCredentials("cassandra", "cassandra")
             .withCloudSecureConnectBundle(bundle)
             .build()) {
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
       verify(logger.appender, timeout(500).atLeast(1))
           .doAppend(logger.loggingEventCaptor.capture());
       assertThat(
@@ -135,7 +135,7 @@ public class CloudIT {
             .withCloudSecureConnectBundle(bundle)
             .withAuthCredentials("cassandra", "cassandra")
             .build()) {
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -149,7 +149,7 @@ public class CloudIT {
             .withAuthCredentials("cassandra", "cassandra")
             .withCloudSecureConnectBundle(bundle)
             .build()) {
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -163,7 +163,7 @@ public class CloudIT {
             .withAuthCredentials("cassandra", "cassandra")
             .withCloudSecureConnectBundle(bundle)
             .build()) {
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -191,7 +191,7 @@ public class CloudIT {
             .build()) {
 
       // then
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -213,7 +213,7 @@ public class CloudIT {
             .build()) {
 
       // then
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -236,7 +236,7 @@ public class CloudIT {
             .build()) {
 
       // then
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -259,7 +259,7 @@ public class CloudIT {
             .build()) {
 
       // then
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -290,7 +290,7 @@ public class CloudIT {
             .build()) {
 
       // then
-      set = session.execute("select * from system.local");
+      set = session.execute("select * from system.local where key='local'");
     }
     assertThat(set).isNotNull();
   }
@@ -311,7 +311,7 @@ public class CloudIT {
             .build(); ) {
 
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))
@@ -348,7 +348,7 @@ public class CloudIT {
             .build(); ) {
 
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))
@@ -379,7 +379,7 @@ public class CloudIT {
             .withSslContext(SSLContext.getInstance("SSL"))
             .build()) {
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))
@@ -415,7 +415,7 @@ public class CloudIT {
             .withAuthCredentials("cassandra", "cassandra")
             .build()) {
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))
@@ -451,7 +451,7 @@ public class CloudIT {
             .build(); ) {
 
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))
@@ -482,7 +482,7 @@ public class CloudIT {
             .build(); ) {
 
       // when
-      ResultSet set = session.execute("select * from system.local");
+      ResultSet set = session.execute("select * from system.local where key='local'");
       // then
       assertThat(set).isNotNull();
       verify(logger.appender, timeout(500).atLeast(1))

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PoolBalancingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PoolBalancingIT.java
@@ -99,7 +99,7 @@ public class PoolBalancingIT {
       }
       SESSION_RULE
           .session()
-          .executeAsync("SELECT release_version FROM system.local")
+          .executeAsync("SELECT release_version FROM system.local WHERE key='local'")
           .whenComplete(this::reschedule);
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
@@ -63,7 +63,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_downgrade_to_v3() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(3);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -81,7 +81,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_downgrade_to_v4() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(4);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -96,7 +96,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_downgrade_to_v5_oss() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(5);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -109,7 +109,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_downgrade_to_dse_v1() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DseProtocolVersion.DSE_V1);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -222,7 +222,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_not_downgrade_if_server_supports_latest_version() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(ProtocolVersion.V5);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -235,7 +235,7 @@ public class ProtocolVersionInitialNegotiationIT {
   public void should_not_downgrade_if_server_supports_latest_version_dse() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(ProtocolVersion.DSE_V2);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -255,7 +255,7 @@ public class ProtocolVersionInitialNegotiationIT {
             .build();
     try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(3);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -275,7 +275,7 @@ public class ProtocolVersionInitialNegotiationIT {
             .build();
     try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(4);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -298,7 +298,7 @@ public class ProtocolVersionInitialNegotiationIT {
             .build();
     try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(5);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -314,7 +314,7 @@ public class ProtocolVersionInitialNegotiationIT {
             .build();
     try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DseProtocolVersion.DSE_V1);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -330,7 +330,7 @@ public class ProtocolVersionInitialNegotiationIT {
             .build();
     try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DseProtocolVersion.DSE_V2);
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
@@ -69,7 +69,7 @@ public class PlainTextAuthProviderIT {
             .withString(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, "cassandra")
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -82,7 +82,7 @@ public class PlainTextAuthProviderIT {
             .withAuthCredentials("cassandra", "cassandra");
 
     try (CqlSession session = (CqlSession) builder.build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -102,7 +102,7 @@ public class PlainTextAuthProviderIT {
             .withAuthProvider(authProvider);
 
     try (CqlSession session = (CqlSession) builder.build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -115,7 +115,7 @@ public class PlainTextAuthProviderIT {
             .withString(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, "badpass")
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -127,7 +127,7 @@ public class PlainTextAuthProviderIT {
             .withAuthCredentials("baduser", "badpass");
 
     try (CqlSession session = (CqlSession) builder.build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -141,14 +141,14 @@ public class PlainTextAuthProviderIT {
             .withAuthProvider(authProvider);
 
     try (CqlSession session = (CqlSession) builder.build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
   @Test(expected = AllNodesFailedException.class)
   public void should_not_connect_without_credentials() {
     try (CqlSession session = SessionUtils.newSession(CCM_RULE)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileSimulacronIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileSimulacronIT.java
@@ -61,7 +61,7 @@ public class DriverExecutionProfileSimulacronIT {
   public void should_fail_if_config_profile_specified_doesnt_exist() {
     try (CqlSession session = SessionUtils.newSession(SIMULACRON_RULE)) {
       SimpleStatement statement =
-          SimpleStatement.builder("select * from system.local")
+          SimpleStatement.builder("select * from system.local where key='local'")
               .setExecutionProfileName("IDONTEXIST")
               .build();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -312,7 +312,7 @@ public class BoundStatementCcmIT {
     int mockPageSize = 2000;
 
     SimpleStatementBuilder simpleStatementBuilder =
-        SimpleStatement.builder("SELECT release_version FROM system.local")
+        SimpleStatement.builder("SELECT release_version FROM system.local WHERE key='local'")
             .setExecutionProfile(mockProfile)
             .setPagingState(mockPagingState)
             .setKeyspace(mockKeyspace)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
@@ -60,7 +60,7 @@ public class QueryTraceIT {
     ExecutionInfo executionInfo =
         SESSION_RULE
             .session()
-            .execute("SELECT release_version FROM system.local")
+            .execute("SELECT release_version FROM system.local WHERE key='local'")
             .getExecutionInfo();
 
     assertThat(executionInfo.getTracingId()).isNull();
@@ -78,7 +78,8 @@ public class QueryTraceIT {
         SESSION_RULE
             .session()
             .execute(
-                SimpleStatement.builder("SELECT release_version FROM system.local")
+                SimpleStatement.builder(
+                        "SELECT release_version FROM system.local WHERE key='local'")
                     .setTracing()
                     .build())
             .getExecutionInfo();
@@ -115,7 +116,7 @@ public class QueryTraceIT {
     assertThat(queryTrace.getParameters())
         .containsEntry("consistency_level", "LOCAL_ONE")
         .containsEntry("page_size", "5000")
-        .containsEntry("query", "SELECT release_version FROM system.local")
+        .containsEntry("query", "SELECT release_version FROM system.local WHERE key='local'")
         .containsEntry("serial_consistency_level", "SERIAL");
     assertThat(queryTrace.getStartedAt()).isPositive();
     // Don't want to get too deep into event testing because that could change across versions

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
@@ -78,7 +78,8 @@ public class NodeTargetingIT {
       Node node = getNode(nodeIndex);
 
       // given a statement with node explicitly set.
-      Statement statement = SimpleStatement.newInstance("select * system.local").setNode(node);
+      Statement statement =
+          SimpleStatement.newInstance("select * system.local WHERE key='local'").setNode(node);
 
       // when statement is executed
       ResultSet result = SESSION_RULE.session().execute(statement);
@@ -114,7 +115,8 @@ public class NodeTargetingIT {
     // given a statement with node explicitly set that for which we have no active pool.
     Node node4 = getNode(4);
 
-    Statement statement = SimpleStatement.newInstance("select * system.local").setNode(node4);
+    Statement statement =
+        SimpleStatement.newInstance("select * system.local WHERE key='local'").setNode(node4);
     try {
       // when statement is executed
       SESSION_RULE.session().execute(statement);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -82,7 +82,7 @@ public class MockResolverIT {
 
       CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
       try (CqlSession session = builder.build()) {
-        ResultSet rs = session.execute("SELECT * FROM system.local");
+        ResultSet rs = session.execute("select * from system.local where key='local'");
         List<Row> rows = rs.all();
         assertThat(rows).hasSize(1);
         LOG.trace("system.local contents: {}", rows.get(0).getFormattedContents());
@@ -157,7 +157,7 @@ public class MockResolverIT {
             numberOfNodes,
             CLUSTER_WAIT_SECONDS);
       }
-      ResultSet rs = session.execute("SELECT * FROM system.local");
+      ResultSet rs = session.execute("select * from system.local where key='local'");
       assertThat(rs).isNotNull();
       Row row = rs.one();
       assertThat(row).isNotNull();
@@ -205,7 +205,7 @@ public class MockResolverIT {
             numberOfNodes,
             CLUSTER_WAIT_SECONDS);
       }
-      ResultSet rs = session.execute("SELECT * FROM system.local");
+      ResultSet rs = session.execute("select * from system.local where key='local'");
       assertThat(rs).isNotNull();
       Row row = rs.one();
       assertThat(row).isNotNull();
@@ -284,7 +284,7 @@ public class MockResolverIT {
           }
           // session.refreshSchema();
           SimpleStatement statement =
-              new SimpleStatementBuilder("SELECT * FROM system.local")
+              new SimpleStatementBuilder("select * from system.local where key='local'")
                   .setTimeout(Duration.ofSeconds(3))
                   .build();
           session.executeAsync(statement);
@@ -293,7 +293,7 @@ public class MockResolverIT {
           break;
         }
       }
-      ResultSet rs = session.execute("SELECT * FROM system.local");
+      ResultSet rs = session.execute("select * from system.local where key='local'");
       assertThat(rs).isNotNull();
       Row row = rs.one();
       assertThat(row).isNotNull();
@@ -344,7 +344,7 @@ public class MockResolverIT {
               break;
             }
             SimpleStatement statement =
-                new SimpleStatementBuilder("SELECT * FROM system.local")
+                new SimpleStatementBuilder("select * from system.local where key='local'")
                     .setTimeout(Duration.ofSeconds(3))
                     .build();
             session.executeAsync(statement);
@@ -400,7 +400,7 @@ public class MockResolverIT {
           }
           // session.refreshSchema();
           SimpleStatement statement =
-              new SimpleStatementBuilder("SELECT * FROM system.local")
+              new SimpleStatementBuilder("select * from system.local where key='local'")
                   .setTimeout(Duration.ofSeconds(3))
                   .build();
           session.executeAsync(statement);
@@ -409,7 +409,7 @@ public class MockResolverIT {
           break;
         }
       }
-      session.execute("SELECT * FROM system.local");
+      session.execute("select * from system.local where key='local'");
     }
     session.close();
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryHostnameValidationIT.java
@@ -60,7 +60,7 @@ public class DefaultSslEngineFactoryHostnameValidationIT {
                 CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
@@ -53,7 +53,7 @@ public class DefaultSslEngineFactoryIT {
             .build();
 
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -72,7 +72,7 @@ public class DefaultSslEngineFactoryIT {
                 CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -84,14 +84,14 @@ public class DefaultSslEngineFactoryIT {
             .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
   @Test(expected = AllNodesFailedException.class)
   public void should_not_connect_if_not_using_ssl() {
     try (CqlSession session = SessionUtils.newSession(CCM_RULE)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
@@ -54,7 +54,7 @@ public class DefaultSslEngineFactoryPropertyBasedIT {
             .withClass(DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, DefaultSslEngineFactory.class)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
@@ -57,7 +57,7 @@ public class DefaultSslEngineFactoryPropertyBasedWithClientAuthIT {
             .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
@@ -59,7 +59,7 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
                 CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -77,7 +77,7 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
                 CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/ProgrammaticSslIT.java
@@ -53,7 +53,7 @@ public class ProgrammaticSslIT {
                 .addContactEndPoints(CCM_RULE.getContactPoints())
                 .withSslEngineFactory(factory)
                 .build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 
@@ -66,7 +66,7 @@ public class ProgrammaticSslIT {
                 .addContactEndPoints(CCM_RULE.getContactPoints())
                 .withSslContext(sslContext)
                 .build()) {
-      session.execute("select * from system.local");
+      session.execute("select * from system.local where key='local'");
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
@@ -84,7 +84,7 @@ public class RequestLoggerIT {
   private static final Predicate<String> WITH_EXECUTION_PREFIX =
       log -> LOG_PREFIX_WITH_EXECUTION_NUMBER.matcher(log).lookingAt();
 
-  private static final String QUERY = "SELECT release_version FROM system.local";
+  private static final String QUERY = "SELECT release_version FROM system.local WHERE key='local'";
 
   private final SimulacronRule simulacronRule =
       new SimulacronRule(ClusterSpec.builder().withNodes(3));


### PR DESCRIPTION
Full scan requests slower even when only one record there is.

Fixes: https://github.com/scylladb/java-driver/issues/282