### PR TITLE
docs: scylla-3.11.4.x Replace dead link in maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
                             <link>http://www.joda.org/joda-time/apidocs/</link>
                             <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
                             <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
-                            <link>https://javaee-spec.java.net/nonav/javadocs/</link>
+                            <link>https://javaee.github.io/javaee-spec/javadocs/</link>
                         </links>
                         <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
                         <additionalDependencies>


### PR DESCRIPTION
The link to https://javaee-spec.java.net/nonav/javadocs/ is long dead since 2017. For some reason this causes excruciatingly long wait times until connection attempts eventually timeout. Regardless of that it's worth updating. This change replaces it with link to another publicly available legacy documentation at https://javaee.github.io/javaee-spec/javadocs/