### PR TITLE
4.x: Handle empty metadataid when metadataid feature is on

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -83,7 +83,7 @@
       <dependency>
         <groupId>com.scylladb</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.2.0</version>
+        <version>1.5.2.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -44,6 +44,7 @@ import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -679,6 +680,38 @@ public class PreparedStatementIT {
     CqlSession session = sessionRule.session();
     BoundStatement boundStatement = session.prepare(queryString).bind();
     assertThat(boundStatement.getRoutingKey()).isNull();
+  }
+
+  /**
+   * Verifies driver behavior when a prepared statement is created on a node that does not support
+   * the metadata ID feature, but later executed on a node that does. In this scenario, the metadata
+   * ID is {@code null}, yet the feature flag is enabled. The test ensures that such a mixed-node
+   * situation is handled gracefully without errors.
+   */
+  @Test
+  @ScyllaOnly
+  @SuppressWarnings("ConstantConditions")
+  public void should_handle_empty_metadata_id_when_executing_statement_when_supported() {
+    // given
+    CqlSession session = sessionRule.session();
+    PreparedStatement preparedStatement =
+        session.prepare("SELECT * FROM prepared_statement_test WHERE a = ?");
+    if (hasNoScyllaMetadataIdSupport()) {
+      assertThat(preparedStatement.getResultMetadataId()).isNull();
+    } else {
+      assertThat(preparedStatement.getResultMetadataId()).isNotNull();
+      preparedStatement.setResultMetadata(null, preparedStatement.getResultSetDefinitions());
+    }
+
+    // when
+    session.execute(preparedStatement.bind(1));
+
+    // then
+    if (hasNoScyllaMetadataIdSupport()) {
+      assertThat(preparedStatement.getResultMetadataId()).isNull();
+    } else {
+      assertThat(preparedStatement.getResultMetadataId()).isNotNull();
+    }
   }
 
   private static Iterable<Row> firstPageOf(CompletionStage<AsyncResultSet> stage) {


### PR DESCRIPTION
Updating `native-protocol` to `1.5.2.1` which includes fix for  proper empty `resultMetadataId` handling.