### PR TITLE
Generalize application information API

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ApplicationInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ApplicationInfo.java
@@ -1,0 +1,8 @@
+package com.datastax.driver.core;
+
+import java.util.Map;
+
+public interface ApplicationInfo {
+  /** Adds application information to startup options. */
+  void addOption(Map<String, String> options);
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1522,32 +1522,13 @@ public class Cluster implements Closeable {
     }
 
     /**
-     * Sets application name that will be sent to the server on startup.
+     * Sets application information provider, every connection on startup sends this information to
+     * the server.
      *
-     * @param applicationName name of the application.
+     * @param applicationInfo an application information provider.
      */
-    public Builder withApplicationName(String applicationName) {
-      configurationBuilder.withApplicationName(applicationName);
-      return this;
-    }
-
-    /**
-     * Sets application version that will be sent to the server on startup.
-     *
-     * @param applicationVersion version of the application.
-     */
-    public Builder withApplicationVersion(String applicationVersion) {
-      configurationBuilder.withApplicationVersion(applicationVersion);
-      return this;
-    }
-
-    /**
-     * Sets client id that will be sent to the server on startup.
-     *
-     * @param clientId id of the application.
-     */
-    public Builder withClientId(String clientId) {
-      configurationBuilder.withClientId(clientId);
+    public Builder withApplicationInfo(ApplicationInfo applicationInfo) {
+      configurationBuilder.withApplicationInfo(applicationInfo);
       return this;
     }
 
@@ -1705,9 +1686,7 @@ public class Cluster implements Closeable {
                 .withThreadingOptions(configuration.getThreadingOptions())
                 .withNettyOptions(configuration.getNettyOptions())
                 .withCodecRegistry(configuration.getCodecRegistry())
-                .withApplicationName(configuration.getApplicationName())
-                .withApplicationVersion(configuration.getApplicationVersion())
-                .withClientId(configuration.getClientId())
+                .withApplicationInfo(configuration.getApplicationInfo())
                 .build();
       } else {
         this.configuration = configuration;

--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -32,8 +32,8 @@ import java.util.List;
  *   <li>Netty layer customization options.
  * </ul>
  *
- * This is also where you get the configured policies, though those cannot be changed (they are set
- * during the built of the Cluster object).
+ * <p>This is also where you get the configured policies, though those cannot be changed (they are
+ * set during the built of the Cluster object).
  */
 public class Configuration {
 
@@ -59,9 +59,7 @@ public class Configuration {
   private final NettyOptions nettyOptions;
   private final CodecRegistry codecRegistry;
   private final String defaultKeyspace;
-  private final String applicationName;
-  private final String applicationVersion;
-  private final String clientId;
+  private final ApplicationInfo applicationInfo;
 
   private Configuration(
       Policies policies,
@@ -74,9 +72,7 @@ public class Configuration {
       NettyOptions nettyOptions,
       CodecRegistry codecRegistry,
       String defaultKeyspace,
-      String applicationName,
-      String applicationVersion,
-      String clientId) {
+      ApplicationInfo applicationInfo) {
     this.policies = policies;
     this.protocolOptions = protocolOptions;
     this.poolingOptions = poolingOptions;
@@ -87,9 +83,7 @@ public class Configuration {
     this.nettyOptions = nettyOptions;
     this.codecRegistry = codecRegistry;
     this.defaultKeyspace = defaultKeyspace;
-    this.applicationName = applicationName;
-    this.applicationVersion = applicationVersion;
-    this.clientId = clientId;
+    this.applicationInfo = applicationInfo;
   }
 
   /**
@@ -109,9 +103,7 @@ public class Configuration {
         toCopy.getNettyOptions(),
         toCopy.getCodecRegistry(),
         toCopy.getDefaultKeyspace(),
-        toCopy.getApplicationName(),
-        toCopy.getApplicationVersion(),
-        toCopy.getClientId());
+        toCopy.getApplicationInfo());
   }
 
   void register(Cluster.Manager manager) {
@@ -226,16 +218,8 @@ public class Configuration {
     return defaultKeyspace;
   }
 
-  public String getApplicationName() {
-    return applicationName;
-  }
-
-  public String getApplicationVersion() {
-    return applicationVersion;
-  }
-
-  public String getClientId() {
-    return clientId;
+  public ApplicationInfo getApplicationInfo() {
+    return applicationInfo;
   }
 
   /**
@@ -262,42 +246,18 @@ public class Configuration {
     private QueryOptions queryOptions;
     private ThreadingOptions threadingOptions;
     private NettyOptions nettyOptions;
+    private ApplicationInfo applicationInfo;
     private CodecRegistry codecRegistry;
     private String defaultKeyspace;
-    private String applicationName;
-    private String applicationVersion;
-    private String clientId;
 
     /**
-     * Sets application name, to be reported to server
+     * Sets application information provider.
      *
-     * @param applicationName application name.
+     * @param applicationInfo application information provider.
      * @return this builder.
      */
-    public Builder withApplicationName(String applicationName) {
-      this.applicationName = applicationName;
-      return this;
-    }
-
-    /**
-     * Sets application version, to be reported to server
-     *
-     * @param applicationVersion application version.
-     * @return this builder.
-     */
-    public Builder withApplicationVersion(String applicationVersion) {
-      this.applicationVersion = applicationVersion;
-      return this;
-    }
-
-    /**
-     * Sets client id, to be reported to server
-     *
-     * @param clientId application version.
-     * @return this builder.
-     */
-    public Builder withClientId(String clientId) {
-      this.clientId = clientId;
+    public Builder withApplicationInfo(ApplicationInfo applicationInfo) {
+      this.applicationInfo = applicationInfo;
       return this;
     }
 
@@ -432,9 +392,7 @@ public class Configuration {
           nettyOptions != null ? nettyOptions : NettyOptions.DEFAULT_INSTANCE,
           codecRegistry != null ? codecRegistry : CodecRegistry.DEFAULT_INSTANCE,
           defaultKeyspace,
-          applicationName,
-          applicationVersion,
-          clientId);
+          applicationInfo);
     }
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -154,6 +154,7 @@ class Connection {
       new AtomicReference<ConnectionCloseFuture>();
 
   private final AtomicReference<Owner> ownerRef = new AtomicReference<Owner>();
+  private final ApplicationInfo applicationInfo;
 
   /**
    * Create a new connection to a Cassandra node and associate it with the given pool.
@@ -173,6 +174,7 @@ class Connection {
     ListenableFuture<Connection> thisFuture = Futures.immediateFuture(this);
     this.defaultKeyspaceAttempt = new SetKeyspaceAttempt(null, thisFuture);
     this.targetKeyspace = new AtomicReference<SetKeyspaceAttempt>(defaultKeyspaceAttempt);
+    this.applicationInfo = factory.configuration.getApplicationInfo();
   }
 
   /** Create a new connection to a Cassandra node. */
@@ -505,6 +507,9 @@ class Connection {
       public ListenableFuture<Void> apply(Void input) throws Exception {
         ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
         Map<String, String> extraOptions = new HashMap<String, String>();
+        if (applicationInfo != null) {
+          applicationInfo.addOption(extraOptions);
+        }
         LwtInfo lwtInfo = getHost().getLwtInfo();
         if (lwtInfo != null) {
           lwtInfo.addOption(extraOptions);
@@ -515,19 +520,6 @@ class Connection {
             && ProtocolFeature.CUSTOM_PAYLOADS.isSupportedBy(protocolVersion)) {
           logger.debug("Enabling tablet support in OPTIONS message");
           TabletInfo.addOption(extraOptions);
-        }
-
-        if (factory.configuration.getApplicationName() != null
-            && !factory.configuration.getApplicationName().isEmpty()) {
-          extraOptions.put("APPLICATION_NAME", factory.configuration.getApplicationName());
-        }
-        if (factory.configuration.getApplicationVersion() != null
-            && !factory.configuration.getApplicationVersion().isEmpty()) {
-          extraOptions.put("APPLICATION_VERSION", factory.configuration.getApplicationVersion());
-        }
-        if (factory.configuration.getClientId() != null
-            && !factory.configuration.getClientId().isEmpty()) {
-          extraOptions.put("CLIENT_ID", factory.configuration.getClientId());
         }
 
         Future startupResponseFuture =

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultApplicationInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultApplicationInfo.java
@@ -1,0 +1,29 @@
+package com.datastax.driver.core;
+
+import java.util.Map;
+
+public class DefaultApplicationInfo implements ApplicationInfo {
+  private String applicationName;
+  private String applicationVersion;
+  private String clientId;
+
+  public DefaultApplicationInfo(
+      String applicationName, String applicationVersion, String clientId) {
+    this.applicationName = applicationName;
+    this.applicationVersion = applicationVersion;
+    this.clientId = clientId;
+  }
+
+  @Override
+  public void addOption(Map<String, String> options) {
+    if (applicationName != null && !applicationName.isEmpty()) {
+      options.put("APPLICATION_NAME", applicationName);
+    }
+    if (applicationVersion != null && !applicationVersion.isEmpty()) {
+      options.put("APPLICATION_VERSION", applicationVersion);
+    }
+    if (clientId != null && !clientId.isEmpty()) {
+      options.put("CLIENT_ID", clientId);
+    }
+  }
+}


### PR DESCRIPTION
In PR #554 application API was implemented in the form of three additional Configuration attributes.

This PR to have one Configuration attribute of `ApplicationInfo` interface. Default implementation of which will supply same three fields. `ApplicationInfo` interface is done in such a way that allows to inject any application information into startup message.