### PR TITLE
3.x: Update github ubuntu runner

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/.github/workflows/tests-reports-4x@v1.yml
+++ b/.github/workflows/tests-reports-4x@v1.yml
@@ -10,7 +10,7 @@ on:
       - completed
 jobs:
   report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/tests-reports@v1.yml
+++ b/.github/workflows/tests-reports@v1.yml
@@ -10,7 +10,7 @@ on:
       - completed
 jobs:
   report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:
@@ -33,7 +33,7 @@ jobs:
 
   verify:
     name: Full verify
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:
@@ -56,7 +56,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   setup-integration-tests:
     name: Setup ITs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -113,7 +113,7 @@ jobs:
 
   cassandra-integration-tests:
     name: Cassandra ITs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [setup-integration-tests]
     timeout-minutes: 90
 
@@ -139,10 +139,8 @@ jobs:
 
       - name: Setup environment
         run: |
-          sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
-          sudo apt-get update
-          sudo apt-get install libssl1.0.0
           pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
 
       - name: Run integration tests on Cassandra (${{ matrix.cassandra-version }})
         run: mvn -B verify -Pshort -Dcassandra.version=${{ matrix.cassandra-version }} -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
@@ -170,7 +168,7 @@ jobs:
 
   scylla-integration-tests:
     name: Scylla ITs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [setup-integration-tests]
     timeout-minutes: 90
 
@@ -196,9 +194,6 @@ jobs:
 
       - name: Setup environment
         run: |
-          sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
-          sudo apt-get update
-          sudo apt-get install libssl1.0.0
           pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
           sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
-        <netty.version>4.1.100.Final</netty.version>
-        <netty-tcnative.artifact>netty-tcnative</netty-tcnative.artifact>
-        <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
+        <netty.version>4.1.119.Final</netty.version>
+        <netty-tcnative.artifact>netty-tcnative-boringssl-static</netty-tcnative.artifact>
+        <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
         <snappy.version>1.1.10.5</snappy.version>
         <lz4.version>1.4.1</lz4.version>


### PR DESCRIPTION
Image going to be depricated at 2025.04.01,
https://github.com/actions/runner-images/issues/11101.

This PR does:
1. Moves runners to ubuntu-latest
2. Switches from `netty-tcnative` to `netty-tcnative-boringssl-static` due to problems of getting old `libssl.so.1.0.0` installed on modern distros.
3. Updates netty