### PR TITLE
3.x: Do not append "-fedora" to `os.detected.classifier` anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The 'extras' module is also published as a separate artifact:
 We also provide a [shaded JAR](manual/shaded_jar/)
 to avoid the explicit dependency to Netty.
 
+On Fedora 30 or later you may need to install dependencies for `netty-tcnative-boringssl-static`
+by running `dnf -y install libxcrypt-compat`
+
+
 ## Compatibility
 
 The Java client driver 3.11.5.0 ([branch scylla-3.x](https://github.com/scylladb/java-driver/tree/scylla-3.x)) is compatible with 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,11 @@
         <javadoc.opts />
         <!-- Append "-fedora" to os.detected.classifier for Fedora systems
              (see https://netty.io/wiki/forked-tomcat-native.html) -->
+        <!-- Commenting this out since artifact in use right now is statically
+             linked. There is no linux-x86_64-fedora variant like with
+             regular netty-tcnative.
         <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+        -->
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Since `netty-tcnative.artifact` property was changed to `netty-tcnative-boringssl-static` this suffix is no longer a valid configuration. This change skips it and adds notice about required dependency as mentioned at:
https://netty.io/wiki/forked-tomcat-native.html#prerequisites-for-statically-linked-netty-tcnative--static

Fixes #471 