### PR TITLE
Intruduce flag to disable skip metadata

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/DseConversions.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/DseConversions.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.cql.Conversions;
+import com.datastax.oss.driver.internal.core.cql.DefaultPreparedStatement;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.request.Execute;
 import com.datastax.oss.protocol.internal.request.Query;
@@ -115,8 +116,15 @@ public class DseConversions {
           protocolVersion, DefaultProtocolFeature.UNSET_BOUND_VALUES)) {
         Conversions.ensureAllSet(boundStatement);
       }
-      boolean skipMetadata =
-          boundStatement.getPreparedStatement().getResultSetDefinitions().size() > 0;
+
+      boolean skipMetadata;
+      if (boundStatement.getPreparedStatement() instanceof DefaultPreparedStatement) {
+        skipMetadata =
+            ((DefaultPreparedStatement) boundStatement.getPreparedStatement()).isSkipMetadata();
+      } else {
+        skipMetadata = boundStatement.getPreparedStatement().getResultSetDefinitions().size() > 0;
+        ;
+      }
       DseQueryOptions queryOptions =
           new DseQueryOptions(
               consistencyCode,

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CQL4SkipMetadataResolveMethod.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CQL4SkipMetadataResolveMethod.java
@@ -1,0 +1,42 @@
+package com.datastax.oss.driver.api.core;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public enum CQL4SkipMetadataResolveMethod {
+  // SMART (Default) - Disables the skip metadata flag only for wildcard selects (`SELECT * FROM`)
+  // and queries
+  //  that return UDTs (including UDT collections and maps containing UDTs).
+  SMART("smart"),
+  // ENABLED – Enables the `skip metadata` flag, preventing metadata from being sent
+  ENABLED("enabled"),
+  // DISABLED - Disables the `skip metadata` flag, ensuring metadata is included in every RESULT
+  // frame for bound statement execution.
+  DISABLED("disabled");
+
+  private final String value;
+
+  CQL4SkipMetadataResolveMethod(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  // Case in-sensitive version of `valueOf`. To be used at all times instead of `valueOf`
+  @NonNull
+  public static CQL4SkipMetadataResolveMethod fromValue(@NonNull String value)
+      throws IllegalArgumentException {
+    switch (value.toLowerCase()) {
+      case "smart":
+        return SMART;
+      case "enabled":
+        return ENABLED;
+      case "disabled":
+        return DISABLED;
+      default:
+        throw new IllegalArgumentException("Unsupported value " + value);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -689,6 +689,34 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: boolean
    */
   PREPARE_ON_ALL_NODES("advanced.prepared-statements.prepare-on-all-nodes"),
+
+  /**
+   * CQL 4.x has a known issue where prepared statement invalidation may be bypassed on the client
+   * side. Reference: https://github.com/scylladb/scylladb/issues/20860
+   *
+   * <p>When this occurs, the client's metadata can become outdated, leading to various
+   * deserialization errors.
+   *
+   * <p>To mitigate this, the driver can disable the `skip metadata` flag, ensuring the server
+   * includes metadata with every bound statement RESULT query response.
+   *
+   * <p>This setting determines how the driver handles the `skip metadata` flag for CQL 4 prepared
+   * statements: - **"smart"** (default) – Disables the flag only for wildcard selects (`SELECT *
+   * FROM`) and queries that return UDTs (including UDT collections and maps containing UDTs). -
+   * **"enabled"** – Enables the `skip metadata` flag, preventing metadata from being sent. -
+   * **"disabled"** – Disables the `skip metadata` flag, ensuring metadata is included in every
+   * RESULT frame.
+   *
+   * <p>Sending metadata reduces performance on both the driver and server while increasing traffic.
+   * If you need to use UDTs or wildcard selects, you must either accept the performance impact or
+   * ensure: 1. No schema alterations are performed on tables or UDTs in use. 2. After any schema
+   * change, all relevant prepared statements are re-prepared.
+   *
+   * <p>Value-type: string
+   */
+  PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD(
+      "advanced.prepared-statements.skip-cql4-metadata-resolve-method"),
+
   /**
    * Whether the driver tries to prepare on new nodes at all.
    *

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -17,6 +17,7 @@
  */
 package com.datastax.oss.driver.api.core.config;
 
+import com.datastax.oss.driver.api.core.CQL4SkipMetadataResolveMethod;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -258,6 +259,9 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.REQUEST_TIMEOUT, requestTimeout);
     map.put(TypedDriverOption.REQUEST_CONSISTENCY, "LOCAL_ONE");
     map.put(TypedDriverOption.REQUEST_PAGE_SIZE, requestPageSize);
+    map.put(
+        TypedDriverOption.PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD,
+        CQL4SkipMetadataResolveMethod.SMART.toString());
     map.put(TypedDriverOption.REQUEST_SERIAL_CONSISTENCY, "SERIAL");
     map.put(TypedDriverOption.REQUEST_DEFAULT_IDEMPOTENCE, false);
     map.put(TypedDriverOption.GRAPH_TRAVERSAL_SOURCE, "g");

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -583,6 +583,10 @@ public class TypedDriverOption<ValueT> {
   /** Whether `Session.prepare` calls should be sent to all nodes in the cluster. */
   public static final TypedDriverOption<Boolean> PREPARE_ON_ALL_NODES =
       new TypedDriverOption<>(DefaultDriverOption.PREPARE_ON_ALL_NODES, GenericType.BOOLEAN);
+  /** Method to resolve skip metadata flag for CQL4. */
+  public static final TypedDriverOption<String> PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD =
+      new TypedDriverOption<>(
+          DefaultDriverOption.PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD, GenericType.STRING);
   /** Whether the driver tries to prepare on new nodes at all. */
   public static final TypedDriverOption<Boolean> REPREPARE_ENABLED =
       new TypedDriverOption<>(DefaultDriverOption.REPREPARE_ENABLED, GenericType.BOOLEAN);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -194,8 +194,15 @@ public class Conversions {
           protocolVersion, DefaultProtocolFeature.UNSET_BOUND_VALUES)) {
         ensureAllSet(boundStatement);
       }
-      boolean skipMetadata =
-          boundStatement.getPreparedStatement().getResultSetDefinitions().size() > 0;
+
+      boolean skipMetadata;
+      if (boundStatement.getPreparedStatement() instanceof DefaultPreparedStatement) {
+        skipMetadata =
+            ((DefaultPreparedStatement) boundStatement.getPreparedStatement()).isSkipMetadata();
+      } else {
+        skipMetadata = boundStatement.getPreparedStatement().getResultSetDefinitions().size() > 0;
+      }
+
       QueryOptions queryOptions =
           new QueryOptions(
               consistencyCode,
@@ -382,6 +389,17 @@ public class Conversions {
 
     Partitioner partitioner = PartitionerFactory.partitioner(variableDefinitions, context);
 
+    DriverExecutionProfile executionProfile = request.getExecutionProfileForBoundStatements();
+    if (executionProfile == null) {
+      if (request.getExecutionProfileNameForBoundStatements() != null
+          && !request.getExecutionProfileNameForBoundStatements().isEmpty()) {
+        executionProfile =
+            context.getConfig().getProfile(request.getExecutionProfileNameForBoundStatements());
+      } else {
+        executionProfile = context.getConfig().getDefaultProfile();
+      }
+    }
+
     return new DefaultPreparedStatement(
         ByteBuffer.wrap(response.preparedQueryId).asReadOnlyBuffer(),
         request.getQuery(),
@@ -395,7 +413,7 @@ public class Conversions {
         partitioner,
         NullAllowingImmutableMap.copyOf(request.getCustomPayload()),
         request.getExecutionProfileNameForBoundStatements(),
-        request.getExecutionProfileForBoundStatements(),
+        executionProfile,
         request.getRoutingKeyspaceForBoundStatements(),
         request.getRoutingKeyForBoundStatements(),
         request.getRoutingTokenForBoundStatements(),

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
@@ -23,29 +23,43 @@
  */
 package com.datastax.oss.driver.internal.core.cql;
 
+import com.datastax.oss.driver.api.core.CQL4SkipMetadataResolveMethod;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.token.Partitioner;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
+import com.datastax.oss.driver.api.core.type.ContainerType;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.TupleType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.data.ValuesHelper;
 import com.datastax.oss.driver.internal.core.session.RepreparePayload;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ThreadSafe
 public class DefaultPreparedStatement implements PreparedStatement {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPreparedStatement.class);
+  private static final Splitter SPACE_SPLITTER = Splitter.onPattern("\\s+");
+  private static final Splitter COMMA_SPLITTER = Splitter.onPattern(",");
 
   private final ByteBuffer id;
   private final RepreparePayload repreparePayload;
@@ -69,6 +83,7 @@ public class DefaultPreparedStatement implements PreparedStatement {
   private final Duration timeoutForBoundStatements;
   private final Partitioner partitioner;
   private final boolean isLWT;
+  private volatile boolean skipMetadata;
 
   public DefaultPreparedStatement(
       ByteBuffer id,
@@ -122,6 +137,9 @@ public class DefaultPreparedStatement implements PreparedStatement {
     this.codecRegistry = codecRegistry;
     this.protocolVersion = protocolVersion;
     this.isLWT = isLWT;
+    this.skipMetadata =
+        resolveSkipMetadata(
+            query, resultMetadataId, resultSetDefinitions, this.executionProfileForBoundStatements);
   }
 
   @NonNull
@@ -145,6 +163,10 @@ public class DefaultPreparedStatement implements PreparedStatement {
   @Override
   public Partitioner getPartitioner() {
     return partitioner;
+  }
+
+  public boolean isSkipMetadata() {
+    return skipMetadata;
   }
 
   @NonNull
@@ -172,6 +194,13 @@ public class DefaultPreparedStatement implements PreparedStatement {
   @Override
   public void setResultMetadata(
       @NonNull ByteBuffer newResultMetadataId, @NonNull ColumnDefinitions newResultSetDefinitions) {
+    this.skipMetadata =
+        resolveSkipMetadata(
+            this.getQuery(),
+            newResultMetadataId,
+            newResultSetDefinitions,
+            executionProfileForBoundStatements);
+
     this.resultMetadata = new ResultMetadata(newResultMetadataId, newResultSetDefinitions);
   }
 
@@ -241,5 +270,122 @@ public class DefaultPreparedStatement implements PreparedStatement {
       this.resultMetadataId = resultMetadataId;
       this.resultSetDefinitions = resultSetDefinitions;
     }
+  }
+
+  private static boolean resolveSkipMetadata(
+      String query,
+      ByteBuffer resultMetadataId,
+      ColumnDefinitions resultSet,
+      DriverExecutionProfile executionProfileForBoundStatements) {
+    if (resultSet == null || resultSet.size() == 0) {
+      // there is no reason to send this flag, there will be no rows in the response and,
+      // consequently, no metadata.
+      return false;
+    }
+    if (resultMetadataId != null && resultMetadataId.capacity() > 0) {
+      // Result metadata ID feature is supported, it makes prepared statement invalidation work
+      // properly.
+      // Skip Metadata should be enabled.
+      // Prepared statement invalidation works perfectly no need to disable skip metadata
+      return true;
+    }
+
+    CQL4SkipMetadataResolveMethod resolveMethod = CQL4SkipMetadataResolveMethod.SMART;
+
+    if (executionProfileForBoundStatements != null) {
+      String resolveMethodName =
+          executionProfileForBoundStatements.getString(
+              DefaultDriverOption.PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD);
+      try {
+        resolveMethod = CQL4SkipMetadataResolveMethod.fromValue(resolveMethodName);
+      } catch (IllegalArgumentException e) {
+        LOGGER.warn(
+            "Property advanced.prepared-statements.skip-cql4-metadata-resolve-method is incorrectly set to `{}`, "
+                + "available options: smart, enabled, disabled. Defaulting to `SMART`",
+            resolveMethodName);
+        resolveMethod = CQL4SkipMetadataResolveMethod.SMART;
+      }
+    }
+
+    switch (resolveMethod) {
+      case ENABLED:
+        return true;
+      case DISABLED:
+        return false;
+      case SMART:
+        break;
+    }
+
+    if (isWildcardSelect(query)) {
+      LOGGER.warn(
+          "Prepared statement {} is a wildcard select, which can cause prepared statement invalidation issues when executed on CQL4. "
+              + "These issues may lead to broken deserialization or data corruption. "
+              + "To mitigate this, the driver ensures that the server returns metadata with each query for such statements, "
+              + "though this negatively impacts performance. "
+              + "To avoid this, consider using a targeted select instead. "
+              + "Find more mitigation options in description of `advanced.prepared-statements.skip-cql4-metadata-resolve-method` flag",
+          query);
+      return false;
+    }
+    // Disable skipping metadata if results contains udt and
+    for (ColumnDefinition columnDefinition : resultSet) {
+      if (containsUDT(columnDefinition.getType())) {
+        LOGGER.warn(
+            "Prepared statement {} contains UDT in result, which can cause prepared statement invalidation issues when executed on CQL4. "
+                + "These issues may lead to broken deserialization or data corruption. "
+                + "To mitigate this, the driver ensures that the server returns metadata with each query for such statements, "
+                + "though this negatively impacts performance. "
+                + "To avoid this, consider using regular columns instead of UDT. "
+                + "Find more mitigation options in description of `advanced.prepared-statements.skip-cql4-metadata-resolve-method` flag",
+            query);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean containsUDT(DataType dataType) {
+    if (dataType instanceof ContainerType) {
+      return containsUDT(((ContainerType) dataType).getElementType());
+    } else if (dataType instanceof TupleType) {
+      for (DataType elementType : ((TupleType) dataType).getComponentTypes()) {
+        if (containsUDT(elementType)) {
+          return true;
+        }
+      }
+      return false;
+    } else if (dataType instanceof MapType) {
+      return containsUDT(((MapType) dataType).getKeyType())
+          || containsUDT(((MapType) dataType).getValueType());
+    }
+    return dataType instanceof UserDefinedType;
+  }
+
+  private static boolean isWildcardSelect(String query) {
+    List<String> chunks = SPACE_SPLITTER.splitToList(query.trim().toLowerCase());
+    if (chunks.size() < 2) {
+      // Weird query, assuming no result expected
+      return false;
+    }
+
+    if (!chunks.get(0).equals("select")) {
+      // In case if non-select sneaks in, disable skip metadata for it no result expected.
+      return false;
+    }
+
+    for (String chunk : chunks) {
+      if (chunk.equals("from")) {
+        return false;
+      }
+      if (chunk.equals("*")) {
+        return true;
+      }
+      for (String part : COMMA_SPLITTER.split(chunk)) {
+        if (part.equals("*")) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2182,6 +2182,28 @@ datastax-java-driver {
     # Overridable in a profile: yes
     prepare-on-all-nodes = true
 
+    # CQL 4.x has a known issue where prepared statement invalidation may be bypassed on the client side.
+    # Reference: https://github.com/scylladb/scylladb/issues/20860
+    # When this occurs, the client's metadata can become outdated, leading to various deserialization errors.
+    #
+    # To mitigate this, the driver can disable the `skip metadata` flag, ensuring the server includes metadata with every bound statement RESULT query response.
+    # This setting determines how the driver handles the `skip metadata` flag for CQL 4 prepared statements:
+    # - **"smart"** (default) – Disables the flag only for wildcard selects (`SELECT * FROM`) and queries
+    #   that return UDTs (including UDT collections and maps containing UDTs).
+    # - **"enabled"** – Enables the `skip metadata` flag, preventing metadata from being sent.
+    # - **"disabled"** – Disables the `skip metadata` flag, ensuring metadata is included in every bound statement RESULT query response.
+    #
+    # Sending metadata reduces performance on both the driver and server while increasing traffic.
+    # If you need to use UDTs or wildcard selects, you must either accept the performance impact or ensure:
+    # 1. No schema alterations are performed on tables or UDTs in use.
+    # 2. After any schema change, all relevant prepared statements are re-prepared.
+    #
+    # Required: yes
+    # Modifiable at runtime: no and yes, prepared statement that is already created will keep `skip metadata` flag.
+    #  But newly prepared statement will use updated value
+    # Overridable in a profile: yes
+    skip-cql4-metadata-resolve-method = smart
+
     # How the driver replicates prepared statements on a node that just came back up or joined the
     # cluster.
     reprepare-on-up {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.CQL4SkipMetadataResolveMethod;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
@@ -122,6 +123,8 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     when(defaultProfile.getBoolean(DefaultDriverOption.REQUEST_DEFAULT_IDEMPOTENCE))
         .thenReturn(builder.defaultIdempotence);
     when(defaultProfile.getBoolean(DefaultDriverOption.PREPARE_ON_ALL_NODES)).thenReturn(true);
+    when(defaultProfile.getString(DefaultDriverOption.PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD))
+        .thenReturn(CQL4SkipMetadataResolveMethod.SMART.toString());
 
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
     when(context.getConfig()).thenReturn(config);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import com.datastax.oss.driver.api.core.CQL4SkipMetadataResolveMethod;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -36,6 +37,7 @@ import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
@@ -56,11 +58,16 @@ import com.datastax.oss.driver.core.type.codec.CqlIntToStringCodec;
 import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.cql.DefaultPreparedStatement;
+import com.datastax.oss.driver.internal.core.type.DefaultUserDefinedType;
 import com.datastax.oss.driver.internal.core.util.RoutingKey;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.util.Bytes;
 import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableMap;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
@@ -75,8 +82,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
 
 @Category(ParallelizableTests.class)
+@RunWith(DataProviderRunner.class)
 public class BoundStatementCcmIT {
 
   private CcmRule ccmRule = CcmRule.getInstance();
@@ -397,6 +406,149 @@ public class BoundStatementCcmIT {
     should_set_all_occurrences_of_variable(ps.boundStatementBuilder().setInt(id, 12).build());
   }
 
+  @DataProvider
+  public static Object[][] cql4SkipMetadataResolveMethod() {
+    return new Object[][] {
+      {
+        CQL4SkipMetadataResolveMethod.SMART,
+      },
+      {
+        CQL4SkipMetadataResolveMethod.ENABLED,
+      },
+      {
+        CQL4SkipMetadataResolveMethod.DISABLED,
+      }
+    };
+  }
+
+  @Test
+  @UseDataProvider(value = "cql4SkipMetadataResolveMethod")
+  public void prepared_stmt_metadata_update_loopholes_test(
+      CQL4SkipMetadataResolveMethod cql4SkipMetadataResolveMethod) {
+    // v0 is an int column, but we'll bind a String to it
+    try (CqlSession session =
+        sessionWithSkipCQL4MetadataResolveMethod(cql4SkipMetadataResolveMethod)) {
+      String udtName =
+          String.format(
+              "skip_metadata_test_%s_udt", cql4SkipMetadataResolveMethod.name().toLowerCase());
+      String udtTable =
+          String.format(
+              "skip_metadata_test_%s_udttable", cql4SkipMetadataResolveMethod.name().toLowerCase());
+      String table =
+          String.format(
+              "skip_metadata_test_%s_table", cql4SkipMetadataResolveMethod.name().toLowerCase());
+      session.execute(String.format("CREATE TYPE IF NOT EXISTS %s (x int, y int)", udtName));
+
+      session.execute(
+          String.format("CREATE TABLE %s (pk int, v %s, PRIMARY KEY (pk))", udtTable, udtName));
+      session.execute(String.format("CREATE TABLE %s (pk int, v int, PRIMARY KEY (pk))", table));
+
+      session.execute(String.format("INSERT INTO %s (pk, v) VALUES (1, 1)", table));
+      session.execute(String.format("INSERT INTO %s (pk, v) VALUES (1, {x: 1, y: 1})", udtTable));
+
+      PreparedStatement stmtRegularTableWCS =
+          session.prepare(String.format("SELECT * FROM %s WHERE pk = ?", table));
+      PreparedStatement stmtRegularTableTS =
+          session.prepare(String.format("SELECT pk, v FROM %s WHERE pk = ?", table));
+      PreparedStatement stmtUDTTableWCS =
+          session.prepare(String.format("SELECT * FROM %s WHERE pk = ?", udtTable));
+      PreparedStatement stmtUDTTableTS =
+          session.prepare(String.format("SELECT pk, v FROM %s WHERE pk = ?", udtTable));
+
+      // Metadata ID feature makes prepared statement invalidation works properly.
+      // It is mostly supported on CQL >= 5
+      boolean isMetadataIDFeatureSupported = stmtRegularTableWCS.getResultMetadataId() == null;
+      boolean isPreparedStatementInvalidationBroken =
+          isMetadataIDFeatureSupported
+              && cql4SkipMetadataResolveMethod == CQL4SkipMetadataResolveMethod.ENABLED;
+
+      if (isMetadataIDFeatureSupported) {
+        switch (cql4SkipMetadataResolveMethod) {
+          case ENABLED:
+            assertThat(((DefaultPreparedStatement) stmtRegularTableTS).isSkipMetadata())
+                .isEqualTo(true);
+            assertThat(((DefaultPreparedStatement) stmtRegularTableWCS).isSkipMetadata())
+                .isEqualTo(true);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableWCS).isSkipMetadata())
+                .isEqualTo(true);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableTS).isSkipMetadata())
+                .isEqualTo(true);
+            break;
+          case DISABLED:
+            assertThat(((DefaultPreparedStatement) stmtRegularTableTS).isSkipMetadata())
+                .isEqualTo(false);
+            assertThat(((DefaultPreparedStatement) stmtRegularTableWCS).isSkipMetadata())
+                .isEqualTo(false);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableWCS).isSkipMetadata())
+                .isEqualTo(false);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableTS).isSkipMetadata())
+                .isEqualTo(false);
+            break;
+          default: // "SMART"
+            assertThat(((DefaultPreparedStatement) stmtRegularTableTS).isSkipMetadata())
+                .isEqualTo(true);
+            assertThat(((DefaultPreparedStatement) stmtRegularTableWCS).isSkipMetadata())
+                .isEqualTo(false);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableWCS).isSkipMetadata())
+                .isEqualTo(false);
+            assertThat(((DefaultPreparedStatement) stmtUDTTableTS).isSkipMetadata())
+                .isEqualTo(false);
+        }
+      }
+
+      Row row = session.execute(stmtUDTTableWCS.bind(1)).one();
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+      assertThat(getUDTColumnCount(row.getColumnDefinitions().get(1))).isEqualTo(2);
+      row = session.execute(stmtUDTTableTS.bind(1)).one();
+      assertThat(getUDTColumnCount(row.getColumnDefinitions().get(1))).isEqualTo(2);
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+      row = session.execute(stmtRegularTableWCS.bind(1)).one();
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+      row = session.execute(stmtRegularTableWCS.bind(1)).one();
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+
+      session.execute(String.format("ALTER TABLE %s ADD z int;", table));
+      session.execute(String.format("ALTER TYPE %s ADD z int;", udtName));
+
+      int expectedColumnCount = 3;
+      if (isPreparedStatementInvalidationBroken) {
+        // When case of CQL4 and skip metadata is set prepared statements will not be invalidated.
+        expectedColumnCount = 2;
+      }
+
+      row = session.execute(stmtUDTTableWCS.bind(1)).one();
+      try {
+        assertThat(row.getUdtValue(1).size()).isEqualTo(expectedColumnCount);
+        // if isPreparedStatementInvalidationBroken is true it should throw exception
+        assertThat(isPreparedStatementInvalidationBroken).isFalse();
+      } catch (java.lang.IllegalArgumentException e) {
+        assertThat(isPreparedStatementInvalidationBroken).isTrue();
+      }
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+      assertThat(getUDTColumnCount(row.getColumnDefinitions().get(1)))
+          .isEqualTo(expectedColumnCount);
+
+      row = session.execute(stmtUDTTableTS.bind(1)).one();
+      try {
+        assertThat(row.getUdtValue(1).size()).isEqualTo(expectedColumnCount);
+        // if isPreparedStatementInvalidationBroken is true it should throw exception
+        assertThat(isPreparedStatementInvalidationBroken).isFalse();
+      } catch (java.lang.IllegalArgumentException e) {
+        assertThat(isPreparedStatementInvalidationBroken).isTrue();
+      }
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(2);
+      assertThat(getUDTColumnCount(row.getColumnDefinitions().get(1)))
+          .isEqualTo(expectedColumnCount);
+
+      row = session.execute(stmtRegularTableWCS.bind(1)).one();
+      assertThat(row.getColumnDefinitions().size()).isEqualTo(expectedColumnCount);
+    }
+  }
+
+  private int getUDTColumnCount(ColumnDefinition cd) {
+    return ((DefaultUserDefinedType) cd.getType()).getFieldTypes().size();
+  }
+
   private void should_set_all_occurrences_of_variable(BoundStatement bs) {
     assertThat(bs.getInt(0)).isEqualTo(12);
     assertThat(bs.getInt(1)).isEqualTo(12);
@@ -445,6 +597,21 @@ public class BoundStatementCcmIT {
             .addContactEndPoints(ccmRule.getContactPoints())
             .withKeyspace(sessionRule.keyspace())
             .addTypeCodecs(codec)
+            .build();
+  }
+
+  private CqlSession sessionWithSkipCQL4MetadataResolveMethod(
+      CQL4SkipMetadataResolveMethod cql4SkipMetadataResolveMethod) {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactEndPoints(ccmRule.getContactPoints())
+            .withKeyspace(sessionRule.keyspace())
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withString(
+                        DefaultDriverOption.PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD,
+                        cql4SkipMetadataResolveMethod.name())
+                    .build())
             .build();
   }
 


### PR DESCRIPTION
CQL 4.x has a known issue where prepared statement invalidation may be bypassed on the client-side. 
Reference: https://github.com/scylladb/scylladb/issues/20860 
When this occurs, the client's metadata can become outdated, leading to various deserialization errors.

To mitigate this new options `PREPARE_SKIP_CQL4_METADATA_RESOLVE_METHOD(advanced.prepared-statements.skip-cql4-metadata-resolve-method)` was introduced.
This setting determines how the driver handles the `skip metadata` flag for CQL 4 prepared statements: 
- **"smart"** (default) – Disables the flag only for wildcard selects (`SELECT * FROM`) and queries that return UDTs (including UDT collections and maps containing UDTs). 
- **"enabled"** – Enables the `skip metadata` flag, preventing metadata from being sent.
- **"disabled"** – Disables the `skip metadata` flag, ensuring metadata is included in every RESULT frame.
