### PR TITLE
docs: Add recent releases to documentation versions list

### DIFF
--- a/docs/_utils/javadoc.sh
+++ b/docs/_utils/javadoc.sh
@@ -14,4 +14,4 @@ fi
 mvn javadoc:javadoc -T 1C
 [ -d $OUTPUT_DIR ] && rm -r $OUTPUT_DIR
 mkdir -p "$OUTPUT_DIR"
-mv -f driver-core/target/site/apidocs/* $OUTPUT_DIR
+mv -f core/target/site/apidocs/* $OUTPUT_DIR

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,10 +22,13 @@ BRANCHES = [
     'scylla-4.12.0.x',
     'scylla-4.13.0.x',
     'scylla-4.14.1.x',
-    'scylla-4.15.0.x'
+    'scylla-4.15.0.x',
+    'scylla-4.17.0.x',
+    'scylla-4.18.1.x',
+    'scylla-4.19.0.x'
 ]
 # Set the latest version.
-LATEST_VERSION = 'scylla-4.15.0.x'
+LATEST_VERSION = 'scylla-4.19.0.x'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = []
 # Set which versions are deprecated
@@ -99,6 +102,9 @@ scylladb_markdown_recommonmark_versions = [
     'scylla-4.13.0.x',
     'scylla-4.14.1.x',
     'scylla-4.15.0.x',
+    'scylla-4.17.0.x',
+    'scylla-4.18.1.x',
+    'scylla-4.19.0.x'
 ]
 suppress_warnings = ["ref.any", "myst.header","myst.xref_missing","autosectionlabel"]
 


### PR DESCRIPTION
Created some branches for those versions according to existing format. Note that `scylla-4.19.0.x` corresponds to the latest released `4.19.0.1` and not current master (`scylla-4.x`).
If the next released version is `4.19.0.2` then `scylla-4.19.0.x` will need to be moved with whatever documentation backports it has on top of `4.19.0.2`. However it's unlikely that `4.19.0.2` will not have the same changes already, so it should not be an issue.