### PR TITLE
fix(deps): update dependency org.assertj:assertj-core to v3.27.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,11 @@
         <version>${assertj.version}</version>
       </dependency>
       <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.17.7</version>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>2.28.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <snappy.version>1.1.10.8</snappy.version>
     <lz4.version>1.7.1</lz4.version>
     <!-- test dependencies -->
-    <assertj.version>3.19.0</assertj.version>
+    <assertj.version>3.27.6</assertj.version>
     <commons-exec.version>1.5.0</commons-exec.version>
     <junit.version>4.13.2</junit.version>
     <logback.version>1.2.13</logback.version>


### PR DESCRIPTION
Update assertj-core and add byte-buddy dependency with version that `assertj-core` needed.