### PR TITLE
heartbeat: ignore "Connection has been closed" error

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1592,7 +1592,13 @@ class Connection {
             "{} was inactive for {} seconds, sending heartbeat",
             Connection.this,
             factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds());
-        write(HEARTBEAT_CALLBACK);
+        try {
+          write(HEARTBEAT_CALLBACK);
+        } catch (ConnectionException e) {
+          if (!e.getMessage().contains("Connection has been closed")) {
+            throw e;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
It can happen that connection is being closed between `isClosed()` from userEventTriggered `isClosed()` from `write()`.
Which will result in netty event loop printing warning. 
Not a big deal, but it confuses QA in regards of the analyzing if this is a real error or not.
So, let's just ignore it.

Closes: https://github.com/scylladb/java-driver/issues/585