### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -2,6 +2,9 @@ name: "Docs / Build PR"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/java-driver/security/code-scanning/1](https://github.com/scylladb/java-driver/security/code-scanning/1)

In general, the fix is to explicitly restrict the default GITHUB_TOKEN permissions for this workflow or job so that it only has the minimal access required. For a docs build job that only checks out code and runs local build commands, `contents: read` is typically sufficient.

The best fix without changing existing functionality is to add a `permissions` block at the workflow root level, just under the `name` (or before `on:`). This root-level block applies to all jobs that don’t override it, so the `build` job will run with `contents: read`. No changes are needed to the steps themselves, as `actions/checkout` and the other actions work fine with read-only contents for a build-only workflow.

Concretely, in `.github/workflows/docs-pr.yml`, insert:

```yml
permissions:
  contents: read
```

between the existing `name: "Docs / Build PR"` and the `on:` section. No additional imports, methods, or definitions are required because this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
