### PR TITLE
Recalculate maxQueueSize based on shards count

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -514,6 +514,7 @@ class HostConnectionPool implements Connection.Owner {
 
     int shardId = 0;
     if (host.getShardingInfo() != null) {
+      maxQueueSize = host.getShardingInfo().getShardsCount() * maxQueueSize;
       if (routingKey != null) {
         Metadata metadata = manager.cluster.getMetadata();
         Token t = metadata.newToken(partitioner, routingKey);

--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -462,7 +462,8 @@ public class PoolingOptions {
   }
 
   /**
-   * Returns the maximum number of requests that get enqueued if no connection is available.
+   * Returns the maximum number of requests per shard that get enqueued if no connection is
+   * available.
    *
    * @return the maximum queue size.
    */


### PR DESCRIPTION
Currently `maxQueueSize` is `256` by default.
Problem is that some hosts can have 1 shard, others can have `256` shards. 
While having cap of `256` pending requests for `1` shard host is ok, for bigger host of `256` shards it is way to low.
This commit scales `maxQueueSize` by number of shards, which allow default value works for hosts of any size.

Fix: https://github.com/scylladb/java-driver/issues/577