### PR TITLE
Update lz4-java to 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <metrics.version>3.2.6</metrics.version>
         <snappy.version>1.1.10.7</snappy.version>
-        <lz4.version>1.8.0</lz4.version>
+        <lz4.version>1.8.1</lz4.version>
         <hdr.version>2.2.2</hdr.version>
         <jackson.version>2.15.4</jackson.version>
         <joda.version>2.12.7</joda.version>


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-ORGLZ4-14151788