### PR TITLE
Fix RemovedNodeIT random behavior

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
@@ -24,7 +24,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.token.TokenRange;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
@@ -33,10 +33,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-@ScyllaSkip(description = "@IntegrationTestDisabledFlaky")
 public class RemovedNodeIT {
 
   @ClassRule
@@ -44,8 +44,21 @@ public class RemovedNodeIT {
       CustomCcmRule.builder()
           // We need 4 nodes to run this test against DSE, because it requires at least 3 nodes to
           // maintain RF=3 for keyspace system_distributed
-          .withNodes(4)
+          //
+          // To avoid issue with flakiness of this test (scylladb/java-driver/issues/393) we start
+          // with 1 node and manually start 3 more nodes with initial_token explicitly set.
+          .withNodes(1)
           .build();
+
+  @Before
+  public void setup() {
+    CcmBridge ccmBridge = CCM_RULE.getCcmBridge();
+    for (int nodeId = 2; nodeId <= 4; nodeId++) {
+      ccmBridge.addWithoutStart(nodeId, "dc1", "-j", String.valueOf(7000 + nodeId * 100));
+      ccmBridge.updateNodeConfig(nodeId, "initial_token", String.valueOf(nodeId * 100));
+      ccmBridge.start(nodeId);
+    }
+  }
 
   @Test
   public void should_signal_and_destroy_pool_when_node_gets_removed() {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -487,6 +487,18 @@ public class CcmBridge implements AutoCloseable {
     execute("node" + n, "stop");
   }
 
+  public void addWithoutStart(int n, String dc, String... extraArgs) {
+    String[] initialArgs = new String[] {"add", "-i", ipPrefix + n, "-d", dc, "node" + n};
+    ArrayList<String> args = new ArrayList<>(Arrays.asList(initialArgs));
+    args.addAll(Arrays.asList(extraArgs));
+    if (getDseVersion().isPresent()) {
+      args.add("--dse");
+    } else if (getScyllaVersion().isPresent()) {
+      args.add("--scylla");
+    }
+    execute(args.toArray(new String[] {}));
+  }
+
   public void addWithoutStart(int n, String dc) {
     String[] initialArgs = new String[] {"add", "-i", ipPrefix + n, "-d", dc, "node" + n};
     ArrayList<String> args = new ArrayList<>(Arrays.asList(initialArgs));


### PR DESCRIPTION
`RemovedNodeIt#should_signal_and_destroy_pool_when_node_gets_removed` test starts 4 node cluster. Probably because of nodes starting in parallel it sometimes leads to the situation where two nodes own the same token. This throws the test off. Not only the driver sees one node as invalid, but also the assertion that expects 4 different token ranges fails, because there are only 3.

To remediate that this change modifies the test to start the setup with 1 node and then sequentially add remaining 3 nodes with their `initial_token` explicitly set.

Fixes https://github.com/scylladb/java-driver/issues/393