### PR TITLE
4.x: Stabilize `will_cache_invalid_cql` test method.

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
@@ -31,8 +31,13 @@ import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor;
 import com.datastax.oss.driver.shaded.guava.common.base.Predicates;
 import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
+import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -118,6 +123,20 @@ public class PreparedStatementCancellationIT {
 
     CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
     CqlPrepareAsyncProcessor processor = findProcessor(session);
+    AtomicInteger removals = new AtomicInteger();
+
+    // Forcibly replace the cache with one that has a removal listener
+    Field cacheField = CqlPrepareAsyncProcessor.class.getDeclaredField("cache");
+    cacheField.setAccessible(true);
+    Cache<PrepareRequest, CompletableFuture<PreparedStatement>> newCache =
+        CacheBuilder.newBuilder()
+            .removalListener(
+                (evt) -> {
+                  removals.incrementAndGet();
+                })
+            .weakValues()
+            .build();
+    cacheField.set(processor, newCache);
     Cache<PrepareRequest, CompletableFuture<PreparedStatement>> cache = processor.getCache();
     assertThat(cache.size()).isEqualTo(0);
 
@@ -133,8 +152,9 @@ public class PreparedStatementCancellationIT {
       fail();
     } catch (Exception e) {
     }
-
-    assertThat(cache.size()).isEqualTo(1);
+    cache.cleanUp();
+    // If an entry was evicted, it had to be cached first
+    Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> removals.get() == 1);
   }
 
   @Test


### PR DESCRIPTION
The main issue is that it uses `cache.size()`.
While it may not be a bad idea to use that, the documentation mentions that it returns an approximate size of the cache. `CqlPrepareAsyncProcessor` actually invalidates the prepare requests that finish with errors (see `process` method). Such is the case with this test. The `PreparedStatement` gets cached for a really short period and then invalidated because of the exception.
Depending on the exact timings it would be correct for the cache to report either size 0 or size 1. Additionally the moment when the size gets updated may differ from the moments modifications to the cache contents are made.

This change is a quick workaround that should
achieve the same end result as the setup in PreparedStatementCachingIT. Here we use reflection to forcibly change the cache used by the request processor. Same type, but has removal listener added to it. Instead of relying on the uncertain cache size the test will listen for the removal from the cache.

The alternative would be reimplementing similar setup as in PreparedStatementCachingIT with some changes. That means having a test version of DefaultDriverContext, CqlPrepareAsyncProcessor, SessionBuilder and necessary methods, so that we could inject the listener without the reflection.

The other option is moving this test method to the PreparedStatementCachingIT, but then the cache's remove callback which is used there throughout the class needs to be adjusted specifically for this method.

Fixes #514 