### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -27,6 +27,9 @@ on:
       - ".gitignore"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/java-driver/security/code-scanning/3](https://github.com/scylladb/java-driver/security/code-scanning/3)

In general, the fix is to explicitly set `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the minimal required privileges. Since the jobs here only check out code, use caches, and run Maven/Make, they only need read access to the repository contents; they do not need to write to the repo, issues, or PRs.

The single best fix with no functional change is to add a top-level `permissions` block (so it applies to all jobs) just after the `on:` triggers and before `jobs:`. This block should set `contents: read`, which is the minimal reasonable permission for workflows that need to check out the code. No changes are needed inside individual jobs or steps.

Concretely, in `.github/workflows/tests@v1.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `workflow_dispatch:` line and the `jobs:` key. No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
