### PR TITLE
4.x: Bump netty-handler to 4.1.127.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.2.37</metrics.version>
-    <netty.version>4.1.118.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in


### PR DESCRIPTION
Upgrade to 4.2 requires additional checks.
Settling for highest 4.1 for now.