### PR TITLE
Configuration: implement application name, version and client id

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1522,6 +1522,36 @@ public class Cluster implements Closeable {
     }
 
     /**
+     * Sets application name that will be sent to the server on startup.
+     *
+     * @param applicationName name of the application.
+     */
+    public Builder withApplicationName(String applicationName) {
+      configurationBuilder.withApplicationName(applicationName);
+      return this;
+    }
+
+    /**
+     * Sets application version that will be sent to the server on startup.
+     *
+     * @param applicationVersion version of the application.
+     */
+    public Builder withApplicationVersion(String applicationVersion) {
+      configurationBuilder.withApplicationVersion(applicationVersion);
+      return this;
+    }
+
+    /**
+     * Sets client id that will be sent to the server on startup.
+     *
+     * @param clientId id of the application.
+     */
+    public Builder withClientId(String clientId) {
+      configurationBuilder.withClientId(clientId);
+      return this;
+    }
+
+    /**
      * The configuration that will be used for the new cluster.
      *
      * <p>You <b>should not</b> modify this object directly because changes made to the returned
@@ -1675,6 +1705,9 @@ public class Cluster implements Closeable {
                 .withThreadingOptions(configuration.getThreadingOptions())
                 .withNettyOptions(configuration.getNettyOptions())
                 .withCodecRegistry(configuration.getCodecRegistry())
+                .withApplicationName(configuration.getApplicationName())
+                .withApplicationVersion(configuration.getApplicationVersion())
+                .withClientId(configuration.getClientId())
                 .build();
       } else {
         this.configuration = configuration;

--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -59,6 +59,9 @@ public class Configuration {
   private final NettyOptions nettyOptions;
   private final CodecRegistry codecRegistry;
   private final String defaultKeyspace;
+  private final String applicationName;
+  private final String applicationVersion;
+  private final String clientId;
 
   private Configuration(
       Policies policies,
@@ -70,7 +73,10 @@ public class Configuration {
       ThreadingOptions threadingOptions,
       NettyOptions nettyOptions,
       CodecRegistry codecRegistry,
-      String defaultKeyspace) {
+      String defaultKeyspace,
+      String applicationName,
+      String applicationVersion,
+      String clientId) {
     this.policies = policies;
     this.protocolOptions = protocolOptions;
     this.poolingOptions = poolingOptions;
@@ -81,6 +87,9 @@ public class Configuration {
     this.nettyOptions = nettyOptions;
     this.codecRegistry = codecRegistry;
     this.defaultKeyspace = defaultKeyspace;
+    this.applicationName = applicationName;
+    this.applicationVersion = applicationVersion;
+    this.clientId = clientId;
   }
 
   /**
@@ -99,7 +108,10 @@ public class Configuration {
         toCopy.getThreadingOptions(),
         toCopy.getNettyOptions(),
         toCopy.getCodecRegistry(),
-        toCopy.getDefaultKeyspace());
+        toCopy.getDefaultKeyspace(),
+        toCopy.getApplicationName(),
+        toCopy.getApplicationVersion(),
+        toCopy.getClientId());
   }
 
   void register(Cluster.Manager manager) {
@@ -213,6 +225,19 @@ public class Configuration {
   public String getDefaultKeyspace() {
     return defaultKeyspace;
   }
+
+  public String getApplicationName() {
+    return applicationName;
+  }
+
+  public String getApplicationVersion() {
+    return applicationVersion;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
   /**
    * Returns the {@link CodecRegistry} instance for this configuration.
    *
@@ -239,6 +264,42 @@ public class Configuration {
     private NettyOptions nettyOptions;
     private CodecRegistry codecRegistry;
     private String defaultKeyspace;
+    private String applicationName;
+    private String applicationVersion;
+    private String clientId;
+
+    /**
+     * Sets application name, to be reported to server
+     *
+     * @param applicationName application name.
+     * @return this builder.
+     */
+    public Builder withApplicationName(String applicationName) {
+      this.applicationName = applicationName;
+      return this;
+    }
+
+    /**
+     * Sets application version, to be reported to server
+     *
+     * @param applicationVersion application version.
+     * @return this builder.
+     */
+    public Builder withApplicationVersion(String applicationVersion) {
+      this.applicationVersion = applicationVersion;
+      return this;
+    }
+
+    /**
+     * Sets client id, to be reported to server
+     *
+     * @param clientId application version.
+     * @return this builder.
+     */
+    public Builder withClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
 
     /**
      * Sets the policies for this cluster.
@@ -370,7 +431,10 @@ public class Configuration {
           threadingOptions != null ? threadingOptions : new ThreadingOptions(),
           nettyOptions != null ? nettyOptions : NettyOptions.DEFAULT_INSTANCE,
           codecRegistry != null ? codecRegistry : CodecRegistry.DEFAULT_INSTANCE,
-          defaultKeyspace);
+          defaultKeyspace,
+          applicationName,
+          applicationVersion,
+          clientId);
     }
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -516,6 +516,20 @@ class Connection {
           logger.debug("Enabling tablet support in OPTIONS message");
           TabletInfo.addOption(extraOptions);
         }
+
+        if (factory.configuration.getApplicationName() != null
+            && !factory.configuration.getApplicationName().isEmpty()) {
+          extraOptions.put("APPLICATION_NAME", factory.configuration.getApplicationName());
+        }
+        if (factory.configuration.getApplicationVersion() != null
+            && !factory.configuration.getApplicationVersion().isEmpty()) {
+          extraOptions.put("APPLICATION_VERSION", factory.configuration.getApplicationVersion());
+        }
+        if (factory.configuration.getClientId() != null
+            && !factory.configuration.getClientId().isEmpty()) {
+          extraOptions.put("CLIENT_ID", factory.configuration.getClientId());
+        }
+
         Future startupResponseFuture =
             write(
                 new Requests.Startup(


### PR DESCRIPTION
Make driver report application name, version and client id to server on startup message.

Fixes: https://github.com/scylladb/java-driver/issues/553

Tested:
```
cqlsh> SELECT client_options FROM system_views.clients;

 client_options
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
                                                                                                          {'CQL_VERSION': '3.4.7', 'DRIVER_NAME': 'DataStax Python Driver', 'DRIVER_VERSION': '3.29.0'}
                                                                                                          {'CQL_VERSION': '3.4.7', 'DRIVER_NAME': 'DataStax Python Driver', 'DRIVER_VERSION': '3.29.0'}
 {'APPLICATION_NAME': 'app_name', 'APPLICATION_VERSION': 'app_version', 'CLIENT_ID': 'client_id', 'CQL_VERSION': '3.0.0', 'DRIVER_NAME': 'ScyllaDB Java Driver', 'DRIVER_VERSION': '3.11.5.8-SNAPSHOT'}
 {'APPLICATION_NAME': 'app_name', 'APPLICATION_VERSION': 'app_version', 'CLIENT_ID': 'client_id', 'CQL_VERSION': '3.0.0', 'DRIVER_NAME': 'ScyllaDB Java Driver', 'DRIVER_VERSION': '3.11.5.8-SNAPSHOT'}
```