### PR TITLE
docs: scylla-4.17.0.x documentation fixes

### DIFF
--- a/docs/_utils/javadoc.sh
+++ b/docs/_utils/javadoc.sh
@@ -15,3 +15,5 @@ mvn javadoc:javadoc
 [ -d $OUTPUT_DIR ] && rm -r $OUTPUT_DIR
 mkdir -p "$OUTPUT_DIR"
 mv -f core/target/site/apidocs/* $OUTPUT_DIR
+cp -an query-builder/target/site/apidocs/* $OUTPUT_DIR
+cp -an mapper-runtime/target/site/apidocs/* $OUTPUT_DIR

--- a/manual/core/reconnection/README.md
+++ b/manual/core/reconnection/README.md
@@ -84,7 +84,7 @@ Note that the session is not accessible until it is fully ready: the `CqlSession
 call &mdash; or the future returned by `buildAsync()` &mdash; will not complete until the connection
 was established.
 
-[ConstantReconnectionPolicy]:    https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.html
+[ConstantReconnectionPolicy]:    https://github.com/scylladb/java-driver/blob/scylla-4.17.0.x/core/src/main/java/com/datastax/oss/driver/internal/core/connection/ConstantReconnectionPolicy.java
 [DriverContext]:                 https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/context/DriverContext.html
-[ExponentialReconnectionPolicy]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.html
+[ExponentialReconnectionPolicy]: https://github.com/scylladb/java-driver/blob/scylla-4.17.0.x/core/src/main/java/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicy.java
 [ReconnectionPolicy]:            https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/connection/ReconnectionPolicy.html

--- a/manual/mapper/daos/getentity/README.md
+++ b/manual/mapper/daos/getentity/README.md
@@ -89,7 +89,7 @@ The method can return:
 * a single entity instance. If the argument is a result set type, the generated code will extract
   the first row and convert it, or return `null` if the result set is empty.
 
-    ````java
+    ```java
     @GetEntity
     Product asProduct(Row row);
 


### PR DESCRIPTION
Collection of fixes for scylla-4.17.0.x branch. See respective commit descriptions for details.
Recreation of #543 because github does not allow reopening it for some reason.