### PR TITLE
Fix BasicLoadBalancingPolicy.getReplica empty partitioner

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/TokenMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/TokenMap.java
@@ -189,4 +189,8 @@ public interface TokenMap {
   /** The name of the partitioner class in use, as reported by the Cassandra nodes. */
   @NonNull
   String getPartitionerName();
+
+  /** The partitioner class in use, as reported by the Cassandra nodes. */
+  @NonNull
+  Partitioner getPartitioner();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -333,6 +333,9 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
       }
 
       partitioner = request.getPartitioner();
+      if (partitioner == null && maybeTokenMap.isPresent()) {
+        partitioner = maybeTokenMap.get().getPartitioner();
+      }
     } catch (Exception e) {
       // Protect against poorly-implemented Request instances
       LOG.error("Unexpected error while trying to compute query plan", e);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/DefaultTokenMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/DefaultTokenMap.java
@@ -207,6 +207,12 @@ public class DefaultTokenMap implements TokenMap {
     return tokenFactory.getPartitionerName();
   }
 
+  @NonNull
+  @Override
+  public Partitioner getPartitioner() {
+    return tokenFactory;
+  }
+
   private KeyspaceTokenMap getKeyspaceMap(CqlIdentifier keyspace) {
     Map<String, String> config = replicationConfigs.get(keyspace);
     return (config == null) ? null : keyspaceMaps.get(config);


### PR DESCRIPTION
`DefaultBoundStatement` getting it's paritioner from when it is being prepared against cdc table.
In other cases statement does not get any partitioner. 
For proper tablet routing driver needs to calculate token from the key, which needs partitioner, if partitioner is not present driver returns empty replica list.

This PR is rather quick-fix.
Implementing proper solution that will help with CDC+tablets case, is scheduled at https://github.com/scylladb/java-driver/issues/502

Fixes: https://github.com/scylladb/java-driver/issues/497
Tests for fixed functionality to be added in https://github.com/scylladb/java-driver/issues/506