### PR TITLE
Cleanup tablets code

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
@@ -141,7 +141,7 @@ public class TabletMap {
       HostShardPair hostShardPair = new HostShardPair(tuple.getUUID(0), tuple.getInt(1));
       replicas.add(hostShardPair);
     }
-    Tablet newTablet = new Tablet(keyspace, null, table, firstToken, lastToken, replicas);
+    Tablet newTablet = new Tablet(keyspace, table, firstToken, lastToken, replicas);
 
     TabletSet tabletSet = mapping.computeIfAbsent(ktPair, k -> new TabletSet());
     Lock writeLock = tabletSet.lock.writeLock();
@@ -316,7 +316,6 @@ public class TabletMap {
    */
   public static class Tablet implements Comparable<Tablet> {
     private final String keyspaceName;
-    private final UUID tableId; // currently null almost everywhere
     private final String tableName;
     private final long firstToken;
     private final long lastToken;
@@ -324,13 +323,11 @@ public class TabletMap {
 
     private Tablet(
         String keyspaceName,
-        UUID tableId,
         String tableName,
         long firstToken,
         long lastToken,
         List<HostShardPair> replicas) {
       this.keyspaceName = keyspaceName;
-      this.tableId = tableId;
       this.tableName = tableName;
       this.firstToken = firstToken;
       this.lastToken = lastToken;
@@ -345,15 +342,11 @@ public class TabletMap {
      * @return New {@link Tablet} object
      */
     public static Tablet malformedTablet(long lastToken) {
-      return new Tablet(null, null, null, lastToken, lastToken, null);
+      return new Tablet(null, null, lastToken, lastToken, null);
     }
 
     public String getKeyspaceName() {
       return keyspaceName;
-    }
-
-    public UUID getTableId() {
-      return tableId;
     }
 
     public String getTableName() {
@@ -378,8 +371,6 @@ public class TabletMap {
           + "keyspaceName='"
           + keyspaceName
           + '\''
-          + ", tableId="
-          + tableId
           + ", tableName='"
           + tableName
           + '\''
@@ -400,14 +391,13 @@ public class TabletMap {
       return firstToken == that.firstToken
           && lastToken == that.lastToken
           && keyspaceName.equals(that.keyspaceName)
-          && Objects.equals(tableId, that.tableId)
           && tableName.equals(that.tableName)
           && Objects.equals(replicas, that.replicas);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(keyspaceName, tableId, tableName, firstToken, lastToken, replicas);
+      return Objects.hash(keyspaceName, tableName, firstToken, lastToken, replicas);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
@@ -141,7 +141,7 @@ public class TabletMap {
       HostShardPair hostShardPair = new HostShardPair(tuple.getUUID(0), tuple.getInt(1));
       replicas.add(hostShardPair);
     }
-    Tablet newTablet = new Tablet(keyspace, table, firstToken, lastToken, replicas);
+    Tablet newTablet = new Tablet(firstToken, lastToken, replicas);
 
     TabletSet tabletSet = mapping.computeIfAbsent(ktPair, k -> new TabletSet());
     Lock writeLock = tabletSet.lock.writeLock();
@@ -315,20 +315,11 @@ public class TabletMap {
    * for quick lookup on sorted Collections based just on the token value.
    */
   public static class Tablet implements Comparable<Tablet> {
-    private final String keyspaceName;
-    private final String tableName;
     private final long firstToken;
     private final long lastToken;
     private final List<HostShardPair> replicas;
 
-    private Tablet(
-        String keyspaceName,
-        String tableName,
-        long firstToken,
-        long lastToken,
-        List<HostShardPair> replicas) {
-      this.keyspaceName = keyspaceName;
-      this.tableName = tableName;
+    private Tablet(long firstToken, long lastToken, List<HostShardPair> replicas) {
       this.firstToken = firstToken;
       this.lastToken = lastToken;
       this.replicas = replicas;
@@ -342,15 +333,7 @@ public class TabletMap {
      * @return New {@link Tablet} object
      */
     public static Tablet malformedTablet(long lastToken) {
-      return new Tablet(null, null, lastToken, lastToken, null);
-    }
-
-    public String getKeyspaceName() {
-      return keyspaceName;
-    }
-
-    public String getTableName() {
-      return tableName;
+      return new Tablet(lastToken, lastToken, null);
     }
 
     public long getFirstToken() {
@@ -368,13 +351,7 @@ public class TabletMap {
     @Override
     public String toString() {
       return "LazyTablet{"
-          + "keyspaceName='"
-          + keyspaceName
-          + '\''
-          + ", tableName='"
-          + tableName
-          + '\''
-          + ", firstToken="
+          + "firstToken="
           + firstToken
           + ", lastToken="
           + lastToken
@@ -390,14 +367,12 @@ public class TabletMap {
       Tablet that = (Tablet) o;
       return firstToken == that.firstToken
           && lastToken == that.lastToken
-          && keyspaceName.equals(that.keyspaceName)
-          && tableName.equals(that.tableName)
           && Objects.equals(replicas, that.replicas);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(keyspaceName, tableName, firstToken, lastToken, replicas);
+      return Objects.hash(firstToken, lastToken, replicas);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
@@ -350,7 +350,7 @@ public class TabletMap {
 
     @Override
     public String toString() {
-      return "LazyTablet{"
+      return "Tablet{"
           + "firstToken="
           + firstToken
           + ", lastToken="

--- a/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TabletMap.java
@@ -84,7 +84,7 @@ public class TabletMap {
     Lock readLock = tabletSet.lock.readLock();
     try {
       readLock.lock();
-      Tablet row = mapping.get(key).tablets.ceiling(Tablet.malformedTablet(token));
+      Tablet row = tabletSet.tablets.ceiling(Tablet.malformedTablet(token));
       if (row == null || row.firstToken >= token) {
         logger.trace(
             "Could not find tablet for {}.{} that owns token {}. Returning empty set.",


### PR DESCRIPTION
This PR cleanups tablets code to reduce tablet memory and CPU footprint.
And couple of nearly cosmetic changes.
1. Removes unused fields: tabletId, keyspace, table
2. Changes class name in the toString
3. Reuses tabletSet
