### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     concurrency:
       group: single


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/java-driver/security/code-scanning/2](https://github.com/scylladb/java-driver/security/code-scanning/2)

In general, to fix this class of problem you explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, either at the top (applies to all jobs) or at the job level, reducing them to the minimum required for the workflow’s operations. This prevents inheriting overly broad repository defaults.

For this specific workflow, the safest change without breaking existing behavior is to add a `permissions` block to the `release` job (or at the workflow root) that grants just enough access for the docs deployment. Because the final step runs a deploy script that almost certainly pushes generated docs to a branch or pages site, it will need `contents: write`. Nothing in the shown steps indicates a need for other scopes like `pull-requests`, `issues`, etc., so we can omit those.

Concretely, in `.github/workflows/docs-pages.yml`, directly under `jobs:   release:` (before `runs-on:`) add:

```yaml
    permissions:
      contents: write
```

This satisfies CodeQL’s requirement to explicitly scope the token, avoids changing functional behavior (write access is still available for pushing docs), and adheres to the principle of least privilege as far as we can reasonably infer from the snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
