### PR TITLE
3.x: Update lz4 package

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <optional>true</optional>
         </dependency>

--- a/driver-tests/osgi/common/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/common/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -101,7 +101,7 @@ public class BundleOptions {
       public Option[] getOptions() {
         return options(
             systemProperty("cassandra.compression").value(ProtocolOptions.Compression.LZ4.name()),
-            mavenBundle("org.lz4", "lz4-java", getVersion("lz4.version")));
+            mavenBundle("at.yawk.lz4", "lz4-java", getVersion("lz4.version")));
       }
     };
   }

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -28,9 +28,9 @@ Maven dependency:
 
 ```xml
 <dependency>
-    <groupId>org.lz4</groupId>
+    <groupId>at.yawk.lz4</groupId>
     <artifactId>lz4-java</artifactId>
-    <version>1.4.1</version>
+    <version>1.9.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <metrics.version>3.2.6</metrics.version>
         <snappy.version>1.1.10.7</snappy.version>
-        <lz4.version>1.8.0</lz4.version>
+        <lz4.version>1.10.1</lz4.version>
         <hdr.version>2.2.2</hdr.version>
         <jackson.version>2.15.4</jackson.version>
         <joda.version>2.12.7</joda.version>
@@ -184,7 +184,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.lz4</groupId>
+                <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
                 <version>${lz4.version}</version>
             </dependency>
@@ -558,7 +558,7 @@
                                 <version>${snappy.version}</version>
                             </additionalDependency>
                             <additionalDependency>
-                                <groupId>org.lz4</groupId>
+                                <groupId>at.yawk.lz4</groupId>
                                 <artifactId>lz4-java</artifactId>
                                 <version>${lz4.version}</version>
                             </additionalDependency>


### PR DESCRIPTION
To address [CVE-2025-66566](https://github.com/advisories/GHSA-cmp6-m4wj-q63q) it does the following:
- Move from `org.lz4/lz4-java` to `at.yawk.lz4/lz4-java:1.10.1`
- Update documentation and examples

