### PR TITLE
3.x: Make all queries to system.local contain WHERE clause

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -73,7 +73,8 @@ public class AsyncQueryTest extends CCMTestsSupport {
   /** Checks that a cancelled query releases the connection (JAVA-407). */
   @Test(groups = "short")
   public void cancelled_query_should_release_the_connection() throws InterruptedException {
-    ResultSetFuture future = session().executeAsync("select release_version from system.local");
+    ResultSetFuture future =
+        session().executeAsync("select release_version from system.local where key='local'");
     future.cancel(true);
     assertTrue(future.isCancelled());
 
@@ -98,7 +99,8 @@ public class AsyncQueryTest extends CCMTestsSupport {
       // Neither cluster2 nor session2 are initialized at this point
       assertThat(cluster2.manager.metadata).isNull();
 
-      ResultSetFuture future = session2.executeAsync("select release_version from system.local");
+      ResultSetFuture future =
+          session2.executeAsync("select release_version from system.local where key='local'");
       Row row = Uninterruptibles.getUninterruptibly(future).one();
 
       assertThat(row.getString(0)).isNotEmpty();
@@ -152,14 +154,15 @@ public class AsyncQueryTest extends CCMTestsSupport {
   @Test(groups = "short")
   public void should_fail_when_synchronous_call_on_io_thread() throws Exception {
     for (int i = 0; i < 1000; i++) {
-      ResultSetFuture f = session().executeAsync("select release_version from system.local");
+      ResultSetFuture f =
+          session().executeAsync("select release_version from system.local where key='local'");
       ListenableFuture<Thread> f2 =
           GuavaCompatibility.INSTANCE.transform(
               f,
               new Function<ResultSet, Thread>() {
                 @Override
                 public Thread apply(ResultSet input) {
-                  session().execute("select release_version from system.local");
+                  session().execute("select release_version from system.local where key='local'");
                   return Thread.currentThread();
                 }
               });
@@ -176,14 +179,15 @@ public class AsyncQueryTest extends CCMTestsSupport {
       throws Exception {
     final Session session = new SessionWrapper(session());
     for (int i = 0; i < 1000; i++) {
-      ResultSetFuture f = session.executeAsync("select release_version from system.local");
+      ResultSetFuture f =
+          session.executeAsync("select release_version from system.local where key='local'");
       ListenableFuture<Thread> f2 =
           GuavaCompatibility.INSTANCE.transform(
               f,
               new Function<ResultSet, Thread>() {
                 @Override
                 public Thread apply(ResultSet input) {
-                  session.execute("select release_version from system.local");
+                  session.execute("select release_version from system.local where key='local'");
                   return Thread.currentThread();
                 }
               });

--- a/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DelegatingClusterIntegrationTest.java
@@ -25,7 +25,8 @@ public class DelegatingClusterIntegrationTest extends CCMTestsSupport {
   public void should_allow_subclass_to_delegate_to_other_instance() {
     SimpleDelegatingCluster delegatingCluster = new SimpleDelegatingCluster(cluster());
 
-    ResultSet rs = delegatingCluster.connect().execute("select * from system.local");
+    ResultSet rs =
+        delegatingCluster.connect().execute("select * from system.local where key='local'");
 
     assertThat(rs.all()).hasSize(1);
   }

--- a/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTests.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DnsEndpointTests.java
@@ -41,7 +41,7 @@ public class DnsEndpointTests {
               .build();
       session = cluster.connect();
 
-      ResultSet rs = session.execute("select * from system.local");
+      ResultSet rs = session.execute("select * from system.local where key='local'");
       Row row = rs.one();
       String address = row.getInet("broadcast_address").toString();
       logger.info("Queried node has broadcast_address: {}}", address);
@@ -64,7 +64,7 @@ public class DnsEndpointTests {
               .build();
       bridgeB.start();
       Thread.sleep(1000 * 92);
-      ResultSet rs = session.execute("select * from system.local");
+      ResultSet rs = session.execute("select * from system.local where key='local'");
       Row row = rs.one();
       String address = row.getInet("broadcast_address").toString();
       logger.info("Queried node has broadcast_address: {}}", address);
@@ -89,7 +89,7 @@ public class DnsEndpointTests {
                 .build()) {
       ccmBridge.start();
       Session session = cluster.connect();
-      ResultSet rs = session.execute("SELECT * FROM system.local");
+      ResultSet rs = session.execute("SELECT * FROM system.local WHERE key='local'");
       List<Row> rows = rs.all();
       assertThat(rows).hasSize(1);
       Row row = rows.get(0);

--- a/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
@@ -91,7 +91,8 @@ public class HostTargetingTest {
       Host host = TestUtils.findHost(cluster, hostIndex);
 
       // given a statement with host explicitly set.
-      Statement statement = new SimpleStatement("select * system.local").setHost(host);
+      Statement statement =
+          new SimpleStatement("select * system.local where key='local'").setHost(host);
 
       // when statement is executed
       ResultSet result = session.execute(statement);
@@ -136,7 +137,8 @@ public class HostTargetingTest {
   public void should_fail_if_host_is_not_connected() {
     // given a statement with host explicitly set that for which we have no active pool.
     Host host4 = TestUtils.findHost(cluster, 4);
-    Statement statement = new SimpleStatement("select * system.local").setHost(host4);
+    Statement statement =
+        new SimpleStatement("select * system.local where key='local'").setHost(host4);
 
     try {
       // when statement is executed

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
@@ -45,7 +45,7 @@ public class ProtocolV1Test extends CCMTestsSupport {
    */
   @Test(groups = "short")
   public void should_execute_query_with_no_variables() throws Exception {
-    session().execute("select * from system.local");
+    session().execute("select * from system.local where key='local'");
   }
 
   /**

--- a/driver-core/src/test/java/com/datastax/driver/core/ReusedStreamIdTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReusedStreamIdTest.java
@@ -91,7 +91,7 @@ public class ReusedStreamIdTest extends CCMTestsSupport {
           }
           semaphore.acquire();
           final String column = columnsToGrab.get(i % columnsToGrab.size()).getName();
-          String query = String.format("select %s from system.local", column);
+          String query = String.format("select %s from system.local where key='local'", column);
           ResultSetFuture future = session().executeAsync(query);
 
           GuavaCompatibility.INSTANCE.addCallback(

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -43,7 +43,7 @@ public class SchemaAgreementTest extends CCMTestsSupport {
   public void should_set_flag_on_non_schema_altering_statement() {
     ProtocolOptions protocolOptions = cluster().getConfiguration().getProtocolOptions();
     protocolOptions.maxSchemaAgreementWaitSeconds = 10;
-    ResultSet rs = session().execute("select release_version from system.local");
+    ResultSet rs = session().execute("select release_version from system.local where key='local'");
     assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
   }
 
@@ -68,7 +68,8 @@ public class SchemaAgreementTest extends CCMTestsSupport {
     Cluster controlCluster = register(TestUtils.buildControlCluster(cluster(), ccm()));
     Session controlSession = controlCluster.connect();
 
-    Row localRow = controlSession.execute("SELECT schema_version FROM system.local").one();
+    Row localRow =
+        controlSession.execute("SELECT schema_version FROM system.local WHERE key='local'").one();
     UUID localVersion = localRow.getUUID("schema_version");
     Row peerRow = controlSession.execute("SELECT peer, schema_version FROM system.peers").one();
     InetAddress peerAddress = peerRow.getInet("peer");

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
@@ -54,7 +54,7 @@ public class SingleConnectionPoolTest extends CCMTestsSupport {
 
     // Generate the load
     for (int i = 0; i < 10000; i++)
-      session().executeAsync("SELECT release_version FROM system.local");
+      session().executeAsync("SELECT release_version FROM system.local WHERE key='local'");
 
     openConnectionsWatcherExecutor.shutdownNow();
     if (excessInflightQueriesSpotted.get()) {

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementSizeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementSizeTest.java
@@ -154,7 +154,7 @@ public class StatementSizeTest {
 
   @Test(groups = "unit")
   public void should_measure_size_of_batch_statement() {
-    String queryString = "SELECT release_version FROM system.local";
+    String queryString = "SELECT release_version FROM system.local WHERE key='local'";
     SimpleStatement statement1 = new SimpleStatement(queryString);
 
     BoundStatement statement2 =

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -60,7 +60,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
   public void should_pass_wrapped_statement_to_load_balancing_policy() {
     loadBalancingPolicy.customStatementsHandled.set(0);
 
-    SimpleStatement s = new SimpleStatement("select * from system.local");
+    SimpleStatement s = new SimpleStatement("select * from system.local where key='local'");
     session().execute(s);
     assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(0);
 
@@ -133,7 +133,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
   public void should_pass_wrapped_statement_to_speculative_execution_policy() {
     speculativeExecutionPolicy.customStatementsHandled.set(0);
 
-    SimpleStatement s = new SimpleStatement("select * from system.local");
+    SimpleStatement s = new SimpleStatement("select * from system.local where key='local'");
     session().execute(s);
     assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(0);
 
@@ -148,7 +148,8 @@ public class StatementWrapperTest extends CCMTestsSupport {
     // Set CL TWO with only one node, so the statement will always cause UNAVAILABLE,
     // which our custom policy ignores.
     Statement s =
-        new SimpleStatement("select * from system.local").setConsistencyLevel(ConsistencyLevel.TWO);
+        new SimpleStatement("select * from system.local where key='local'")
+            .setConsistencyLevel(ConsistencyLevel.TWO);
 
     session().execute(s);
     assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(0);

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -312,7 +312,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
               .equals(cluster().manager.controlConnection.connectionRef.get().endPoint);
       Row row;
       if (isControlHost) {
-        row = session().execute("select tokens from system.local").one();
+        row = session().execute("select tokens from system.local where key='local'").one();
       } else {
         // non-control hosts are populated from system.peers and their broadcast address should be
         // known

--- a/driver-core/src/test/java/com/datastax/driver/core/TrafficMetersTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TrafficMetersTest.java
@@ -34,7 +34,8 @@ public class TrafficMetersTest extends CCMTestsSupport {
     long bytesReceivedBefore = bytesReceived.getCount();
     long bytesSentBefore = bytesSent.getCount();
 
-    SimpleStatement statement = new SimpleStatement("SELECT host_id FROM system.local");
+    SimpleStatement statement =
+        new SimpleStatement("SELECT host_id FROM system.local WHERE key='local'");
     // Set serial CL to something non-default so request size estimate is accurate.
     statement.setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
     int requestSize =

--- a/driver-examples/src/main/java/com/datastax/driver/examples/basic/ReadCassandraVersion.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/basic/ReadCassandraVersion.java
@@ -53,7 +53,7 @@ public class ReadCassandraVersion {
       // We use execute to send a query to Cassandra. This returns a ResultSet, which is essentially
       // a collection
       // of Row objects.
-      ResultSet rs = session.execute("select release_version from system.local");
+      ResultSet rs = session.execute("select release_version from system.local where key='local'");
       //  Extract the first row (which is the only one in this case).
       Row row = rs.one();
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
@@ -84,7 +84,7 @@ public class MapperAccessorTest extends CCMTestsSupport {
   @SuppressWarnings("unused")
   @Accessor
   public interface SystemAccessor {
-    @Query("select release_version from system.local")
+    @Query("select release_version from system.local where key='local'")
     ResultSet getCassandraVersion();
   }
 


### PR DESCRIPTION
Full scan queries are slower even when only one record in the table

Fixes: https://github.com/scylladb/java-driver/issues/282