### PR TITLE
3.x: migrate to sonatype central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,20 @@ name: Release ScyllaDB Java Driver
 on:
   workflow_dispatch:
     inputs:
-      dryrun:
+      dry-run:
         type: boolean
-        description: 'dryrun: run without pushing SCM changes to upstream'
-        default: true
+        description: 'dry-run: run without pushing SCM changes to upstream'
+        default: false
+
+      skip-tests:
+        type: boolean
+        description: 'skip-tests: do not run tests while releasing'
+        default: false
+
+      target-tag:
+        type: string
+        description: 'target-tag: tag or branch name to release. Use to to re-release failed releases'
+        default: scylla-3.x
 
 jobs:
   release:
@@ -20,44 +30,79 @@ jobs:
       MVNCMD: mvn -B -X -ntp
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-        server-id: ossrh
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-        server-username: OSSRH_USERNAME
-        server-password: OSSRH_PASSWORD
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
+        if: inputs.target-tag != 'scylla-3.x'
+        run: |
+          git fetch --prune --unshallow || true
+          git checkout ${{ inputs.target-tag }}~1
+          git tag -d ${{ inputs.target-tag }}
 
-    - name: Configure Git user
-      run: |
-        git config user.name "ScyllaDB Promoter"
-        git config user.email "github-promoter@scylladb.com"
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: central
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          server-username: SONATYPE_TOKEN_USERNAME
+          server-password: SONATYPE_TOKEN_PASSWORD
 
-    - name: Clean project
-      run: $MVNCMD clean
+      - name: Configure Git user
+        run: |
+          git config user.name "ScyllaDB Promoter"
+          git config user.email "github-promoter@scylladb.com"
 
-    - name: Clean release
-      run: $MVNCMD release:clean
+      - name: Clean project
+        run: $MVNCMD clean
 
-    - name: Prepare release
-      env:
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      run: $MVNCMD release:prepare -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+      - name: Clean release
+        run: $MVNCMD release:clean
 
-    - name: Perform release
-      env:
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      run: $MVNCMD release:perform -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+      - name: Prepare release
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [[ "${{ inputs.skip-tests }}" == "true" ]]; then
+            MAVEN_OPTS="${MAVEN_OPTS} -DskipTests=true -DskipITs=true"
+          fi
+          export MAVEN_OPTS
+          $MVNCMD release:prepare -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
-    - name: Push changes to SCM
-      if: ${{ github.event.inputs.dryrun == 'false' }}
-      run: |
-        git status && git log -3
-        git push origin --follow-tags -v
+      - name: Perform release
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
+        run: |
+          CMD_OPTS=""
+          if [[ "${{ inputs.dry-run }}" != "true" ]]; then
+            CMD_OPTS="-Drelease.autopublish=true"
+          fi
+          if [[ "${{ inputs.skip-tests }}" == "true" ]]; then
+            MAVEN_OPTS="${MAVEN_OPTS} -DskipTests=true -DskipITs=true"
+          fi
+          export MAVEN_OPTS
+          $MVNCMD release:perform $CMD_OPTS -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} > >(tee /tmp/logs-stdout.log) 2> >(tee /tmp/logs-stderr.log)
+
+      - name: Upload stdout.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-stdout
+          path: /tmp/logs-stdout.log
+
+      - name: Upload stderr.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-stderr
+          path: /tmp/logs-stderr.log
+
+      - name: Push changes to SCM
+        if: ${{ inputs.dry-run == 'false' && inputs.target-tag == 'scylla-3.x' }}
+        run: |
+          git status && git log -3
+          git push origin --follow-tags -v

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -144,13 +144,6 @@
                             <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -94,7 +94,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -188,23 +188,4 @@
 
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
-    </profiles>
-
 </project>

--- a/driver-tests/osgi/unshaded/pom.xml
+++ b/driver-tests/osgi/unshaded/pom.xml
@@ -25,7 +25,7 @@
         <version>3.11.5.8-SNAPSHOT</version>
     </parent>
 
-    <artifactId>cassandra-driver-tests-osgi-unshaded</artifactId>
+    <artifactId>scylla-driver-tests-osgi-unshaded</artifactId>
     <name>Java Driver for Scylla and Apache Cassandra Tests - OSGi - Unshaded</name>
     <description>A test for the unshaded Java Driver in an OSGi container.</description>
 

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -91,23 +91,4 @@
 
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-    </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -819,27 +819,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.5</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                            <configuration>
-                                <gpgArguments>
-                                    <arg>--pinentry-mode</arg>
-                                    <arg>loopback</arg>
-                                </gpgArguments>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
                     <groupId>org.ops4j</groupId>
                     <artifactId>maven-pax-plugin</artifactId>
                     <version>1.6.0</version>
@@ -903,38 +882,16 @@
                     <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.8</version>
+            </plugin>
         </plugins>
 
     </build>
 
     <profiles>
-
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <profile>
             <id>short</id>

--- a/pom.xml
+++ b/pom.xml
@@ -542,14 +542,15 @@
                         <quiet>true</quiet>
                         <verbose>false</verbose>
                         <additionalparam>${javadoc.opts}</additionalparam>
+                        <detectJavaApiLink>true</detectJavaApiLink>
                         <links>
-                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>https://javadoc.io/doc/javax/javaee-api/8.0/</link>
                             <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
                             <link>http://netty.io/4.0/api/</link>
                             <link>http://www.joda.org/joda-time/apidocs/</link>
                             <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
                             <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
-                            <link>https://javaee-spec.java.net/nonav/javadocs/</link>
+                            <link>https://jakarta.ee/specifications/platform/8/apidocs/</link>
                         </links>
                         <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
                         <additionalDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,8 @@
              regular netty-tcnative.
         <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
         -->
+        <gpg.passphrase/>
+        <release.autopublish>false</release.autopublish>
     </properties>
 
     <dependencyManagement>
@@ -638,14 +640,12 @@
                     <configuration>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <!-- useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
-                        <goals>deploy</goals-->
+                        <useReleaseProfile>false</useReleaseProfile>
                         <localCheckout>true</localCheckout>
-                        <deployAtEnd>true</deployAtEnd>
                         <pushChanges>${pushChanges}</pushChanges>
                         <mavenExecutorId>forked-path</mavenExecutorId>
-                        <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                        <arguments>-Dgpg.passphrase=${gpg.passphrase} -Drelease.autopublish=${release.autopublish}</arguments>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -840,18 +840,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <groupId>org.ops4j</groupId>
                     <artifactId>maven-pax-plugin</artifactId>
                     <version>1.6.0</version>
@@ -903,7 +891,18 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <excludeArtifacts>scylla-driver-tests-parent,scylla-driver-tests-osgi,scylla-driver-tests-osgi-common,scylla-driver-tests-osgi-shaded,scylla-driver-tests-shading,scylla-driver-tests-shading-shaded,scylla-driver-tests-shading-unshaded,scylla-driver-tests-osgi-unshaded,scylla-driver-tests-stress,scylla-driver-dist,scylla-driver-examples</excludeArtifacts>
+                    <autoPublish>${release.autopublish}</autoPublish>
+                    <waitUntil>validated</waitUntil>
+                </configuration>
+            </plugin>
         </plugins>
 
     </build>
@@ -1054,17 +1053,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <!-- skipLocalStaging>true</skipLocalStaging -->
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -1130,12 +1118,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-releases</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Migrate from old sonatype API to new one:
1. Switch to `central-publishing-maven-plugin` instead of `nexus-staging-maven-plugin`
2. Since `central-publishing-maven-plugin` works in a different way, use `excludeArtifacts` to skip some artifacts instead of per-module `release` profile configuration
3. Rename `cassandra-driver-tests-osgi-unshaded` to `scylla-driver-tests-osgi-unshaded`
4. Address `maven-javadoc-plugin` issues
