### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphTestUtils.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphTestUtils.java
@@ -171,6 +171,10 @@ public class GraphTestUtils {
 
   public static void assertThatContainsProperties(
       Map<Object, Object> properties, Object... propsToMatch) {
+    if ((propsToMatch.length % 2) != 0) {
+      throw new IllegalArgumentException(
+          "propsToMatch must contain an even number of elements (key/value pairs)");
+    }
     for (int i = 0; i < propsToMatch.length; i += 2) {
       assertThat(properties).containsEntry(propsToMatch[i], propsToMatch[i + 1]);
     }


### PR DESCRIPTION
In general, the problem is that the loop unconditionally assumes that `propsToMatch` has an even number of elements and indexes `i + 1` without verifying this. The robust fix is to either (a) validate upfront that `propsToMatch.length` is even and fail fast with a clear message if not, or (b) adjust the loop bound so that `i + 1` is always within range. Both approaches prevent an `ArrayIndexOutOfBoundsException`.

The best way here, without changing existing functionality for valid inputs, is to add an explicit check at the start of `assertThatContainsProperties` ensuring that `propsToMatch.length` is even. If it is not, we can throw an `IllegalArgumentException` with a helpful message. This preserves the current behavior for correct usages (even length), while turning undefined/out-of-bounds behavior into a clear, deterministic failure. The loop body itself can then stay as-is. All changes are confined to `assertThatContainsProperties` in `core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphTestUtils.java`; no imports or additional methods are required.

Concretely:
- Inside `assertThatContainsProperties`, before the `for` loop, add:

```java
if ((propsToMatch.length % 2) != 0) {
  throw new IllegalArgumentException(
      "propsToMatch must contain an even number of elements (key/value pairs)");
}
```

- Leave the loop and method signature unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._