### PR TITLE
HostConnectionPool pendingBorrows can be nil at closing

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -975,9 +975,12 @@ class HostConnectionPool implements Connection.Owner {
 
     phase.set(Phase.CLOSING);
 
-    for (Queue<PendingBorrow> queue : pendingBorrows) {
-      for (PendingBorrow pendingBorrow : queue) {
-        pendingBorrow.setException(new ConnectionException(host.getEndPoint(), "Pool is shutdown"));
+    if (pendingBorrows != null) {
+      for (Queue<PendingBorrow> queue : pendingBorrows) {
+        for (PendingBorrow pendingBorrow : queue) {
+          pendingBorrow.setException(
+              new ConnectionException(host.getEndPoint(), "Pool is shutdown"));
+        }
       }
     }
 


### PR DESCRIPTION
`SessionManager.replacePool` adds pool to the pools map and only afterwards calls `.initAsync` on it. 
For short period of time pool stays in `SessionManager.pools` uninitialized.
If you close session in that exact time `HostConnectionPool.closeAsync` is going to endup in panic, because `pendingBorrows` is null :
```
java.lang.NullPointerException: null
	at com.datastax.driver.core.HostConnectionPool.closeAsync(HostConnectionPool.java:978)
```

Fixes: https://github.com/scylladb/java-driver/issues/464