### PR TITLE
4.x: Adjust cache path for Scylla ccm images

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -331,7 +331,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: ccm-cache
         with:
-          path: ~/.ccm/repository
+          path: ~/.ccm/scylla-repository
           key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
 
       - name: Download Scylla (${{ steps.scylla-version.outputs.value }}) image
@@ -346,7 +346,7 @@ jobs:
         uses: actions/cache/save@v4
         if: steps.ccm-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.ccm/repository
+          path: ~/.ccm/scylla-repository
           key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
 
       - name: Run integration tests on Scylla (${{ steps.scylla-version.outputs.value }})


### PR DESCRIPTION
It seems that the Scylla images for ccm were not cached correctly, because in contrast to cassandra images the path to them is slightly different. The save step outputs a warning about that but it's not failing the step itself.