### PR TITLE
docs: Update replacements and links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,7 +184,11 @@ def setup(app):
     current_slug = os.getenv("SPHINX_MULTIVERSION_NAME", "stable")
     replacements = {
         r'docs.datastax.com/en/drivers/java\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/api/",
-        r'java-driver.docs.scylladb.com\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/"
+        r'java-driver.docs.scylladb.com\/(.*?)\/': "java-driver.docs.scylladb.com/" + current_slug + "/",
+        r'github.com\/apache\/cassandra-java-driver\/blob\/4.x\/': "github.com/scylladb/java-driver/blob/scylla-4.x/",
+        r'github.com\/apache\/cassandra-java-driver\/tree\/4.x\/': "github.com/scylladb/java-driver/tree/scylla-4.x/",
+        r'github.com\/datastax\/java-driver\/blob\/4.x\/': "github.com/scylladb/java-driver/blob/scylla-4.x/",
+        r'github.com\/datastax\/java-driver\/tree\/4.x\/': "github.com/scylladb/java-driver/tree/scylla-4.x/"
     }
     app.add_config_value('replacements', replacements, True)
     app.connect('source-read', replace_relative_links)

--- a/manual/core/reconnection/README.md
+++ b/manual/core/reconnection/README.md
@@ -103,7 +103,7 @@ Note that the session is not accessible until it is fully ready: the `CqlSession
 call &mdash; or the future returned by `buildAsync()` &mdash; will not complete until the connection
 was established.
 
-[ConstantReconnectionPolicy]:    https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.html
+[ConstantReconnectionPolicy]:    https://github.com/scylladb/java-driver/blob/scylla-4.x/core/src/main/java/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.java
 [DriverContext]:                 https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/context/DriverContext.html
-[ExponentialReconnectionPolicy]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.html
+[ExponentialReconnectionPolicy]: https://github.com/scylladb/java-driver/blob/scylla-4.x/core/src/main/java/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.java
 [ReconnectionPolicy]:            https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/connection/ReconnectionPolicy.html


### PR DESCRIPTION
Adds a few extra replacement patterns for documentation links and fixes broken links in reconnection manual, but for this (scylla-4.x) branch only. Once this patch is approved I will create backports fixing the links in older versions.