### PR TITLE
4.x: Occasionally force cache cleanup in PreparedStatementCachingIT

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -267,11 +267,17 @@ public class PreparedStatementCachingIT {
       session.execute("ALTER TYPE test_type_2 add i blob");
 
       // wait for latches and fail if they don't reach zero before timeout
-      assertThat(
-              Uninterruptibles.awaitUninterruptibly(
-                  preparedStmtCacheRemoveLatch, 10, TimeUnit.SECONDS))
-          .withFailMessage("preparedStmtCacheRemoveLatch did not trigger before timeout")
-          .isTrue();
+      if (!Uninterruptibles.awaitUninterruptibly(
+          preparedStmtCacheRemoveLatch, 10, TimeUnit.SECONDS)) {
+        // On rare occasions cache does not trigger removal shortly after alter.
+        forceCacheCleanUp((DefaultDriverContext) session.getContext());
+        assertThat(
+                Uninterruptibles.awaitUninterruptibly(
+                    preparedStmtCacheRemoveLatch, 10, TimeUnit.SECONDS))
+            .withFailMessage("preparedStmtCacheRemoveLatch did not trigger before timeout")
+            .isTrue();
+      }
+
       assertThat(Uninterruptibles.awaitUninterruptibly(typeChangeEventLatch, 10, TimeUnit.SECONDS))
           .withFailMessage("typeChangeEventLatch did not trigger before timeout")
           .isTrue();
@@ -425,5 +431,19 @@ public class PreparedStatementCachingIT {
                 new AssertionError(
                     "Could not access metric "
                         + DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()));
+  }
+
+  private void forceCacheCleanUp(DefaultDriverContext context) {
+    context
+        .getRequestProcessorRegistry()
+        .getProcessors()
+        .forEach(
+            requestProcessor -> {
+              if (requestProcessor instanceof CqlPrepareAsyncProcessor) {
+                ((CqlPrepareAsyncProcessor) requestProcessor).getCache().cleanUp();
+              } else if (requestProcessor instanceof CqlPrepareSyncProcessor) {
+                ((CqlPrepareSyncProcessor) requestProcessor).getCache().cleanUp();
+              }
+            });
   }
 }


### PR DESCRIPTION
This integration test from time to time fails on one of its methods. Evidence points to the cache itself being the culprit, as there is no guarantee that elements will be removed right away. This leads to removal event not being fired and timing out on wait for it. Calling `cache.cleanUp()` seems to greatly improve stability of this test.

Fixes #476 and #477