### PR TITLE
3.x: apply driver matrix patches

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -119,13 +119,14 @@ public class ControlConnectionTest extends CCMTestsSupport {
     Cluster cluster = register(createClusterBuilder().build());
     Session session = cluster.connect();
     session.execute(
-        "create keyspace ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
-    session.execute("create type ks.foo (i int)");
+        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+    session.execute("create type ControlConnectionTest_ks.foo (i int)");
     cluster.close();
 
     // Second driver instance: read UDT definition
     Cluster cluster2 = register(createClusterBuilder().build());
-    UserType fooType = cluster2.getMetadata().getKeyspace("ks").getUserType("foo");
+    UserType fooType =
+        cluster2.getMetadata().getKeyspace("ControlConnectionTest_ks").getUserType("foo");
 
     assertThat(fooType.getFieldNames()).containsExactly("i");
   }

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -775,6 +775,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
    * @since 2.2.0
    */
   @Test(groups = "long")
+  @ScyllaSkip
   public void should_create_tombstone_when_null_value_on_bound_statement() {
     PreparedStatement prepared =
         session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");


### PR DESCRIPTION
Two last patches to integrate:
1. Make keyspace in should_parse_UDT_definitions_when_using_default_protocol_version be specific for test
2. Ignore should_create_tombstone_when_null_value_on_bound_statement on scylla