### PR TITLE
Don't log invalid row for zero-token nodes

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -1007,12 +1007,12 @@ class ControlConnection implements Connection.Owner {
               && !peerRow.isNull("data_center")
               && peerRow.getColumnDefinitions().contains("rack")
               && !peerRow.isNull("rack")
-              && peerRow.getColumnDefinitions().contains("tokens")
-              && (!peerRow.isNull("tokens")
-                  || cluster
-                      .configuration
-                      .getQueryOptions()
-                      .shouldConsiderZeroTokenNodesValidPeers());
+              && peerRow.getColumnDefinitions().contains("tokens");
+
+      if (isValid && peerRow.isNull("tokens")) {
+        // Don't log invalid row for zero token nodes, but report it if it is configured so.
+        return cluster.configuration.getQueryOptions().shouldConsiderZeroTokenNodesValidPeers();
+      }
     }
     if (!isValid && logIfInvalid)
       logger.warn(

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -378,7 +378,12 @@ public class ControlConnectionTest extends CCMTestsSupport {
             .extractingResultOf("getAddress")
             .doesNotContain(node2Address);
 
-        assertThat(log).containsOnlyOnce(expectedError);
+        if (columns.equals("tokens")) {
+          // For zero token nodes driver does not log an error
+          assertThat(log).doesNotContain(expectedError);
+        } else {
+          assertThat(log).containsOnlyOnce(expectedError);
+        }
       }
     } finally {
       cLogger.removeAppender(logs);


### PR DESCRIPTION
In some cases having zero token node is a normal thing. 
Logging invalid row each time driver updates metadata confuses users in such case and produce bad UX.

Fixes: https://github.com/scylladb/java-driver/issues/520