### PR TITLE
release: return back bom dependency definitions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,6 +33,60 @@
   <artifactId>java-driver-bom</artifactId>
   <packaging>pom</packaging>
   <name>Java driver for Scylla and Apache Cassandra(R) - Bill Of Materials</name>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-core-shaded</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-mapper-processor</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-mapper-runtime</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-query-builder</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-guava-shaded</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-test-infra</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-metrics-micrometer</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>java-driver-metrics-microprofile</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.scylladb</groupId>
+        <artifactId>native-protocol</artifactId>
+        <version>4.19.0.3-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <skipUnitTests>${skipTests}</skipUnitTests>
     <release.autopublish>false</release.autopublish>
     <pushChanges>false</pushChanges>
-    <mockitoopens.argline />
+    <mockitoopens.argline/>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
It was changed by https://github.com/scylladb/java-driver/pull/754, but unfortunately bom does not get dependencies unless they are referenced in the pom.xml.
Without these definitions BOM have empty dependency list

Fixes: https://github.com/scylladb/java-driver/issues/759