### PR TITLE
4.x: Stabilize metrics integration tests

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
 import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(ParallelizableTests.class)
+// Not parallelizable because of unsynchronized concurrent access to the
+// AbstractMetricUpdater.MIN_EXPIRE_AFTER
 public class DropwizardMetricsIT extends MetricsITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.core.metrics.MetricsITBase;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
@@ -40,11 +39,9 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.experimental.categories.Category;
 
-@Ignore("@IntegrationTestDisabledFlaky")
-@Category(ParallelizableTests.class)
+// Not parallelizable because of unsynchronized concurrent access to the
+// AbstractMetricUpdater.MIN_EXPIRE_AFTER
 public class MicrometerMetricsIT extends MetricsITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.core.metrics.MetricsITBase;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(ParallelizableTests.class)
+// Not parallelizable because of unsynchronized concurrent access to the
+// AbstractMetricUpdater.MIN_EXPIRE_AFTER
 public class MicroProfileMetricsIT extends MetricsITBase {
 
   @ClassRule


### PR DESCRIPTION
Removes DropwizardMetricsIT, MicroProfileMetricsIT, MicrometerMetricsIT from parallelizable tests category, making them serial. Additionally enables MicrometerMetricsIT which was previously ignored due to flakiness.

`should_evict_down_node_metrics_when_timeout_fires` in MetricsITBase relies on setting static field `MIN_EXPIRE_AFTER` in AbstractMetricUpdater and then setting it back to 5 minutes.
Those three test classes inherit this test method and when they run concurrently it sometimes results in setting the minimal expire time back to 5 minutes before another test initializes its session with expire time set to 1 second. This can be evidenced by the appearance of lines like
```
 c.d.o.d.i.c.m.AbstractMetricUpdater - [s6] Value too low for advanced.metrics.node.expire-after: PT1S. Forcing to PT5M instead.
```
whenever that method fails. It does not appear when the test passes (due to lucky schedule).
Making those tests serial seems to be the simplest solution.