### PR TITLE
docs: fix md redirections for multiversion support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,10 +52,7 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = {
-    '.rst': 'restructuredtext',
-    '.md': 'markdown',
-}
+source_suffix = ['.rst', '.md']
 autosectionlabel_prefix_document = True
 
 # The master toctree document.


### PR DESCRIPTION
Related issue & explanation https://github.com/scylladb/scylladb/pull/23957

This should allow navigation between versions without being redirected to the main index page:

![image](https://github.com/user-attachments/assets/ccd21867-eed0-4968-8ab0-8876dc5c7efd)

**Note:** This fix will only apply to future versions unless backported. While backporting may not be worth the effort, it's important to be aware that the issue will remain in older versions