### PR TITLE
4.x: Update lz4 library

### DIFF
--- a/NOTICE_binary.txt
+++ b/NOTICE_binary.txt
@@ -100,7 +100,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * LICENSE:
     * license/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/jpountz/lz4-java
+    * https://github.com/yawkat/lz4-java
 
 This product optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -78,7 +78,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <optional>true</optional>
     </dependency>
@@ -301,7 +301,7 @@
                   <version>${snappy.version}</version>
                 </additionalDependency>
                 <additionalDependency>
-                  <groupId>org.lz4</groupId>
+                  <groupId>at.yawk.lz4</groupId>
                   <artifactId>lz4-java</artifactId>
                   <version>${lz4.version}</version>
                 </additionalDependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,7 +67,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <optional>true</optional>
     </dependency>

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/insights/PlatformInfoFinderTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/insights/PlatformInfoFinderTest.java
@@ -77,7 +77,7 @@ public class PlatformInfoFinderTest {
         "com.fasterxml.jackson.core:jackson-annotations", withUnverifiedRuntimeVersion("2.8.11"));
     expected.put("com.fasterxml.jackson.core:jackson-core", withUnverifiedRuntimeVersion("2.8.11"));
     expected.put("io.netty:netty-handler", withUnverifiedRuntimeVersion("4.0.56.Final"));
-    expected.put("org.lz4:lz4-java", withUnverifiedRuntimeVersionOptional("1.4.1"));
+    expected.put("at.yawk.lz4:lz4-java", withUnverifiedRuntimeVersionOptional("1.8.1"));
     expected.put("org.hdrhistogram:HdrHistogram", withUnverifiedRuntimeVersionOptional("2.1.10"));
     expected.put("com.github.jnr:jffi", withUnverifiedRuntimeVersion("1.2.16"));
     expected.put("io.netty:netty-buffer", withUnverifiedRuntimeVersion("4.0.56.Final"));

--- a/core/src/test/resources/insights/test-dependencies.txt
+++ b/core/src/test/resources/insights/test-dependencies.txt
@@ -17,7 +17,7 @@ The following files have been resolved:
    com.fasterxml.jackson.core:jackson-core:jar:2.8.11:compile
    org.hdrhistogram:HdrHistogram:jar:2.1.10:compile (optional)
    org.ow2.asm:asm-tree:jar:5.0.3:compile
-   org.lz4:lz4-java:jar:1.4.1:compile (optional)
+   at.yawk.lz4:lz4-java:jar:1.8.1:compile (optional)
    io.netty:netty-transport:jar:4.0.56.Final:compile
    io.dropwizard.metrics:metrics-core:jar:3.2.2:compile
    io.netty:netty-common:jar:4.0.56.Final:compile

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -116,7 +116,7 @@
               <windowtitle>Java driver for Scylla and Apache Cassandra(R) ${project.version} API</windowtitle>
               <additionalDependencies>
                 <additionalDependency>
-                  <groupId>org.lz4</groupId>
+                  <groupId>at.yawk.lz4</groupId>
                   <artifactId>lz4-java</artifactId>
                   <version>${lz4.version}</version>
                 </additionalDependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -123,7 +123,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>

--- a/manual/core/compression/README.md
+++ b/manual/core/compression/README.md
@@ -46,7 +46,7 @@ datastax-java-driver {
 
 Compression must be set before opening a session, it cannot be changed at runtime.
 
-Two algorithms are supported out of the box: [LZ4](https://github.com/jpountz/lz4-java) and
+Two algorithms are supported out of the box: [LZ4](https://github.com/yawkat/lz4-java) and
 [Snappy](http://google.github.io/snappy/). The LZ4 implementation is a good first choice; it offers
 fallback implementations in case native libraries fail to load and
 [benchmarks](http://java-performance.info/performance-general-compression/) suggest that it offers
@@ -63,9 +63,9 @@ Dependency:
 
 ```xml
 <dependency>
-  <groupId>org.lz4</groupId>
+  <groupId>at.yawk.lz4</groupId>
   <artifactId>lz4-java</artifactId>
-  <version>1.4.1</version>
+  <version>1.8.1</version>
 </dependency>
 ```
 

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -416,7 +416,7 @@ are not available on your platform, you can exclude the following dependency:
 
 #### Compression libraries
 
-The driver supports compression with either [LZ4](https://github.com/jpountz/lz4-java) or
+The driver supports compression with either [LZ4](https://github.com/yawkat/lz4-java) or
 [Snappy](http://google.github.io/snappy/).
 
 These dependencies are optional; you have to add them explicitly in your application in order to

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -75,7 +75,7 @@
       <artifactId>snappy-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
     </dependency>
     <dependency>

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -117,7 +117,7 @@ public class BundleOptions {
   public static CompositeOption lz4Bundle() {
     return () ->
         options(
-            mavenBundle("org.lz4", "lz4-java").versionAsInProject(),
+            mavenBundle("at.yawk.lz4", "lz4-java").versionAsInProject(),
             systemProperty("cassandra.compression").value("LZ4"));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <legacy-jackson.version>1.9.12</legacy-jackson.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.10.8</snappy.version>
-    <lz4.version>1.8.1</lz4.version>
+    <lz4.version>1.10.1</lz4.version>
     <!-- test dependencies -->
     <assertj.version>3.27.6</assertj.version>
     <commons-exec.version>1.5.0</commons-exec.version>
@@ -205,7 +205,7 @@
         <version>${snappy.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
         <version>${lz4.version}</version>
       </dependency>


### PR DESCRIPTION
To address [CVE-2025-66566](https://github.com/advisories/GHSA-cmp6-m4wj-q63q) it does the following:
- Move from `org.lz4/lz4-java` to `at.yawk.lz4/lz4-java:1.10.1`
- Update documentation and examples
