### PR TITLE
Disable should_make_JMX_connection for any version after 2025.1

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
@@ -32,6 +32,7 @@ public class CCMBridgeTest extends CCMTestsSupport {
   @Test(groups = "short")
   @ScyllaVersion(
       maxOSS = "6.2.0",
+      maxEnterprise = "2025.1.0",
       description = "JMX was dropped in scylladb/3cd2a6173668c5a13b6e674f912ff597f76422f5")
   public void should_make_JMX_connection() throws Exception {
     InetSocketAddress addr1 = ccm().jmxAddressOfNode(1);


### PR DESCRIPTION
Commit https://github.com/scylladb/scylladb/commit/3cd2a6173668c5a13b6e674f912ff597f76422f5 that removes JMX finally reached enterprise at `2025.1`, we need to disable the test.

Reinstantiation of https://github.com/scylladb/java-driver/pull/490