### PR TITLE
release: release regular, non-shaded pom.xml

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -295,6 +295,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <artifactSet>
                         <includes>
                             <include>io.netty:*</include>


### PR DESCRIPTION
After updating `maven-shade-plugin` it start populating shaded pom file, instead of regular one.
As result shaded dependencies are not resolved for rugular jar. To fix it we make `maven-shade-plugin` to not produce shaded pom, which fixes the problem, but also makes shaded jar contain non-shaded pom.xml, which is not big deal.