### PR TITLE
tests: remove ccm.scylla cli option

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -351,7 +351,7 @@ jobs:
 
       - name: Run integration tests on Scylla (${{ steps.scylla-version.outputs.value }})
         id: run-integration-tests
-        run: mvn -B verify -Dccm.version=${{ steps.scylla-version.outputs.value }} -Dccm.scylla=true -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+        run: mvn -B verify -Dccm.version=${{ steps.scylla-version.outputs.value }} -Dccm.distribution=scylla -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
 
       - name: Copy test results
         if: steps.run-integration-tests.outcome == 'failure'

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
@@ -41,6 +41,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions;
@@ -183,7 +184,8 @@ public class DefaultReactiveResultSetIT {
 
   @Test
   public void should_write_cas() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
 
     SimpleStatement statement =
         SimpleStatement.builder(
@@ -243,7 +245,8 @@ public class DefaultReactiveResultSetIT {
 
   @Test
   public void should_write_batch_cas() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
 
     BatchStatement batch = createCASBatch();
     CqlSession session = sessionRule.session();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
@@ -38,6 +38,7 @@ import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import java.nio.ByteBuffer;
@@ -76,7 +77,8 @@ public class LWTLoadBalancingIT {
 
   @Test
   public void should_use_only_one_node_when_lwt_detected() {
-    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT); // Functionality only available in Scylla
+    assumeTrue(
+        CcmBridge.isDistributionOf(BackendType.SCYLLA)); // Functionality only available in Scylla
     CqlSession session = SESSION_RULE.session();
     int pk = 1234;
     ByteBuffer routingKey = TypeCodecs.INT.encodePrimitive(pk, ProtocolVersion.DEFAULT);
@@ -97,7 +99,7 @@ public class LWTLoadBalancingIT {
   // Sanity check for the previous test - non-LWT queries should
   // not always be sent to same node
   public void should_not_use_only_one_node_when_non_lwt() {
-    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT);
+    assumeTrue(CcmBridge.isDistributionOf(BackendType.SCYLLA));
     CqlSession session = SESSION_RULE.session();
     int pk = 1234;
     PreparedStatement statement = session.prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?)");
@@ -114,7 +116,8 @@ public class LWTLoadBalancingIT {
 
   @Test
   public void should_use_only_one_node_when_lwt_batch_detected() {
-    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT); // Functionality only available in Scylla
+    assumeTrue(
+        CcmBridge.isDistributionOf(BackendType.SCYLLA)); // Functionality only available in Scylla
     CqlSession session = SESSION_RULE.session();
     int pk = 1234;
     ByteBuffer routingKey = TypeCodecs.INT.encodePrimitive(pk, ProtocolVersion.DEFAULT);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -250,7 +250,8 @@ public class SchemaChangesIT {
   public void should_handle_view_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V3_0_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     should_handle_creation(
         "CREATE TABLE scores(user text, game text, score int, PRIMARY KEY (user, game))",
         "CREATE MATERIALIZED VIEW highscores "
@@ -325,7 +326,7 @@ public class SchemaChangesIT {
   public void should_handle_function_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_creation(
         null,
@@ -351,7 +352,7 @@ public class SchemaChangesIT {
   public void should_handle_function_drop() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_drop(
         ImmutableList.of(
@@ -369,7 +370,7 @@ public class SchemaChangesIT {
   public void should_handle_function_update() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_update_via_drop_and_recreate(
         ImmutableList.of(
@@ -391,7 +392,7 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_creation() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_creation(
         "CREATE FUNCTION plus(i int, j int) RETURNS NULL ON NULL INPUT RETURNS int "
@@ -419,7 +420,7 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_drop() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_drop(
         ImmutableList.of(
@@ -438,7 +439,7 @@ public class SchemaChangesIT {
   public void should_handle_aggregate_update() {
     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
         .isTrue();
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT)
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
         .isFalse(); // @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF
     should_handle_update_via_drop_and_recreate(
         ImmutableList.of(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -11,6 +11,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -31,7 +32,7 @@ public class ZeroTokenNodesIT {
     // Zero-token nodes introduced in scylladb/scylladb#19684
     // 2025.1 is an estimated future version and it still may not have this change in.
     // This number may need to be adjusted once CI picks up this test.
-    assumeTrue(CcmBridge.SCYLLA_ENABLEMENT);
+    assumeTrue(CcmBridge.isDistributionOf(BackendType.SCYLLA));
     if (CcmBridge.SCYLLA_ENTERPRISE) {
       assumeTrue(
           CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("2025.1.0"))) >= 0);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
@@ -44,6 +44,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -229,7 +230,8 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(dao.saveIfNotExists(FLAMETHROWER)).isNull();
 
     Product otherProduct =
@@ -248,7 +250,8 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_asynchronously() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(CompletableFutures.getUninterruptibly(dao.saveAsyncIfNotExists(FLAMETHROWER)))
         .isNull();
 
@@ -275,7 +278,8 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_returning_optional() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(dao.saveIfNotExistsOptional(FLAMETHROWER)).isEmpty();
 
     Product otherProduct =
@@ -285,7 +289,8 @@ public class InsertIT extends InventoryITBase {
 
   @Test
   public void should_insert_entity_if_not_exists_returning_optional_asynchronously() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     assertThat(
             CompletableFutures.getUninterruptibly(dao.saveAsyncIfNotExistsOptional(FLAMETHROWER)))
         .isEmpty();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
@@ -112,8 +112,9 @@ public abstract class InventoryITBase {
 
   protected static boolean supportsSASI(BaseCcmRule ccmRule) {
     return ccmRule.getCassandraVersion().compareTo(MINIMUM_SASI_VERSION) >= 0
-        && !CcmBridge
-            .SCYLLA_ENABLEMENT /* @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex */;
+        && !CcmBridge.isDistributionOf(
+            BackendType
+                .SCYLLA) /* @IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex */;
   }
 
   @Entity

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SchemaValidationIT.java
@@ -206,7 +206,8 @@ public class SchemaValidationIT extends InventoryITBase {
 
   @Test
   public void should_throw_general_driver_exception_when_schema_validation_check_is_disabled() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
     // @IntegrationTestDisabledScyllaDifferentText
     assertThatThrownBy(
             () -> mapperDisabledValidation.productDaoValidationDisabled(sessionRule.keyspace()))

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
@@ -111,7 +111,8 @@ public class SelectOtherClausesIT {
 
   @Test
   public void should_select_with_per_partition_limit() {
-    assumeThat(CcmBridge.SCYLLA_ENABLEMENT).isFalse(); // @IntegrationTestDisabledScyllaFailure
+    assumeThat(CcmBridge.isDistributionOf(BackendType.SCYLLA))
+        .isFalse(); // @IntegrationTestDisabledScyllaFailure
 
     PagingIterable<Simple> elements = dao.selectWithPerPartitionLimit(5);
     assertThat(elements.isFullyFetched()).isTrue();

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmPaxExam.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmPaxExam.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import java.util.Objects;
 import java.util.Optional;
 import org.junit.AssumptionViolatedException;
@@ -110,11 +111,11 @@ public class CcmPaxExam extends PaxExam {
             String.format(
                 "Test requires %s %s %s but %s is configured.  Description: %s",
                 lessThan ? "less than" : "at least",
-                dse ? "DSE" : (CcmBridge.SCYLLA_ENABLEMENT ? "SCYLLA" : "C*"),
+                dse ? "DSE" : (CcmBridge.isDistributionOf(BackendType.SCYLLA) ? "SCYLLA" : "C*"),
                 requirement,
                 dse
                     ? CCM_BRIDGE.getDseVersion().orElse(null)
-                    : (CcmBridge.SCYLLA_ENABLEMENT
+                    : (CcmBridge.isDistributionOf(BackendType.SCYLLA)
                         ? CCM_BRIDGE.getScyllaVersion().orElse(null)
                         : CCM_BRIDGE.getCassandraVersion()),
                 description));

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -77,11 +77,11 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
             String.format(
                 "Test requires %s %s %s but %s is configured.  Description: %s",
                 lessThan ? "less than" : "at least",
-                dse ? "DSE" : (CcmBridge.SCYLLA_ENABLEMENT ? "SCYLLA" : "C*"),
+                dse ? "DSE" : (CcmBridge.isDistributionOf(BackendType.SCYLLA) ? "SCYLLA" : "C*"),
                 requirement,
                 dse
                     ? ccmBridge.getDseVersion().orElse(null)
-                    : (CcmBridge.SCYLLA_ENABLEMENT
+                    : (CcmBridge.isDistributionOf(BackendType.SCYLLA)
                         ? ccmBridge.getScyllaVersion().orElse(null)
                         : ccmBridge.getCassandraVersion()),
                 description));
@@ -97,7 +97,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     // Scylla-specific annotations
     ScyllaSkip scyllaSkip = description.getAnnotation(ScyllaSkip.class);
     if (scyllaSkip != null) {
-      if (CcmBridge.SCYLLA_ENABLEMENT) {
+      if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
         return new Statement() {
 
           @Override
@@ -112,7 +112,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
 
     CassandraSkip cassandraSkip = description.getAnnotation(CassandraSkip.class);
     if (cassandraSkip != null) {
-      if (!CcmBridge.SCYLLA_ENABLEMENT) {
+      if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
         return new Statement() {
 
           @Override

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -67,8 +67,6 @@ public class CcmBridge implements AutoCloseable {
       BackendType.valueOf(
           System.getProperty("ccm.distribution", BackendType.CASSANDRA.name()).toUpperCase());
 
-  public static final Boolean SCYLLA_ENABLEMENT = Boolean.getBoolean("ccm.scylla");
-
   public static final String CCM_VERSION_PROPERTY = System.getProperty("ccm.version", "4.0.0");
 
   public static final Version VERSION = Objects.requireNonNull(parseCcmVersion());
@@ -150,13 +148,8 @@ public class CcmBridge implements AutoCloseable {
 
   static {
     Map<String, String> envMap = Maps.newHashMap(new ProcessBuilder().environment());
-    if (SCYLLA_ENABLEMENT) {
-      LOG.debug("Overriding distribution variable because 'ccm.scylla = true' was passed");
-      DISTRIBUTION = BackendType.SCYLLA;
-
-      if (SCYLLA_ENTERPRISE) {
-        envMap.put("SCYLLA_PRODUCT", "enterprise");
-      }
+    if (isDistributionOf(BackendType.SCYLLA) && SCYLLA_ENTERPRISE) {
+      envMap.put("SCYLLA_PRODUCT", "enterprise");
     }
     LOG.info("CCM Bridge configured with {} version {}", DISTRIBUTION.getFriendlyName(), VERSION);
 
@@ -260,7 +253,9 @@ public class CcmBridge implements AutoCloseable {
           CommandLine.parse(
               String.format(
                   "ccm create get_version -n 1 %s --version %s --config-dir=%s",
-                  (SCYLLA_ENABLEMENT ? "--scylla" : " "), versionString, configDir)));
+                  (isDistributionOf(BackendType.SCYLLA) ? "--scylla" : " "),
+                  versionString,
+                  configDir)));
       String output =
           execute(
               CommandLine.parse(
@@ -281,11 +276,13 @@ public class CcmBridge implements AutoCloseable {
   }
 
   public Optional<Version> getScyllaVersion() {
-    return SCYLLA_ENABLEMENT ? Optional.of(VERSION) : Optional.empty();
+    return isDistributionOf(BackendType.SCYLLA) ? Optional.of(VERSION) : Optional.empty();
   }
 
   public Optional<String> getScyllaUnparsedVersion() {
-    return SCYLLA_ENABLEMENT ? Optional.of(System.getProperty("ccm.version")) : Optional.empty();
+    return isDistributionOf(BackendType.SCYLLA)
+        ? Optional.of(System.getProperty("ccm.version"))
+        : Optional.empty();
   }
 
   public Optional<Version> getDseVersion() {
@@ -321,7 +318,7 @@ public class CcmBridge implements AutoCloseable {
       // If parseCcmVersion has not failed execution it should be usable.
       return propertyString;
     }
-    if (SCYLLA_ENABLEMENT) {
+    if (isDistributionOf(BackendType.SCYLLA)) {
       // Scylla OSS versions before 5.1 had RC versioning scheme of 5.0.rc3.
       // Scylla OSS versions after (and including 5.1) have RC versioning of 5.1.0-rc3.
       // A similar situation occurs with Scylla Enterprise after 2022.2.
@@ -382,7 +379,8 @@ public class CcmBridge implements AutoCloseable {
 
       Version cassandraVersion = getCassandraVersion();
 
-      if (cassandraVersion.compareTo(Version.V2_2_0) >= 0 && !SCYLLA_ENABLEMENT) {
+      if (cassandraVersion.compareTo(Version.V2_2_0) >= 0
+          && !isDistributionOf(BackendType.SCYLLA)) {
         // @IntegrationTestDisabledScyllaJVMArgs @IntegrationTestDisabledScyllaUDF
         cassandraConfiguration.put("enable_user_defined_functions", "true");
       }
@@ -723,7 +721,7 @@ public class CcmBridge implements AutoCloseable {
     /** Enables SSL encryption. */
     public Builder withSsl() {
       cassandraConfiguration.put("client_encryption_options.enabled", "true");
-      if (SCYLLA_ENABLEMENT) {
+      if (isDistributionOf(BackendType.SCYLLA)) {
         cassandraConfiguration.put(
             "client_encryption_options.certificate",
             DEFAULT_SERVER_CERT_CHAIN_FILE.getAbsolutePath());
@@ -756,7 +754,7 @@ public class CcmBridge implements AutoCloseable {
     public Builder withSslAuth() {
       withSsl();
       cassandraConfiguration.put("client_encryption_options.require_client_auth", "true");
-      if (SCYLLA_ENABLEMENT) {
+      if (isDistributionOf(BackendType.SCYLLA)) {
         cassandraConfiguration.put(
             "client_encryption_options.truststore",
             DEFAULT_SERVER_TRUSTSTORE_PEM_FILE.getAbsolutePath());


### PR DESCRIPTION
This option collides with `ccm.distribution` that was introduced in `4.18.0.0`.
Let's remove it to keep code clean.