### PR TITLE
4.x: Fix metadata node events for null tablet map

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddTabletRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddTabletRefresh.java
@@ -20,7 +20,9 @@ public class AddTabletRefresh implements MetadataRefresh {
   @Override
   public Result compute(
       DefaultMetadata oldMetadata, boolean tokenMapEnabled, InternalDriverContext context) {
-    oldMetadata.tabletMap.addTablet(keyspace, table, tablet);
+    if (oldMetadata.tabletMap != null) {
+      oldMetadata.tabletMap.addTablet(keyspace, table, tablet);
+    }
     return new Result(oldMetadata);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefresh.java
@@ -67,7 +67,9 @@ public class RemoveNodeRefresh extends NodesRefresh {
       return new Result(oldMetadata);
     } else {
       LOG.debug("[{}] Removing node {}", logPrefix, removedNode);
-      oldMetadata.tabletMap.removeByNode(removedNode);
+      if (oldMetadata.tabletMap != null) {
+        oldMetadata.tabletMap.removeByNode(removedNode);
+      }
       return new Result(
           oldMetadata.withNodes(newNodesBuilder.build(), tokenMapEnabled, false, null, context),
           ImmutableList.of(NodeStateEvent.removed((DefaultNode) removedNode)));


### PR DESCRIPTION
After https://github.com/scylladb/java-driver/pull/505 tablet map could be empty, we need to address these cases.
