### PR TITLE
Move metadata internal API to use List instead of Set as replicas store

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -22,6 +22,7 @@
 package com.datastax.driver.core;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +53,7 @@ import org.slf4j.LoggerFactory;
 public class Metadata {
 
   private static final Logger logger = LoggerFactory.getLogger(Metadata.class);
+  private static final ImmutableList<Host> EMPTY_LIST = ImmutableList.of();
 
   final Cluster.Manager cluster;
   volatile String clusterName;
@@ -553,9 +556,39 @@ public class Metadata {
    * @return the (immutable) set of replicas for {@code partitionKey} as known by the driver. Note
    *     that the result might be stale or empty if metadata was explicitly disabled with {@link
    *     QueryOptions#setMetadataEnabled(boolean)}.
+   * @deprecated use {@link Metadata#getReplicasList(String, String, Token.Factory, ByteBuffer)}
    */
+  @Deprecated
   @Beta
   public Set<Host> getReplicas(
+      String keyspace, String table, Token.Factory partitioner, ByteBuffer partitionKey) {
+    return new LinkedHashSet<>(this.getReplicasList(keyspace, table, partitioner, partitionKey));
+  }
+
+  /**
+   * Extension of legacy method {@link Metadata#getReplicas(String, Token.Factory, ByteBuffer)}.
+   * Tablets model requires knowledge of the table name to determine the replicas. This method will
+   * first try to lookup replicas through known tablets metadata. It will default to TokenMap lookup
+   * if either {@code null} was passed as table name or the tablet lookup is unsuccessful for any
+   * other reason.
+   *
+   * <p>Returns the list of hosts that are replica for a given partition key. Partitioner can be
+   * {@code null} and then a cluster-wide partitioner will be invoked.
+   *
+   * <p>Note that this information is refreshed asynchronously by the control connection, when
+   * schema or ring topology changes. It might occasionally be stale (or even empty).
+   *
+   * @param keyspace the name of the keyspace to get replicas for.
+   * @param table the name of the table to get replicas for. Necessary for distinction for tablets.
+   *     Unnecessary for regular TokenMap
+   * @param partitioner the partitioner to use or @{code null} for cluster-wide partitioner.
+   * @param partitionKey the partition key for which to find the list of replica.
+   * @return the (immutable) list of replicas for {@code partitionKey} as known by the driver. Note
+   *     that the result might be stale or empty if metadata was explicitly disabled with {@link
+   *     QueryOptions#setMetadataEnabled(boolean)}.
+   */
+  @Beta
+  public List<Host> getReplicasList(
       String keyspace, String table, Token.Factory partitioner, ByteBuffer partitionKey) {
     keyspace = handleId(keyspace);
     table = handleId(table);
@@ -564,7 +597,7 @@ public class Metadata {
       partitioner = current.factory;
     }
     if (partitioner == null) {
-      return Collections.emptySet();
+      return EMPTY_LIST;
     }
     Token token = partitioner.hash(partitionKey);
 
@@ -575,14 +608,13 @@ public class Metadata {
         assert (token instanceof Token.TokenLong64);
         return tabletMap.getReplicas(keyspace, table, (long) token.getValue());
       } else {
-        return Collections.emptySet();
+        return EMPTY_LIST;
       }
     }
 
     // TokenMap:
-    if (current == null) return Collections.<Host>emptySet();
-    Set<Host> hosts = current.getReplicas(keyspace, token);
-    return hosts == null ? Collections.<Host>emptySet() : hosts;
+    if (current == null) return EMPTY_LIST;
+    return current.getReplicas(keyspace, token);
   }
 
   /**
@@ -598,10 +630,31 @@ public class Metadata {
    * @return the (immutable) set of replicas for {@code partitionKey} as known by the driver. Note
    *     that the result might be stale or empty if metadata was explicitly disabled with {@link
    *     QueryOptions#setMetadataEnabled(boolean)}.
+   * @deprecated use {@link Metadata#getReplicasList(String, Token.Factory, ByteBuffer)}
    */
+  @Deprecated
   public Set<Host> getReplicas(
       String keyspace, Token.Factory partitioner, ByteBuffer partitionKey) {
     return getReplicas(keyspace, null, partitioner, partitionKey);
+  }
+
+  /**
+   * Returns the immutable list of hosts that are replica for a given partition key. Partitioner can
+   * be {@code null} and then a cluster-wide partitioner will be invoked.
+   *
+   * <p>Note that this information is refreshed asynchronously by the control connection, when
+   * schema or ring topology changes. It might occasionally be stale (or even empty).
+   *
+   * @param keyspace the name of the keyspace to get replicas for.
+   * @param partitioner the partitioner to use or @{code null} for cluster-wide partitioner.
+   * @param partitionKey the partition key for which to find the set of replica.
+   * @return the (immutable) list of replicas for {@code partitionKey} as known by the driver. Note
+   *     that the result might be stale or empty if metadata was explicitly disabled with {@link
+   *     QueryOptions#setMetadataEnabled(boolean)}.
+   */
+  public List<Host> getReplicasList(
+      String keyspace, Token.Factory partitioner, ByteBuffer partitionKey) {
+    return getReplicasList(keyspace, null, partitioner, partitionKey);
   }
 
   /**
@@ -620,6 +673,7 @@ public class Metadata {
    * @return the (immutable) set of replicas for {@code range} as known by the driver. Note that the
    *     result might be stale or empty if metadata was explicitly disabled with {@link
    *     QueryOptions#setMetadataEnabled(boolean)}.
+   * @deprecated use {@link Metadata#getReplicasList(String, TokenRange)}
    */
   public Set<Host> getReplicas(String keyspace, TokenRange range) {
     keyspace = handleId(keyspace);
@@ -627,8 +681,34 @@ public class Metadata {
     if (current == null) {
       return Collections.emptySet();
     } else {
-      Set<Host> hosts = current.getReplicas(keyspace, range.getEnd());
-      return hosts == null ? Collections.<Host>emptySet() : hosts;
+      return new HashSet<>(current.getReplicas(keyspace, range.getEnd()));
+    }
+  }
+
+  /**
+   * Returns the list of hosts that are replica for a given token range.
+   *
+   * <p>Note that it is assumed that the input range does not overlap across multiple host ranges.
+   * If the range extends over multiple hosts, it only returns the replicas for those hosts that are
+   * replicas for the last token of the range. This behavior may change in a future release, see <a
+   * href="https://datastax-oss.atlassian.net/browse/JAVA-1355">JAVA-1355</a>.
+   *
+   * <p>Also note that this information is refreshed asynchronously by the control connection, when
+   * schema or ring topology changes. It might occasionally be stale (or even empty).
+   *
+   * @param keyspace the name of the keyspace to get replicas for.
+   * @param range the token range.
+   * @return the list of replicas for {@code range} as known by the driver. Note that the result
+   *     might be stale or empty if metadata was explicitly disabled with {@link
+   *     QueryOptions#setMetadataEnabled(boolean)}.
+   */
+  public List<Host> getReplicasList(String keyspace, TokenRange range) {
+    keyspace = handleId(keyspace);
+    TokenMap current = tokenMap;
+    if (current == null) {
+      return EMPTY_LIST;
+    } else {
+      return current.getReplicas(keyspace, range.getEnd());
     }
   }
 
@@ -985,7 +1065,7 @@ public class Metadata {
 
     private final Token.Factory factory;
     private final Map<Host, Set<Token>> primaryToTokens;
-    private final Map<String, Map<Token, Set<Host>>> tokenToHostsByKeyspace;
+    private final Map<String, Map<Token, ImmutableList<Host>>> tokenToHostsByKeyspace;
     private final Map<String, Map<Host, Set<TokenRange>>> hostsToRangesByKeyspace;
     private final List<Token> ring;
     private final Set<TokenRange> tokenRanges;
@@ -997,7 +1077,7 @@ public class Metadata {
         Set<TokenRange> tokenRanges,
         Map<Token, Host> tokenToPrimary,
         Map<Host, Set<Token>> primaryToTokens,
-        Map<String, Map<Token, Set<Host>>> tokenToHostsByKeyspace,
+        Map<String, Map<Token, ImmutableList<Host>>> tokenToHostsByKeyspace,
         Map<String, Map<Host, Set<TokenRange>>> hostsToRangesByKeyspace) {
       this.factory = factory;
       this.ring = ring;
@@ -1042,15 +1122,13 @@ public class Metadata {
         Set<TokenRange> tokenRanges,
         Map<Token, Host> tokenToPrimary) {
       Set<Host> hosts = allTokens.keySet();
-      Map<String, Map<Token, Set<Host>>> tokenToHosts =
-          new HashMap<String, Map<Token, Set<Host>>>();
-      Map<ReplicationStrategy, Map<Token, Set<Host>>> replStrategyToHosts =
-          new HashMap<ReplicationStrategy, Map<Token, Set<Host>>>();
-      Map<String, Map<Host, Set<TokenRange>>> hostsToRanges =
-          new HashMap<String, Map<Host, Set<TokenRange>>>();
+      Map<String, Map<Token, ImmutableList<Host>>> tokenToHosts = new HashMap<>();
+      Map<ReplicationStrategy, Map<Token, ImmutableList<Host>>> replStrategyToHosts =
+          new HashMap<>();
+      Map<String, Map<Host, Set<TokenRange>>> hostsToRanges = new HashMap<>();
       for (KeyspaceMetadata keyspace : keyspaces) {
         ReplicationStrategy strategy = keyspace.replicationStrategy();
-        Map<Token, Set<Host>> ksTokens = replStrategyToHosts.get(strategy);
+        Map<Token, ImmutableList<Host>> ksTokens = replStrategyToHosts.get(strategy);
         if (ksTokens == null) {
           ksTokens =
               (strategy == null)
@@ -1077,14 +1155,14 @@ public class Metadata {
           factory, ring, tokenRanges, tokenToPrimary, allTokens, tokenToHosts, hostsToRanges);
     }
 
-    private Set<Host> getReplicas(String keyspace, Token token) {
+    private ImmutableList<Host> getReplicas(String keyspace, Token token) {
 
-      Map<Token, Set<Host>> tokenToHosts = tokenToHostsByKeyspace.get(keyspace);
-      if (tokenToHosts == null) return Collections.emptySet();
+      Map<Token, ImmutableList<Host>> tokenToHosts = tokenToHostsByKeyspace.get(keyspace);
+      if (tokenToHosts == null) return EMPTY_LIST;
 
       // If the token happens to be one of the "primary" tokens, get result directly
-      Set<Host> hosts = tokenToHosts.get(token);
-      if (hosts != null) return hosts;
+      ImmutableList<Host> hosts = tokenToHosts.get(token);
+      if (hosts != null) return ImmutableList.copyOf(hosts);
 
       // Otherwise, find closest "primary" token on the ring
       int i = Collections.binarySearch(ring, token);
@@ -1096,10 +1174,10 @@ public class Metadata {
       return tokenToHosts.get(ring.get(i));
     }
 
-    private static Map<Token, Set<Host>> makeNonReplicatedMap(Map<Token, Host> input) {
-      Map<Token, Set<Host>> output = new HashMap<Token, Set<Host>>(input.size());
+    private static Map<Token, ImmutableList<Host>> makeNonReplicatedMap(Map<Token, Host> input) {
+      Map<Token, ImmutableList<Host>> output = new HashMap<>(input.size());
       for (Map.Entry<Token, Host> entry : input.entrySet())
-        output.put(entry.getKey(), ImmutableSet.of(entry.getValue()));
+        output.put(entry.getKey(), ImmutableList.of(entry.getValue()));
       return output;
     }
 
@@ -1119,11 +1197,11 @@ public class Metadata {
     }
 
     private static Map<Host, Set<TokenRange>> computeHostsToRangesMap(
-        Set<TokenRange> tokenRanges, Map<Token, Set<Host>> ksTokens, int hostCount) {
+        Set<TokenRange> tokenRanges, Map<Token, ImmutableList<Host>> ksTokens, int hostCount) {
       Map<Host, ImmutableSet.Builder<TokenRange>> builders =
           Maps.newHashMapWithExpectedSize(hostCount);
       for (TokenRange range : tokenRanges) {
-        Set<Host> replicas = ksTokens.get(range.getEnd());
+        List<Host> replicas = ksTokens.get(range.getEnd());
         for (Host host : replicas) {
           ImmutableSet.Builder<TokenRange> hostRanges = builders.get(host);
           if (hostRanges == null) {

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.driver.core;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.HashMap;
@@ -67,7 +67,7 @@ abstract class ReplicationStrategy {
     }
   }
 
-  abstract Map<Token, Set<Host>> computeTokenToReplicaMap(
+  abstract Map<Token, ImmutableList<Host>> computeTokenToReplicaMap(
       String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring);
 
   private static Token getTokenWrapping(int i, List<Token> ring) {
@@ -83,18 +83,18 @@ abstract class ReplicationStrategy {
     }
 
     @Override
-    Map<Token, Set<Host>> computeTokenToReplicaMap(
+    Map<Token, ImmutableList<Host>> computeTokenToReplicaMap(
         String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring) {
 
       int rf = Math.min(replicationFactor.fullReplicas(), ring.size());
 
-      Map<Token, Set<Host>> replicaMap = new HashMap<Token, Set<Host>>(tokenToPrimary.size());
+      Map<Token, ImmutableList<Host>> replicaMap = new HashMap<>(tokenToPrimary.size());
       for (int i = 0; i < ring.size(); i++) {
         // Consecutive sections of the ring can assigned to the same host
-        Set<Host> replicas = new LinkedHashSet<Host>();
+        Set<Host> replicas = new LinkedHashSet<>();
         for (int j = 0; j < ring.size() && replicas.size() < rf; j++)
           replicas.add(tokenToPrimary.get(getTokenWrapping(i + j, ring)));
-        replicaMap.put(ring.get(i), ImmutableSet.copyOf(replicas));
+        replicaMap.put(ring.get(i), ImmutableList.copyOf(replicas));
       }
       return replicaMap;
     }
@@ -125,7 +125,7 @@ abstract class ReplicationStrategy {
     }
 
     @Override
-    Map<Token, Set<Host>> computeTokenToReplicaMap(
+    Map<Token, ImmutableList<Host>> computeTokenToReplicaMap(
         String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring) {
 
       logger.debug("Computing token to replica map for keyspace: {}.", keyspaceName);
@@ -135,7 +135,7 @@ abstract class ReplicationStrategy {
 
       // This is essentially a copy of org.apache.cassandra.locator.NetworkTopologyStrategy
       Map<String, Set<String>> racks = getRacksInDcs(tokenToPrimary.values());
-      Map<Token, Set<Host>> replicaMap = new HashMap<Token, Set<Host>>(tokenToPrimary.size());
+      Map<Token, ImmutableList<Host>> replicaMap = new HashMap<>(tokenToPrimary.size());
       Map<String, Integer> dcHostCount = Maps.newHashMapWithExpectedSize(replicationFactors.size());
       Set<String> warnedDcs = Sets.newHashSetWithExpectedSize(replicationFactors.size());
       // find maximum number of nodes in each DC
@@ -157,7 +157,7 @@ abstract class ReplicationStrategy {
         }
 
         // Preserve order - primary replica will be first
-        Set<Host> replicas = new LinkedHashSet<Host>();
+        Set<Host> replicas = new LinkedHashSet<>();
         for (int j = 0; j < ring.size() && !allDone(allDcReplicas, dcHostCount); j++) {
           Host h = tokenToPrimary.get(getTokenWrapping(i + j, ring));
           String dc = h.getDatacenter();
@@ -214,7 +214,7 @@ abstract class ReplicationStrategy {
           }
         }
 
-        replicaMap.put(ring.get(i), ImmutableSet.copyOf(replicas));
+        replicaMap.put(ring.get(i), ImmutableList.copyOf(replicas));
       }
 
       long duration = System.currentTimeMillis() - startTime;

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -121,11 +121,11 @@ class RequestHandler {
       tableName = defs.getTable(0);
     }
 
-    final Set<Host> replicas =
+    final List<Host> replicas =
         manager
             .cluster
             .getMetadata()
-            .getReplicas(Metadata.quote(keyspace), tableName, partitioner, partitionKey);
+            .getReplicasList(Metadata.quote(keyspace), tableName, partitioner, partitionKey);
 
     // replicas are stored in the right order starting with the primary replica
     return replicas.iterator();

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -659,6 +659,7 @@ class SessionManager extends AbstractSession {
       boolean skipMetadata =
           protocolVersion != ProtocolVersion.V1
               && bs.statement.getPreparedId().resultSetMetadata.variables != null;
+
       Requests.QueryProtocolOptions options =
           new Requests.QueryProtocolOptions(
               Message.Request.Type.EXECUTE,

--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
@@ -1,15 +1,14 @@
 package com.datastax.driver.core;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,6 +25,7 @@ import org.slf4j.LoggerFactory;
 @Beta
 public class TabletMap {
   private static final Logger logger = LoggerFactory.getLogger(TabletMap.class);
+  private static final ImmutableList<Host> EMPTY_LIST = ImmutableList.of();
 
   // There are no additional locking mechanisms for the mapping field itself, however each TabletSet
   // inside has its own ReadWriteLock that should be used when dealing with its internals.
@@ -64,21 +64,22 @@ public class TabletMap {
    * @param keyspace the keyspace that table is in
    * @param table the table name
    * @param token the token to look for
-   * @return Set of Host instances that do have a tablet for the given token and table combination.
+   * @return List(immutable) of Host instances that do have a tablet for the given token and table
+   *     combination.
    */
-  public Set<Host> getReplicas(String keyspace, String table, long token) {
+  public List<Host> getReplicas(String keyspace, String table, long token) {
     TabletMap.KeyspaceTableNamePair key = new TabletMap.KeyspaceTableNamePair(keyspace, table);
 
     if (mapping == null) {
       logger.trace("This tablets map is null. Returning empty set.");
-      return Collections.emptySet();
+      return EMPTY_LIST;
     }
 
     TabletSet tabletSet = mapping.get(key);
     if (tabletSet == null) {
       logger.trace(
           "There is no tablets for {}.{} in this mapping. Returning empty set.", keyspace, table);
-      return Collections.emptySet();
+      return EMPTY_LIST;
     }
     Lock readLock = tabletSet.lock.readLock();
     try {
@@ -90,22 +91,22 @@ public class TabletMap {
             keyspace,
             table,
             token);
-        return Collections.emptySet();
+        return EMPTY_LIST;
       }
 
-      HashSet<Host> replicaSet = new HashSet<>();
+      ImmutableList.Builder<Host> replicas = new ImmutableList.Builder();
       for (HostShardPair hostShardPair : row.replicas) {
         Host replica = cluster.metadata.getHost(hostShardPair.getHost());
         if (replica == null) {
           // We've encountered a stale host. Return an empty set to
           // misroute the request. If misrouted then response will
           // contain up to date tablet information that will be processed.
-          return Collections.emptySet();
+          return EMPTY_LIST;
         } else {
-          replicaSet.add(replica);
+          replicas.add(replica);
         }
       }
-      return replicaSet;
+      return replicas.build();
     } finally {
       readLock.unlock();
     }
@@ -134,7 +135,7 @@ public class TabletMap {
         firstToken,
         lastToken);
 
-    Set<HostShardPair> replicas = new HashSet<>();
+    List<HostShardPair> replicas = new ArrayList<>();
     List<TupleValue> list = tupleValue.getList(2, TupleValue.class);
     for (TupleValue tuple : list) {
       HostShardPair hostShardPair = new HostShardPair(tuple.getUUID(0), tuple.getInt(1));
@@ -319,7 +320,7 @@ public class TabletMap {
     private final String tableName;
     private final long firstToken;
     private final long lastToken;
-    private final Set<HostShardPair> replicas;
+    private final List<HostShardPair> replicas;
 
     private Tablet(
         String keyspaceName,
@@ -327,7 +328,7 @@ public class TabletMap {
         String tableName,
         long firstToken,
         long lastToken,
-        Set<HostShardPair> replicas) {
+        List<HostShardPair> replicas) {
       this.keyspaceName = keyspaceName;
       this.tableId = tableId;
       this.tableName = tableName;
@@ -367,7 +368,7 @@ public class TabletMap {
       return lastToken;
     }
 
-    public Set<HostShardPair> getReplicas() {
+    public List<HostShardPair> getReplicas() {
       return replicas;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -32,14 +32,12 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Statement;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.Lists;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -200,8 +198,8 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       tableName = defs.getTable(0);
     }
 
-    final Set<Host> replicas =
-        clusterMetadata.getReplicas(
+    final List<Host> replicas =
+        clusterMetadata.getReplicasList(
             Metadata.quote(keyspace), tableName, statement.getPartitioner(), partitionKey);
     if (replicas.isEmpty()) return childPolicy.newQueryPlan(loggedKeyspace, statement);
 
@@ -250,9 +248,9 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       final Iterator<Host> replicasIterator;
 
       if (replicaOrdering == ReplicaOrdering.RANDOM) {
-        List<Host> replicasList = Lists.newArrayList(replicas);
-        Collections.shuffle(replicasList, ThreadLocalRandom.current());
-        replicasIterator = replicasList.iterator();
+        ArrayList<Host> replicasCopy = new ArrayList<>(replicas);
+        Collections.shuffle(replicasCopy, ThreadLocalRandom.current());
+        replicasIterator = replicasCopy.iterator();
       } else {
         replicasIterator = replicas.iterator();
       }

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -28,7 +28,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Base class for replication strategy tests. Currently only supports testing using the default
@@ -132,15 +131,15 @@ public class AbstractReplicationStrategyTest {
    * Hosts are checked in order, replica placement should be an ordered set
    */
   protected static void assertReplicaPlacement(
-      Map<Token, Set<Host>> replicaMap, Token token, InetSocketAddress... expected) {
-    Set<Host> replicaSet = replicaMap.get(token);
+      Map<Token, ImmutableList<Host>> replicaMap, Token token, InetSocketAddress... expected) {
+    List<Host> replicaSet = replicaMap.get(token);
     assertNotNull(replicaSet);
     assertReplicasForToken(replicaSet, expected);
   }
 
   /** Checks if a given ordered set of replicas matches the expected list of replica hosts */
   protected static void assertReplicasForToken(
-      Set<Host> replicaSet, InetSocketAddress... expected) {
+      List<Host> replicaSet, InetSocketAddress... expected) {
     final String message =
         "Contents of replica set: "
             + replicaSet

--- a/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Maps;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.testng.annotations.Test;
@@ -189,7 +188,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
@@ -226,7 +225,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
@@ -263,7 +262,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1), rf(DC3, 1));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3);
@@ -306,7 +305,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
@@ -365,7 +364,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
@@ -432,7 +431,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP5, IP3, IP6, IP4);
@@ -497,7 +496,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
@@ -564,7 +563,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
     // all nodes will contain all data, question is the replica order
     ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 4), rf(DC2, 4));
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP7, IP2, IP6, IP4, IP8);
@@ -587,7 +586,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
   @Test(groups = "unit")
   public void networkTopologyStrategyExampleTopologyTest() {
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         exampleStrategy.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
     // 105 and 106 will appear as replica for all as they're in separate racks
@@ -614,7 +613,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
   @Test(groups = "unit")
   public void networkTopologyStrategyNoNodesInDCTest() {
     long t1 = System.currentTimeMillis();
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2))
             .computeTokenToReplicaMap(keyspace, largeRingTokenToPrimary, largeRing);
     assertThat(System.currentTimeMillis() - t1).isLessThan(10000);
@@ -637,7 +636,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
   @Test(groups = "unit")
   public void networkTopologyStrategyExampleTopologyTooManyReplicasTest() {
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         exampleStrategyTooManyReplicas.computeTokenToReplicaMap(
             keyspace, exampleTokenToPrimary, exampleRing);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.testng.annotations.Test;
 
 public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
@@ -139,7 +138,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
     ReplicationStrategy strategy = simpleStrategy(2);
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
@@ -163,7 +162,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
     ReplicationStrategy strategy = simpleStrategy(2);
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
@@ -187,7 +186,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
     ReplicationStrategy strategy = simpleStrategy(2);
 
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
@@ -198,7 +197,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
   @Test(groups = "unit")
   public void simpleStrategyExampleTopologyMapTest() {
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         exampleStrategy.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
     assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3);
@@ -223,7 +222,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
   @Test(groups = "unit")
   public void simpleStrategyExampleTopologyTooManyReplicasTest() {
-    Map<Token, Set<Host>> replicaMap =
+    Map<Token, ImmutableList<Host>> replicaMap =
         exampleStrategyTooManyReplicas.computeTokenToReplicaMap(
             keyspace, exampleTokenToPrimary, exampleRing);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.datastax.driver.core.Assertions.assertThat;
 
 import com.datastax.driver.core.utils.Bytes;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Set;
 import org.testng.annotations.Test;
 
@@ -53,9 +54,15 @@ public class SingleTokenIntegrationTest extends CCMTestsSupport {
     Host host1 = TestUtils.findHost(cluster(), 1);
     assertThat(hostsForRange).containsOnly(host1);
 
+    List<Host> hostsForRangeList = metadata.getReplicasList(keyspace, tokenRange);
+    assertThat(hostsForRangeList).containsOnly(host1);
+
     ByteBuffer randomPartitionKey = Bytes.fromHexString("0xCAFEBABE");
     Set<Host> hostsForKey = metadata.getReplicas(keyspace, null, randomPartitionKey);
     assertThat(hostsForKey).containsOnly(host1);
+
+    List<Host> hostsForKeyList = metadata.getReplicasList(keyspace, null, null, randomPartitionKey);
+    assertThat(hostsForKeyList).containsOnly(host1);
 
     Set<TokenRange> rangesForHost = metadata.getTokenRanges(keyspace, host1);
     assertThat(rangesForHost).containsOnly(tokenRange);

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -104,9 +104,10 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
 
     // Find the replica for a given partition key
     int testKey = 1;
-    Set<Host> replicas =
-        metadata.getReplicas(
+    List<Host> replicas =
+        metadata.getReplicasList(
             ks1,
+            null,
             null,
             TypeCodec.cint()
                 .serialize(
@@ -134,6 +135,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
           foundRange = range;
           // That range should be managed by the replica
           assertThat(metadata.getReplicas(ks1, range)).contains(replica);
+          assertThat(metadata.getReplicasList(ks1, range)).contains(replica);
         }
       }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -91,6 +91,8 @@ public class TokenAwarePolicyTest {
     when(cluster.getMetadata()).thenReturn(metadata);
     when(metadata.getReplicas(Metadata.quote("keyspace"), null, null, routingKey))
         .thenReturn(Sets.newLinkedHashSet(host1, host2));
+    when(metadata.getReplicasList(Metadata.quote("keyspace"), null, null, routingKey))
+        .thenReturn(Lists.newArrayList(host1, host2));
     when(childPolicy.newQueryPlan("keyspace", statement))
         .thenReturn(Sets.newLinkedHashSet(host4, host3, host2, host1).iterator());
     when(childPolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);


### PR DESCRIPTION
In almost all use cases replicas are getting converted into a List. 
To make performance better make these API provide List instead.