### PR TITLE
Make `Uuids` have better random distribution

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
@@ -301,7 +301,13 @@ public final class Uuids {
   @NonNull
   public static UUID random(@NonNull Random random) {
     byte[] data = new byte[16];
-    random.nextBytes(data);
+    for (int i = 0; i < 16; i += 4) {
+      int rnd = random.nextInt();
+      data[i] = (byte) (rnd >>> 24);
+      data[i + 1] = (byte) (rnd >>> 16);
+      data[i + 2] = (byte) (rnd >>> 8);
+      data[i + 3] = (byte) rnd;
+    }
     return buildUuid(data, 4);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
@@ -39,6 +39,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,7 +233,7 @@ public final class Uuids {
       }
     }
     if (pid == null) {
-      pid = new Random().nextInt();
+      pid = ThreadLocalRandom.current().nextInt();
       LOG.warn("Could not determine PID, falling back to a random integer: {}", pid);
     }
     ClassLoader loader = Uuids.class.getClassLoader();
@@ -281,7 +282,7 @@ public final class Uuids {
    */
   @NonNull
   public static UUID random() {
-    return random(new Random());
+    return random(ThreadLocalRandom.current());
   }
 
   /**


### PR DESCRIPTION
Before this commit `Uuids` used to initiate `Random` at point when it needs a random number.
Not only it is not efficient it also produced bad distribution which resulted in `should_generate_unique_random_uuids_Random` to fail, due to inability of `Uuids::random` generate unique vales.

I have tested it with:
```
  @Test
  public void should_generate_unique_random_uuids_Random() {
    for (int i = 0; i < 10000; i++) {
      System.out.println(i);
      Set<UUID> generated = serialGeneration(1_000_000, Uuids::random);
      assertThat(generated).hasSize(1_000_000);
    }
  }
```
Which was failing after 100 iterations before fix and never failed after. 