### PR TITLE
dependancy: update apache-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <lz4.version>1.7.1</lz4.version>
     <!-- test dependencies -->
     <assertj.version>3.19.0</assertj.version>
-    <commons-exec.version>1.3</commons-exec.version>
+    <commons-exec.version>1.5.0</commons-exec.version>
     <junit.version>4.13.2</junit.version>
     <logback.version>1.2.13</logback.version>
     <osgi.version>6.0.0</osgi.version>


### PR DESCRIPTION
Current version `1.3` contains high risk issue: CVE-2025-48924