### PR TITLE
Revise disabled tests

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
@@ -34,7 +34,6 @@ import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.UnsupportedProtocolVersionException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -77,6 +76,7 @@ public class ProtocolVersionInitialNegotiationIT {
       minInclusive = "5.0",
       maxExclusive = "5.1",
       description = "Only DSE in [5.0,5.1[ has V4 as its highest version")
+  @BackendRequirement(type = BackendType.SCYLLA)
   @Test
   public void should_downgrade_to_v4() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
@@ -90,9 +90,6 @@ public class ProtocolVersionInitialNegotiationIT {
       minInclusive = "4.0-rc1",
       description = "Only C* in [4.0-rc1,*[ has V5 as its highest version")
   @Test
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_downgrade_to_v5_oss() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion().getCode()).isEqualTo(5);
@@ -216,9 +213,6 @@ public class ProtocolVersionInitialNegotiationIT {
       minInclusive = "4.0",
       description = "Only C* in [4.0,*[ has V5 supported")
   @Test
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_not_downgrade_if_server_supports_latest_version() {
     try (CqlSession session = SessionUtils.newSession(ccm)) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(ProtocolVersion.V5);
@@ -247,6 +241,7 @@ public class ProtocolVersionInitialNegotiationIT {
       type = BackendType.DSE,
       minInclusive = "4.8",
       description = "Only DSE in [4.8,*[ has V3 supported")
+  @BackendRequirement(type = BackendType.SCYLLA)
   @Test
   public void should_use_explicitly_provided_v3() {
     DriverConfigLoader loader =
@@ -267,6 +262,7 @@ public class ProtocolVersionInitialNegotiationIT {
       type = BackendType.DSE,
       minInclusive = "5.0",
       description = "Only DSE in [5.0,*[ has V4 supported")
+  @BackendRequirement(type = BackendType.SCYLLA)
   @Test
   public void should_use_explicitly_provided_v4() {
     DriverConfigLoader loader =
@@ -288,9 +284,6 @@ public class ProtocolVersionInitialNegotiationIT {
       minInclusive = "7.0",
       description = "Only DSE in [7.0,*[ has V5 supported")
   @Test
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_use_explicitly_provided_v5() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
@@ -31,8 +31,9 @@ import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
@@ -41,16 +42,19 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-@ScyllaSkip(
-    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaJVMArgs")
 public class PlainTextAuthProviderIT {
 
-  @ClassRule
-  public static final CustomCcmRule CCM_RULE =
-      CustomCcmRule.builder()
-          .withCassandraConfiguration("authenticator", "PasswordAuthenticator")
-          .withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0")
-          .build();
+  @ClassRule public static final CustomCcmRule CCM_RULE = getCCMRule();
+
+  private static CustomCcmRule getCCMRule() {
+    CustomCcmRule.Builder builder =
+        CustomCcmRule.builder()
+            .withCassandraConfiguration("authenticator", "PasswordAuthenticator");
+    if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      builder = builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
+    }
+    return builder.build();
+  }
 
   @BeforeClass
   public static void sleepForAuth() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/connection/NettyResourceLeakDetectionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/connection/NettyResourceLeakDetectionIT.java
@@ -133,6 +133,7 @@ public class NettyResourceLeakDetectionIT {
       type = BackendType.CASSANDRA,
       maxExclusive = "4.0.0",
       description = "Snappy is not supported in OSS C* 4.0+ with protocol v5")
+  @BackendRequirement(type = BackendType.SCYLLA)
   @Test
   public void should_not_leak_compressed_snappy() {
     DriverConfigLoader loader =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
@@ -168,6 +168,7 @@ public class BatchStatementIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_execute_batch_of_bound_statements_with_unset_values() {
     // Build a batch of batchCount statements with bound statements, each with their own positional
     // variables.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -26,6 +26,7 @@ package com.datastax.oss.driver.core.cql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.Assert.assertThrows;
 
 import com.datastax.oss.driver.api.core.CQL4SkipMetadataResolveMethod;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -48,6 +49,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -301,7 +303,9 @@ public class BoundStatementCcmIT {
   }
 
   @Test
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @ScyllaSkip(description = "scylladb/scylla-driver#567 - fails by unknown reason")
+  @BackendRequirement(type = BackendType.CASSANDRA)
+  @BackendRequirement(type = BackendType.DSE)
   public void should_propagate_attributes_when_preparing_a_simple_statement() {
     CqlSession session = sessionRule.session();
 
@@ -381,6 +385,7 @@ public class BoundStatementCcmIT {
   // Test for JAVA-2066
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_compute_routing_key_when_indices_randomly_distributed() {
     try (CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace())) {
 
@@ -398,13 +403,26 @@ public class BoundStatementCcmIT {
   }
 
   @Test
-  @ScyllaSkip /* Skipping due to https://github.com/scylladb/scylla/issues/10956. */
   public void should_set_all_occurrences_of_variable() {
     CqlSession session = sessionRule.session();
     PreparedStatement ps = session.prepare("INSERT INTO test3 (pk1, pk2, v) VALUES (:i, :i, :i)");
 
     CqlIdentifier id = CqlIdentifier.fromCql("i");
     ColumnDefinitions variableDefinitions = ps.getVariableDefinitions();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla has different behavior, see https://github.com/scylladb/scylladb/pull/10813 and for
+      // more details.
+      assertThat(variableDefinitions.allIndicesOf(id)).containsExactly(0);
+      assertThrows(
+          Exception.class, () -> should_set_all_occurrences_of_variable(ps.bind().setInt(id, 12)));
+      assertThrows(
+          Exception.class,
+          () ->
+              should_set_all_occurrences_of_variable(
+                  ps.boundStatementBuilder().setInt(id, 12).build()));
+      return;
+    }
+
     assertThat(variableDefinitions.allIndicesOf(id)).containsExactly(0, 1, 2);
 
     should_set_all_occurrences_of_variable(ps.bind().setInt(id, 12));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
@@ -24,6 +24,7 @@
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -37,7 +38,7 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -72,6 +73,7 @@ public class ExecutionInfoWarningsIT {
           // set the warn threshold to 5Kb (default is 64Kb in newer versions)
           .withCassandraConfiguration("batch_size_warn_threshold_in_kb", "5")
           .build();
+
   private SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withConfigLoader(
@@ -131,9 +133,7 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "3.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_execute_query_and_log_server_side_warnings() {
     final String query = "SELECT count(*) FROM test;";
     Statement<?> st = SimpleStatement.builder(query).build();
@@ -142,6 +142,11 @@ public class ExecutionInfoWarningsIT {
     ExecutionInfo executionInfo = result.getExecutionInfo();
     assertThat(executionInfo).isNotNull();
     List<String> warnings = executionInfo.getWarnings();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(warnings).isEmpty();
+      verify(appender, after(100).times(0)).doAppend(loggingEventCaptor.capture());
+      return;
+    }
     assertThat(warnings).isNotEmpty();
     String warning = warnings.get(0);
     assertThat(warning).isEqualTo("Aggregation query used without partition key");
@@ -158,9 +163,7 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "3.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_execute_query_and_not_log_server_side_warnings() {
     final String query = "SELECT count(*) FROM test;";
     Statement<?> st =
@@ -170,6 +173,11 @@ public class ExecutionInfoWarningsIT {
     ExecutionInfo executionInfo = result.getExecutionInfo();
     assertThat(executionInfo).isNotNull();
     List<String> warnings = executionInfo.getWarnings();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(warnings).isEmpty();
+      verify(appender, after(100).times(0)).doAppend(loggingEventCaptor.capture());
+      return;
+    }
     assertThat(warnings).isNotEmpty();
     String warning = warnings.get(0);
     assertThat(warning).isEqualTo("Aggregation query used without partition key");
@@ -179,9 +187,7 @@ public class ExecutionInfoWarningsIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_expose_warnings_on_execution_info() {
     // the default batch size warn threshold is 5 * 1024 bytes, but after CASSANDRA-10876 there must
     // be multiple mutations in a batch to trigger this warning so the batch includes 2 different
@@ -198,6 +204,11 @@ public class ExecutionInfoWarningsIT {
     ExecutionInfo executionInfo = result.getExecutionInfo();
     assertThat(executionInfo).isNotNull();
     List<String> warnings = executionInfo.getWarnings();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(warnings).isEmpty();
+      verify(appender, after(100).times(0)).doAppend(loggingEventCaptor.capture());
+      return;
+    }
     assertThat(warnings).isNotEmpty();
     // verify the log was generated
     verify(appender, timeout(500).atLeast(1)).doAppend(loggingEventCaptor.capture());

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/NowInSecondsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/NowInSecondsIT.java
@@ -48,9 +48,7 @@ import org.junit.rules.TestRule;
     type = BackendType.DSE,
     minInclusive = "7.0",
     description = "Feature not available in DSE yet")
-@ScyllaSkip(
-    description =
-        "Scylla keeps negotiating protocol version v4, but \"Can't use nowInSeconds with protocol V4\". Remove skip once Scylla supports protocol version v5.")
+@ScyllaSkip(description = "scylladb/java-driver#573 - to be enabled")
 public class NowInSecondsIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
@@ -36,7 +36,6 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -89,6 +88,7 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_reject_simple_statement_with_keyspace_in_protocol_v4() {
     should_reject_statement_with_keyspace_in_protocol_v4(
         SimpleStatement.newInstance("SELECT * FROM foo").setKeyspace(sessionRule.keyspace()));
@@ -96,6 +96,7 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_reject_batch_statement_with_explicit_keyspace_in_protocol_v4() {
     SimpleStatement statementWithoutKeyspace =
         SimpleStatement.newInstance(
@@ -109,6 +110,7 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_reject_batch_statement_with_inferred_keyspace_in_protocol_v4() {
     SimpleStatement statementWithKeyspace =
         SimpleStatement.newInstance(
@@ -135,9 +137,6 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_simple_statement_with_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -156,9 +155,6 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_batch_with_explicit_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -183,9 +179,6 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_execute_batch_with_inferred_keyspace() {
     CqlSession session = sessionRule.session();
     session.execute(
@@ -218,9 +211,6 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_prepare_statement_with_keyspace() {
     CqlSession session = sessionRule.session();
     PreparedStatement prepared =
@@ -241,9 +231,6 @@ public class PerRequestKeyspaceIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaProtocolV5")
   public void should_reprepare_statement_with_keyspace_on_the_fly() {
     // Create a separate session because we don't want it to have a default keyspace
     SchemaChangeSynchronizer.withLock(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -26,6 +26,7 @@ package com.datastax.oss.driver.core.cql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.Assert.assertThrows;
 
 import com.codahale.metrics.Gauge;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -42,9 +43,7 @@ import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.core.type.DataTypes;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
-import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -160,12 +159,16 @@ public class PreparedStatementIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_update_metadata_when_schema_changed_across_executions() {
     // Given
     CqlSession session = sessionRule.session();
     PreparedStatement ps = session.prepare("SELECT * FROM prepared_statement_test WHERE a = ?");
     ByteBuffer idBefore = ps.getResultMetadataId();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 extensions and metadata id
+      assertThat(idBefore).isNull();
+    }
 
     // When
     session.execute(
@@ -177,6 +180,20 @@ public class PreparedStatementIT {
 
     // Then
     ByteBuffer idAfter = ps.getResultMetadataId();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 extensions and metadata id
+      assertThat(idAfter).isNull();
+      for (ColumnDefinitions columnDefinitions :
+          ImmutableList.of(
+              ps.getResultSetDefinitions(), bs.getPreparedStatement().getResultSetDefinitions())) {
+        assertThat(columnDefinitions).hasSize(3);
+        assertThat(columnDefinitions.contains("d")).isFalse();
+      }
+      assertThat(rows.getColumnDefinitions()).hasSize(4);
+      assertThat(rows.getColumnDefinitions().contains("d")).isTrue();
+      return;
+    }
+
     assertThat(Bytes.toHexString(idAfter)).isNotEqualTo(Bytes.toHexString(idBefore));
     for (ColumnDefinitions columnDefinitions :
         ImmutableList.of(
@@ -190,12 +207,16 @@ public class PreparedStatementIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_update_metadata_when_schema_changed_across_pages() {
     // Given
     CqlSession session = sessionRule.session();
     PreparedStatement ps = session.prepare("SELECT * FROM prepared_statement_test");
     ByteBuffer idBefore = ps.getResultMetadataId();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 and result metadata id
+      assertThat(idBefore).isNull();
+    }
     assertThat(ps.getResultSetDefinitions()).hasSize(3);
 
     CompletionStage<AsyncResultSet> future = session.executeAsync(ps.bind());
@@ -229,14 +250,21 @@ public class PreparedStatementIT {
     assertThat(rows.getColumnDefinitions().get("d").getType()).isEqualTo(DataTypes.INT);
     // Should have updated the prepared statement too
     ByteBuffer idAfter = ps.getResultMetadataId();
-    assertThat(Bytes.toHexString(idAfter)).isNotEqualTo(Bytes.toHexString(idBefore));
-    assertThat(ps.getResultSetDefinitions()).hasSize(4);
-    assertThat(ps.getResultSetDefinitions().get("d").getType()).isEqualTo(DataTypes.INT);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 and result metadata id
+      assertThat(idAfter).isNull();
+      assertThat(ps.getResultSetDefinitions()).hasSize(3);
+      assertThat(ps.getResultSetDefinitions().contains("d")).isFalse();
+    } else {
+      assertThat(Bytes.toHexString(idAfter)).isNotEqualTo(Bytes.toHexString(idBefore));
+      assertThat(ps.getResultSetDefinitions()).hasSize(4);
+      assertThat(ps.getResultSetDefinitions().get("d").getType()).isEqualTo(DataTypes.INT);
+    }
   }
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_update_metadata_when_schema_changed_across_sessions() {
     // Given
     CqlSession session1 = sessionRule.session();
@@ -247,6 +275,11 @@ public class PreparedStatementIT {
 
     ByteBuffer id1a = ps1.getResultMetadataId();
     ByteBuffer id2a = ps2.getResultMetadataId();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 extensions and metadata id
+      assertThat(id1a).isNull();
+      assertThat(id2a).isNull();
+    }
 
     ResultSet rows1 = session1.execute(ps1.bind(1));
     ResultSet rows2 = session2.execute(ps2.bind(1));
@@ -266,6 +299,24 @@ public class PreparedStatementIT {
     ByteBuffer id2b = ps2.getResultMetadataId();
 
     // Then
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 extensions and metadata id
+      assertThat(id1b).isNull();
+      assertThat(id2b).isNull();
+
+      assertThat(ps1.getResultSetDefinitions()).hasSize(3);
+      assertThat(ps1.getResultSetDefinitions().contains("d")).isFalse();
+      assertThat(ps2.getResultSetDefinitions()).hasSize(3);
+      assertThat(ps2.getResultSetDefinitions().contains("d")).isFalse();
+
+      assertThat(rows1.getColumnDefinitions()).hasSize(4);
+      assertThat(rows1.getColumnDefinitions().contains("d")).isTrue();
+      assertThat(rows2.getColumnDefinitions()).hasSize(4);
+      assertThat(rows2.getColumnDefinitions().contains("d")).isTrue();
+
+      session2.close();
+      return;
+    }
     assertThat(Bytes.toHexString(id1b)).isNotEqualTo(Bytes.toHexString(id1a));
     assertThat(Bytes.toHexString(id2b)).isNotEqualTo(Bytes.toHexString(id2a));
 
@@ -284,9 +335,7 @@ public class PreparedStatementIT {
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_fail_to_reprepare_if_query_becomes_invalid() {
     // Given
     CqlSession session = sessionRule.session();
@@ -301,19 +350,22 @@ public class PreparedStatementIT {
     // Then
     assertThat(t)
         .isInstanceOf(InvalidQueryException.class)
-        .hasMessageContaining("Undefined column name d");
+        .hasMessageContaining(
+            CcmBridge.isDistributionOf(BackendType.SCYLLA)
+                ? "Unrecognized name d"
+                : "Undefined column name d");
   }
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_not_store_metadata_for_conditional_updates() {
     should_not_store_metadata_for_conditional_updates(sessionRule.session());
   }
 
   @Test
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
+  @BackendRequirement(type = BackendType.SCYLLA)
   public void should_not_store_metadata_for_conditional_updates_in_legacy_protocol() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
@@ -325,7 +377,6 @@ public class PreparedStatementIT {
     }
   }
 
-  @ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure")
   private void should_not_store_metadata_for_conditional_updates(CqlSession session) {
     // Given
     PreparedStatement ps =
@@ -335,7 +386,11 @@ public class PreparedStatementIT {
     // Never store metadata in the prepared statement for conditional updates, since the result set
     // can change
     // depending on the outcome.
-    assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(ps.getResultSetDefinitions()).hasSize(4);
+    } else {
+      assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    }
     ByteBuffer idBefore = ps.getResultMetadataId();
 
     // When
@@ -344,10 +399,18 @@ public class PreparedStatementIT {
     // Then
     // Successful conditional update => only contains the [applied] column
     assertThat(rs.wasApplied()).isTrue();
-    assertThat(rs.getColumnDefinitions()).hasSize(1);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(rs.getColumnDefinitions()).hasSize(4);
+    } else {
+      assertThat(rs.getColumnDefinitions()).hasSize(1);
+    }
     assertThat(rs.getColumnDefinitions().get("[applied]").getType()).isEqualTo(DataTypes.BOOLEAN);
     // However the prepared statement shouldn't have changed
-    assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(ps.getResultSetDefinitions()).hasSize(4);
+    } else {
+      assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    }
     assertThat(Bytes.toHexString(ps.getResultMetadataId())).isEqualTo(Bytes.toHexString(idBefore));
 
     // When
@@ -363,7 +426,11 @@ public class PreparedStatementIT {
     assertThat(row.getInt("b")).isEqualTo(5);
     assertThat(row.getInt("c")).isEqualTo(5);
     // The prepared statement still shouldn't have changed
-    assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      assertThat(ps.getResultSetDefinitions()).hasSize(4);
+    } else {
+      assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    }
     assertThat(Bytes.toHexString(ps.getResultMetadataId())).isEqualTo(Bytes.toHexString(idBefore));
 
     // When
@@ -373,14 +440,25 @@ public class PreparedStatementIT {
     // Then
     // Failed conditional update => regular metadata that should also contain the new column
     assertThat(rs.wasApplied()).isFalse();
-    assertThat(rs.getColumnDefinitions()).hasSize(5);
-    row = rs.one();
-    assertThat(row.getBoolean("[applied]")).isFalse();
-    assertThat(row.getInt("a")).isEqualTo(5);
-    assertThat(row.getInt("b")).isEqualTo(5);
-    assertThat(row.getInt("c")).isEqualTo(5);
-    assertThat(row.isNull("d")).isTrue();
-    assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not update column definitions is such case
+      assertThat(rs.getColumnDefinitions()).hasSize(4);
+    } else {
+      assertThat(rs.getColumnDefinitions()).hasSize(5);
+    }
+    final Row nextRow = rs.one();
+    assertThat(nextRow.getBoolean("[applied]")).isFalse();
+    assertThat(nextRow.getInt("a")).isEqualTo(5);
+    assertThat(nextRow.getInt("b")).isEqualTo(5);
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL5 and metadata id, that is why response metadata does not
+      // contain "d"
+      assertThrows(IllegalArgumentException.class, () -> nextRow.isNull("d"));
+      assertThat(ps.getResultSetDefinitions()).hasSize(4);
+    } else {
+      assertThat(nextRow.isNull("d")).isTrue();
+      assertThat(ps.getResultSetDefinitions()).hasSize(0);
+    }
     assertThat(Bytes.toHexString(ps.getResultMetadataId())).isEqualTo(Bytes.toHexString(idBefore));
   }
 
@@ -511,12 +589,18 @@ public class PreparedStatementIT {
       minInclusive = "3.11.12",
       maxExclusive = "4.0.0")
   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0.2")
+  @BackendRequirement(type = BackendType.SCYLLA)
   @Test
-  @ScyllaSkip(
-      description =
-          "It seems Scylla always will reprepare with different ID when reproducing CASSANDRA-15252 scenario")
   public void handle_id_changes_on_reprepare() {
-    assertableReprepareAfterIdChange().doesNotThrowAnyException();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla does not support CQL 5 and metadata id therefore it updates prepared statement id
+      // as result this driver throws java.lang.IllegalStateException: ID mismatch while trying to
+      // reprepare
+      assertableReprepareAfterIdChange()
+          .hasMessageContaining("ID mismatch while trying to reprepare");
+    } else {
+      assertableReprepareAfterIdChange().doesNotThrowAnyException();
+    }
   }
 
   @Test
@@ -532,11 +616,6 @@ public class PreparedStatementIT {
   }
 
   @Test
-  @CassandraSkip // Functionality only available in Scylla
-  @ScyllaRequirement(
-      minEnterprise = "2021.0.0",
-      minOSS = "4.3.rc0",
-      description = "Requires LWT_ADD_METADATA_MARK extension")
   public void scylla_should_recognize_prepared_lwt_query() {
     CqlSession session = sessionRule.session();
     PreparedStatement statementNonLWT =
@@ -545,22 +624,12 @@ public class PreparedStatementIT {
         session.prepare("UPDATE prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5");
 
     assertThat(statementNonLWT.isLWT()).isFalse();
-    assertThat(statementLWT.isLWT()).isTrue();
-  }
-
-  @Test
-  @ScyllaSkip // Scylla behaves differently - see `scylla_should_recognize_prepared_lwt_query` test
-  // This test is just to check that no crashes or other weird behaviour occur when this feature is
-  // not supported.
-  public void cassandra_should_not_recognize_prepared_lwt_query() {
-    CqlSession session = sessionRule.session();
-    PreparedStatement statementNonLWT =
-        session.prepare("UPDATE prepared_statement_test SET b = 3 WHERE a = 1");
-    PreparedStatement statementLWT =
-        session.prepare("UPDATE prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5");
-
-    assertThat(statementNonLWT.isLWT()).isFalse();
-    assertThat(statementLWT.isLWT()).isFalse();
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      // Scylla recognize LWT statement and report it to driver
+      assertThat(statementLWT.isLWT()).isTrue();
+    } else {
+      assertThat(statementLWT.isLWT()).isFalse();
+    }
   }
 
   private void should_infer_routing_information_when_partition_key_is_bound(String queryString) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -31,6 +31,7 @@ import static org.awaitility.Awaitility.await;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -42,7 +43,10 @@ import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.metadata.TokenMap;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
@@ -60,13 +64,13 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
-@ScyllaSkip(
-    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledCCMFailure")
 public class DefaultLoadBalancingPolicyIT {
+  @Rule public final BackendRequirementRule backendRequirementRule = new BackendRequirementRule();
 
   private static final String LOCAL_DC = "dc1";
 
@@ -87,9 +91,20 @@ public class DefaultLoadBalancingPolicyIT {
   @BeforeClass
   public static void setup() {
     CqlSession session = SESSION_RULE.session();
-    session.execute(
-        "CREATE KEYSPACE test "
-            + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1}");
+    if (CcmBridge.isDistributionOf(BackendType.SCYLLA)
+        && ((CcmBridge.SCYLLA_ENTERPRISE
+                && CcmBridge.getDistributionVersion().compareTo(Version.parse("2023.1.0")) >= 0)
+            || (!CcmBridge.SCYLLA_ENTERPRISE
+                && CcmBridge.getDistributionVersion().compareTo(Version.parse("6.1.0")) >= 0))) {
+      session.execute(
+          "CREATE KEYSPACE test "
+              + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} "
+              + "AND tablets = { 'enabled': false }");
+    } else {
+      session.execute(
+          "CREATE KEYSPACE test "
+              + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} ");
+    }
     session.execute("CREATE TABLE test.foo (k int PRIMARY KEY)");
   }
 
@@ -99,8 +114,13 @@ public class DefaultLoadBalancingPolicyIT {
       if (LOCAL_DC.equals(node.getDatacenter())) {
         assertThat(node.getDistance()).isEqualTo(NodeDistance.LOCAL);
         assertThat(node.getState()).isEqualTo(NodeState.UP);
-        // 1 regular connection, maybe 1 control connection
-        assertThat(node.getOpenConnections()).isBetween(1, 2);
+        if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+          // 2 per-shard connections and 1 for control connection
+          assertThat(node.getOpenConnections()).isBetween(2, 3);
+        } else {
+          // 1 regular connection, maybe 1 control connection
+          assertThat(node.getOpenConnections()).isBetween(1, 2);
+        }
         assertThat(node.isReconnecting()).isFalse();
       } else {
         assertThat(node.getDistance()).isEqualTo(NodeDistance.IGNORED);
@@ -243,6 +263,7 @@ public class DefaultLoadBalancingPolicyIT {
     }
   }
 
+  @ScyllaSkip(description = "scylladb/java-driver#574 - randomly fails")
   @Test
   public void should_apply_node_filter() {
     Set<Node> localNodes = new HashSet<>();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
@@ -33,6 +33,8 @@ import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -53,7 +55,9 @@ import org.junit.rules.TestRule;
  * @see <a href="https://datastax-oss.atlassian.net/browse/JAVA-2028">JAVA-2028</a>
  */
 @Category(ParallelizableTests.class)
-@ScyllaSkip(description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUDF")
+@ScyllaSkip(description = "java-based UDFs are not supported")
+@BackendRequirement(type = BackendType.CASSANDRA)
+@BackendRequirement(type = BackendType.DSE)
 public class CaseSensitiveUdtIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DefaultMetadataTabletMapIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DefaultMetadataTabletMapIT.java
@@ -10,7 +10,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.KeyspaceTableNamePair;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.Tablet;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
     minOSS = "6.0.0",
     minEnterprise = "2024.2",
     description = "Needs to support tablets")
-@CassandraSkip(description = "Tablets are ScyllaDB-only extension")
+@ScyllaOnly(description = "Tablets are ScyllaDB-only extension")
 public class DefaultMetadataTabletMapIT {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultMetadataTabletMapIT.class);
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/DescribeIT.java
@@ -36,6 +36,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -65,9 +66,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Category(ParallelizableTests.class)
-@ScyllaSkip(
-    description =
-        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality") //  'additional_write_policy' unsupported by Scylla in setupDatabase()
+@ScyllaSkip(description = "scylladb/java-driver#566 - needs to be adopted to scylla")
+@BackendRequirement(type = BackendType.CASSANDRA)
+@BackendRequirement(type = BackendType.DSE)
 public class DescribeIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(DescribeIT.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/Murmur3TokenVnodesIT.java
@@ -36,6 +36,7 @@ import org.junit.rules.TestRule;
     maxExclusive = "4.0-beta4",
     // TODO Re-enable when CASSANDRA-16364 is fixed
     description = "TODO Re-enable when CASSANDRA-16364 is fixed")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class Murmur3TokenVnodesIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
@@ -31,7 +31,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -55,9 +54,6 @@ public class NodeMetadataIT {
   @Rule public CcmRule ccmRule = CcmRule.getInstance();
 
   @Test
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaDifferentText")
   public void should_expose_node_metadata() {
     try (CqlSession session = SessionUtils.newSession(ccmRule)) {
 
@@ -71,7 +67,11 @@ public class NodeMetadataIT {
                   assertThat(broadcastAddress.getAddress()).isEqualTo(connectAddress.getAddress()));
       assertThat(node.getListenAddress().get().getAddress()).isEqualTo(connectAddress.getAddress());
       assertThat(node.getDatacenter()).isEqualTo("dc1");
-      assertThat(node.getRack()).isEqualTo("r1");
+      if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+        assertThat(node.getRack()).isEqualTo("RAC1");
+      } else {
+        assertThat(node.getRack()).isEqualTo("r1");
+      }
       if (CcmBridge.isDistributionOf(BackendType.CASSANDRA)) {
         // CcmBridge does not report accurate C* versions for other distributions (e.g. DSE), only
         // approximated values

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenIT.java
@@ -27,6 +27,8 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
@@ -36,9 +38,9 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
-@ScyllaSkip(
-    description =
-        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
+@ScyllaSkip(description = "scylladb/java-driver#568 - fails to start scylla")
+@BackendRequirement(type = BackendType.CASSANDRA)
+@BackendRequirement(type = BackendType.DSE)
 public class RandomTokenIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/RandomTokenVnodesIT.java
@@ -43,9 +43,7 @@ import org.junit.rules.TestRule;
     maxExclusive = "4.0-beta4",
     // TODO Re-enable when CASSANDRA-16364 is fixed
     description = "TODO Re-enable when CASSANDRA-16364 is fixed")
-@ScyllaSkip(
-    description =
-        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
+@ScyllaSkip(description = "scylladb/java-driver#568 - fails to start scylla")
 public class RandomTokenVnodesIT extends TokenITBase {
 
   private static final CustomCcmRule CCM_RULE =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -39,7 +39,6 @@ import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.core.type.DataTypes;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -199,9 +198,6 @@ public class SchemaIT {
       type = BackendType.CASSANDRA,
       minInclusive = "4.0",
       description = "virtual tables introduced in 4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
   @Test
   public void should_get_virtual_metadata() {
     skipIfDse60();
@@ -316,9 +312,6 @@ public class SchemaIT {
       type = BackendType.CASSANDRA,
       minInclusive = "4.0",
       description = "virtual tables introduced in 4.0")
-  @ScyllaSkip(
-      description =
-          "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality")
   @Test
   public void should_exclude_virtual_keyspaces_from_token_map() {
     skipIfDse60();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TabletMapSchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TabletMapSchemaChangesIT.java
@@ -12,7 +12,7 @@ import com.datastax.oss.driver.api.core.metadata.KeyspaceTableNamePair;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
     minOSS = "6.0.0",
     minEnterprise = "2024.2",
     description = "Needs to support tablets")
-@CassandraSkip(description = "Tablets are ScyllaDB-only extension")
+@ScyllaOnly(description = "Tablets are ScyllaDB-only extension")
 // Ensures that TabletMap used by MetadataManager behaves as desired on certain events
 public class TabletMapSchemaChangesIT {
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -1,17 +1,16 @@
 package com.datastax.oss.driver.core.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
-import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -20,25 +19,14 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
+@ScyllaRequirement(minOSS = "6.2.0", minEnterprise = "2025.1.0")
 public class ZeroTokenNodesIT {
-  @Before
-  public void checkScyllaVersion() {
-    // minOSS = "6.2.0",
-    // minEnterprise = "2025.1.0",
-    // Zero-token nodes introduced in scylladb/scylladb#19684
-    // 2025.1 is an estimated future version and it still may not have this change in.
-    // This number may need to be adjusted once CI picks up this test.
-    assumeTrue(CcmBridge.isDistributionOf(BackendType.SCYLLA));
-    if (CcmBridge.SCYLLA_ENTERPRISE) {
-      assumeTrue(
-          CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("2025.1.0"))) >= 0);
-    } else {
-      assumeTrue(CcmBridge.VERSION.compareTo(Objects.requireNonNull(Version.parse("6.2.0"))) >= 0);
-    }
-  }
+  // For tests to pick up @ScyllaRequirement annotation
+  @ClassRule
+  public static final BackendRequirementRule backendRequirementRule = new BackendRequirementRule();
 
   @Test
   public void should_not_ignore_zero_token_peer_when_option_is_enabled() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
@@ -11,7 +11,7 @@ import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.session.Session;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.LoggerFactory;
 
-@CassandraSkip(description = "Advanced shard awareness relies on ScyllaDB's shard aware port")
+@ScyllaOnly(description = "Advanced shard awareness relies on ScyllaDB's shard aware port")
 @RunWith(DataProviderRunner.class)
 public class AdvancedShardAwarenessIT {
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
@@ -30,8 +30,10 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.token.TokenRange;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
@@ -40,16 +42,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
-@ScyllaSkip(
-    description = "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledCCMFailure")
 public class AddedNodeIT {
+  @Rule public final BackendRequirementRule backendRequirementRule = new BackendRequirementRule();
 
   @ClassRule
   public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(3).build();
 
   @Test
+  @BackendRequirement(type = BackendType.SCYLLA)
+  // It is broken for cassandra: https://github.com/scylladb/java-driver/issues/575
   public void should_signal_and_create_pool_when_node_gets_added() {
     AddListener addListener = new AddListener();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, null, addListener, null, null)) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
@@ -24,7 +24,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.token.TokenRange;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-@ScyllaSkip(description = "@IntegrationTestDisabledFlaky")
 public class RemovedNodeIT {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultNullSavingStrategyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultNullSavingStrategyIT.java
@@ -60,6 +60,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "2.2",
     description = "support for unset values")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class DefaultNullSavingStrategyIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
@@ -58,6 +58,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "3.0",
     description = ">= in WHERE clause not supported in legacy versions")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class DeleteIT extends InventoryITBase {
 
   private static CustomCcmRule CCM_RULE = CustomCcmRule.builder().build();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementWithNullsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementWithNullsIT.java
@@ -46,6 +46,7 @@ import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class IncrementWithNullsIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/NestedUdtIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/NestedUdtIT.java
@@ -69,6 +69,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "2.2",
     description = "support for unset values")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class NestedUdtIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/PrimitivesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/PrimitivesIT.java
@@ -49,6 +49,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "2.2",
     description = "smallint is a reserved keyword in 2.1")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class PrimitivesIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectBypassCacheIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectBypassCacheIT.java
@@ -39,7 +39,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -54,7 +54,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
-@CassandraSkip(description = "BYPASS CACHE clause is a ScyllaDB CQL Extension")
+@ScyllaOnly(description = "BYPASS CACHE clause is a ScyllaDB CQL Extension")
 @ScyllaRequirement(
     minOSS = "3.1.0",
     minEnterprise = "2020.1.0",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
@@ -40,7 +40,6 @@ import com.datastax.oss.driver.api.mapper.annotations.Delete;
 import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -58,9 +57,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
-@ScyllaSkip(
-    description =
-        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex")
 @BackendRequirement(
     type = BackendType.CASSANDRA,
     minInclusive = "3.4",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
@@ -64,6 +64,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "3.6",
     description = "Uses PER PARTITION LIMIT")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class SelectOtherClausesIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateCustomIfClauseIT.java
@@ -38,7 +38,6 @@ import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -56,8 +55,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
-@ScyllaSkip(
-    description = "@IntegrationTestDisabledScyllaFailure") // Test hangs in setup() in productDao()
 @BackendRequirement(
     type = BackendType.CASSANDRA,
     minInclusive = "3.11.0",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateReactiveIT.java
@@ -39,7 +39,6 @@ import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
-import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -61,9 +60,6 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "3.6",
     description = "Uses UDT fields in IF conditions (CASSANDRA-7423)")
-@ScyllaSkip(
-    description =
-        "@IntegrationTestDisabledScyllaFailure @IntegrationTestDisabledScyllaUnsupportedFunctionality @IntegrationTestDisabledScyllaUnsupportedIndex")
 public class UpdateReactiveIT extends InventoryITBase {
 
   private static CcmRule ccmRule = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UsingTimeoutIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UsingTimeoutIT.java
@@ -19,7 +19,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.annotations.Update;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -32,7 +32,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
-@CassandraSkip(description = "USING TIMEOUT is a ScyllaDB CQL Extension")
+@ScyllaOnly(description = "USING TIMEOUT is a ScyllaDB CQL Extension")
 @ScyllaRequirement(
     minOSS = "4.4.0",
     minEnterprise = "2022.1.0",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/JsonInsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/JsonInsertIT.java
@@ -56,6 +56,7 @@ import org.junit.rules.TestRule;
     type = BackendType.CASSANDRA,
     minInclusive = "2.2",
     description = "JSON support in Cassandra was added in 2.2")
+@BackendRequirement(type = BackendType.SCYLLA)
 public class JsonInsertIT {
   private static final CcmRule CCM_RULE = CcmRule.getInstance();
 

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmPaxExam.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmPaxExam.java
@@ -17,15 +17,7 @@
  */
 package com.datastax.oss.driver.internal.osgi.support;
 
-import static com.datastax.oss.driver.internal.osgi.support.CcmStagedReactor.CCM_BRIDGE;
-
-import com.datastax.oss.driver.api.core.Version;
-import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
-import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
-import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
-import java.util.Objects;
-import java.util.Optional;
 import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -42,53 +34,6 @@ public class CcmPaxExam extends PaxExam {
   @Override
   public void run(RunNotifier notifier) {
     Description description = getDescription();
-    ScyllaRequirement scyllaRequirement = description.getAnnotation(ScyllaRequirement.class);
-    if (scyllaRequirement != null) {
-      Optional<Version> scyllaVersionOption = CCM_BRIDGE.getScyllaVersion();
-      if (!scyllaVersionOption.isPresent()) {
-        notifier.fireTestAssumptionFailed(
-            new Failure(
-                description,
-                new AssumptionViolatedException("Test Requires Scylla but it is not configured.")));
-        return;
-      }
-      Version scyllaVersion = scyllaVersionOption.get();
-      if (CcmBridge.SCYLLA_ENTERPRISE) {
-        if (!scyllaRequirement.minEnterprise().isEmpty()) {
-          Version minVersion =
-              Objects.requireNonNull(Version.parse(scyllaRequirement.minEnterprise()));
-          if (minVersion.compareTo(scyllaVersion) > 0) {
-            fireRequirementsNotMet(
-                notifier, description, scyllaRequirement.minEnterprise(), false, false);
-            return;
-          }
-        }
-        if (!scyllaRequirement.maxEnterprise().isEmpty()) {
-          Version maxVersion =
-              Objects.requireNonNull(Version.parse(scyllaRequirement.maxEnterprise()));
-          if (maxVersion.compareTo(scyllaVersion) <= 0) {
-            fireRequirementsNotMet(
-                notifier, description, scyllaRequirement.maxEnterprise(), true, false);
-            return;
-          }
-        }
-      } else {
-        if (!scyllaRequirement.minOSS().isEmpty()) {
-          Version minVersion = Objects.requireNonNull(Version.parse(scyllaRequirement.minOSS()));
-          if (minVersion.compareTo(scyllaVersion) > 0) {
-            fireRequirementsNotMet(notifier, description, scyllaRequirement.minOSS(), false, false);
-            return;
-          }
-        }
-        if (!scyllaRequirement.maxOSS().isEmpty()) {
-          Version maxVersion = Objects.requireNonNull(Version.parse(scyllaRequirement.maxOSS()));
-          if (maxVersion.compareTo(CcmBridge.VERSION) <= 0) {
-            fireRequirementsNotMet(notifier, description, scyllaRequirement.maxOSS(), true, false);
-            return;
-          }
-        }
-      }
-    }
 
     if (BackendRequirementRule.meetsDescriptionRequirements(description)) {
       super.run(notifier);
@@ -98,27 +43,5 @@ public class CcmPaxExam extends PaxExam {
           new AssumptionViolatedException(BackendRequirementRule.buildReasonString(description));
       notifier.fireTestAssumptionFailed(new Failure(description, e));
     }
-  }
-
-  private void fireRequirementsNotMet(
-      RunNotifier notifier,
-      Description description,
-      String requirement,
-      boolean lessThan,
-      boolean dse) {
-    AssumptionViolatedException e =
-        new AssumptionViolatedException(
-            String.format(
-                "Test requires %s %s %s but %s is configured.  Description: %s",
-                lessThan ? "less than" : "at least",
-                dse ? "DSE" : (CcmBridge.isDistributionOf(BackendType.SCYLLA) ? "SCYLLA" : "C*"),
-                requirement,
-                dse
-                    ? CCM_BRIDGE.getDseVersion().orElse(null)
-                    : (CcmBridge.isDistributionOf(BackendType.SCYLLA)
-                        ? CCM_BRIDGE.getScyllaVersion().orElse(null)
-                        : CCM_BRIDGE.getCassandraVersion()),
-                description));
-    notifier.fireTestAssumptionFailed(new Failure(description, e));
   }
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ScyllaOnly.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ScyllaOnly.java
@@ -18,12 +18,9 @@ package com.datastax.oss.driver.api.testinfra;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-/**
- * Annotation for a Class or Method that skips it for Cassandra. If the tests are run against
- * Cassandra, the test is skipped.
- */
+/** Annotation for a Class or Method that skips for non-Scylla backend. */
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CassandraSkip {
+public @interface ScyllaOnly {
   /** @return The description returned if this requirement is not met. */
-  String description() default "Disabled for Cassandra.";
+  String description() default "Supported only for Scylla.";
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -28,7 +28,7 @@ import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
-import com.datastax.oss.driver.api.testinfra.CassandraSkip;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
@@ -87,8 +87,8 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
       }
     }
 
-    CassandraSkip cassandraSkip = description.getAnnotation(CassandraSkip.class);
-    if (cassandraSkip != null) {
+    ScyllaOnly scyllaOnly = description.getAnnotation(ScyllaOnly.class);
+    if (scyllaOnly != null) {
       if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
         return new Statement() {
 
@@ -96,7 +96,8 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
           public void evaluate() {
             throw new AssumptionViolatedException(
                 String.format(
-                    "Test skipped when running with Cassandra.  Description: %s", description));
+                    "Test skipped when running against non-scylla backend.  Description: %s",
+                    description));
           }
         };
       }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -29,15 +29,12 @@ import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
 import com.datastax.oss.driver.api.testinfra.CassandraSkip;
-import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
 import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import java.net.InetSocketAddress;
 import java.util.Collections;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
@@ -72,33 +69,8 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     ccmBridge.close();
   }
 
-  private Statement buildErrorStatement(
-      Version requirement, String description, boolean lessThan, boolean dse) {
-    return new Statement() {
-
-      @Override
-      public void evaluate() {
-        throw new AssumptionViolatedException(
-            String.format(
-                "Test requires %s %s %s but %s is configured.  Description: %s",
-                lessThan ? "less than" : "at least",
-                dse ? "DSE" : (CcmBridge.isDistributionOf(BackendType.SCYLLA) ? "SCYLLA" : "C*"),
-                requirement,
-                dse
-                    ? ccmBridge.getDseVersion().orElse(null)
-                    : (CcmBridge.isDistributionOf(BackendType.SCYLLA)
-                        ? ccmBridge.getScyllaVersion().orElse(null)
-                        : ccmBridge.getCassandraVersion()),
-                description));
-      }
-    };
-  }
-
   @Override
   public Statement apply(Statement base, Description description) {
-
-    // Legacy skipping:
-
     // Scylla-specific annotations
     ScyllaSkip scyllaSkip = description.getAnnotation(ScyllaSkip.class);
     if (scyllaSkip != null) {
@@ -127,50 +99,6 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
                     "Test skipped when running with Cassandra.  Description: %s", description));
           }
         };
-      }
-    }
-
-    ScyllaRequirement scyllaRequirement = description.getAnnotation(ScyllaRequirement.class);
-    if (scyllaRequirement != null) {
-      Optional<Version> scyllaVersionOption = ccmBridge.getScyllaVersion();
-      if (!scyllaVersionOption.isPresent()) {
-        return new Statement() {
-          @Override
-          public void evaluate() {
-            throw new AssumptionViolatedException(
-                "Test has Scylla version requirement, but CCMBridge is not configured for Scylla.");
-          }
-        };
-      }
-      Version scyllaVersion = scyllaVersionOption.get();
-      if (CcmBridge.SCYLLA_ENTERPRISE) {
-        if (!scyllaRequirement.minEnterprise().isEmpty()) {
-          Version minVersion =
-              Objects.requireNonNull(Version.parse(scyllaRequirement.minEnterprise()));
-          if (minVersion.compareTo(scyllaVersion) > 0) {
-            return buildErrorStatement(minVersion, scyllaRequirement.description(), false, false);
-          }
-        }
-        if (!scyllaRequirement.maxEnterprise().isEmpty()) {
-          Version maxVersion =
-              Objects.requireNonNull(Version.parse(scyllaRequirement.maxEnterprise()));
-          if (maxVersion.compareTo(scyllaVersion) <= 0) {
-            return buildErrorStatement(maxVersion, scyllaRequirement.description(), true, false);
-          }
-        }
-      } else {
-        if (!scyllaRequirement.minOSS().isEmpty()) {
-          Version minVersion = Objects.requireNonNull(Version.parse(scyllaRequirement.minOSS()));
-          if (minVersion.compareTo(scyllaVersion) > 0) {
-            return buildErrorStatement(minVersion, scyllaRequirement.description(), false, false);
-          }
-        }
-        if (!scyllaRequirement.maxOSS().isEmpty()) {
-          Version maxVersion = Objects.requireNonNull(Version.parse(scyllaRequirement.maxOSS()));
-          if (maxVersion.compareTo(CcmBridge.VERSION) <= 0) {
-            return buildErrorStatement(maxVersion, scyllaRequirement.description(), true, false);
-          }
-        }
       }
     }
 

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirement.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirement.java
@@ -20,6 +20,8 @@ package com.datastax.oss.driver.api.testinfra.requirement;
 import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.DseRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -97,15 +99,33 @@ public class VersionRequirement {
         BackendType.DSE, requirement.min(), requirement.max(), requirement.description());
   }
 
+  public static VersionRequirement fromScyllaOssRequirement(ScyllaRequirement requirement) {
+    return new VersionRequirement(
+        BackendType.SCYLLA,
+        requirement.minOSS(),
+        !requirement.maxOSS().isEmpty() ? requirement.maxOSS() : "2000.0.0",
+        requirement.description());
+  }
+
+  public static VersionRequirement fromScyllaEnterpriseRequirement(ScyllaRequirement requirement) {
+    return new VersionRequirement(
+        BackendType.SCYLLA,
+        !requirement.minEnterprise().isEmpty() ? requirement.minEnterprise() : "2000.0.0",
+        requirement.maxEnterprise(),
+        requirement.description());
+  }
+
   public static Collection<VersionRequirement> fromAnnotations(Description description) {
     // collect all requirement annotation types
     CassandraRequirement cassandraRequirement =
         description.getAnnotation(CassandraRequirement.class);
     DseRequirement dseRequirement = description.getAnnotation(DseRequirement.class);
+    ScyllaRequirement scyllaRequirement = description.getAnnotation(ScyllaRequirement.class);
     // matches methods/classes with one @BackendRequirement annotation
     BackendRequirement backendRequirement = description.getAnnotation(BackendRequirement.class);
     // matches methods/classes with two or more @BackendRequirement annotations
     BackendRequirements backendRequirements = description.getAnnotation(BackendRequirements.class);
+    ScyllaSkip scyllaSkip = description.getAnnotation(ScyllaSkip.class);
 
     // build list of required versions
     Collection<VersionRequirement> requirements = new ArrayList<>();
@@ -114,6 +134,19 @@ public class VersionRequirement {
     }
     if (dseRequirement != null) {
       requirements.add(VersionRequirement.fromDseRequirement(dseRequirement));
+    }
+    if (scyllaSkip != null) {
+      requirements.add(
+          new VersionRequirement(BackendType.SCYLLA, "0.0.0", "1.0.0", scyllaSkip.description()));
+    }
+    if (scyllaRequirement != null) {
+      if (!scyllaRequirement.minEnterprise().isEmpty()
+          || !scyllaRequirement.maxEnterprise().isEmpty()) {
+        requirements.add(VersionRequirement.fromScyllaEnterpriseRequirement(scyllaRequirement));
+      }
+      if (!scyllaRequirement.minOSS().isEmpty() || !scyllaRequirement.maxOSS().isEmpty()) {
+        requirements.add(VersionRequirement.fromScyllaOssRequirement(scyllaRequirement));
+      }
     }
     if (backendRequirement != null) {
       requirements.add(VersionRequirement.fromBackendRequirement(backendRequirement));


### PR DESCRIPTION
Does the following:
1. Rename CassnadraSkip to ScyllaOnly
2. Go over disabled tests and enable them.
If test fails:
- Make test framework ignore it with proper message
- If it is scylla bug or test needs to be adjusted, create an issue and reference it
- Fix test to match scylla behavior

Consider that there are two ways to disable test for scylla:
- Mark it with @ScyllaSkip
- Mark it with any backend requirement annotation: @CassandraRequirement, @DseRequirement, @BackendRequirement; and do not add sylla-specific requirement.

