### PR TITLE
HdrReservoir: add hint to record error on how to fix it

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/HdrReservoir.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/HdrReservoir.java
@@ -90,7 +90,10 @@ public class HdrReservoir implements Reservoir {
     try {
       recorder.recordValue(value / 1000);
     } catch (ArrayIndexOutOfBoundsException e) {
-      LOG.warn("[{}] Recorded value ({}) is out of bounds, discarding", logPrefix, value);
+      LOG.warn(
+          "[{}] Recorded value ({}) is out of bounds, discarding. Set advanced.metrics.session.cql-requests.highest-latency to maximum possible request timeout to make it not happening.",
+          logPrefix,
+          value);
     }
   }
 


### PR DESCRIPTION
When HdrHistogram writes latency if latency is higher than maximum expected it throws error.
Driver catches this error and logs it.
Users get confused since there is no reciepe how to fix it.

Solution is to set `advanced.metrics.session.cql-requests.highest-latency` to maximum possible latency, which is request timeout. 
But since request timeout could be configured on the execution profile, we can't automatically tune highest-latency to match it. 
So, only good solution is to give user a hint in the log message.