### PR TITLE
4.x: dependancy: update graal-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <awaitility.version>4.0.3</awaitility.version>
     <apacheds.version>2.0.0-M19</apacheds.version>
     <surefire.version>3.0.0</surefire.version>
-    <graalapi.version>22.0.0.2</graalapi.version>
+    <graalapi.version>24.2.2</graalapi.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
     <pushChanges>false</pushChanges>


### PR DESCRIPTION
Current version have:
2 CRITICAL: CVE-2024-21147 and CVE-2025-21587
6 HIGH and 14 MEDIUM security issues.

Let's update to the topmost version.