### PR TITLE
Remove commons-lang3 dependency from core module

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLongArray;
 import net.jcip.annotations.ThreadSafe;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,10 +201,10 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
     Object[] currentNodes = getLiveNodes().dc(getLocalDatacenter()).toArray();
     int replicaCount = 0; // in currentNodes
     if (!replicas.isEmpty()) {
-      Pair<Integer, Integer> counts = moveReplicasToFront(currentNodes, replicas);
-      replicaCount = counts.getLeft();
+      int[] counts = moveReplicasToFront(currentNodes, replicas);
+      replicaCount = counts[0];
 
-      int localRackReplicaCount = counts.getRight(); // in currentNodes
+      int localRackReplicaCount = counts[1]; // in currentNodes
 
       if (replicaCount > 1) {
         shuffleLocalRackReplicasAndReplicas(currentNodes, replicaCount, localRackReplicaCount);
@@ -249,8 +248,7 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
     return orderedReplicas;
   }
 
-  private Pair<Integer, Integer> moveReplicasToFront(
-      Object[] currentNodes, List<Node> allReplicas) {
+  private int[] moveReplicasToFront(Object[] currentNodes, List<Node> allReplicas) {
     int replicaCount = 0, localRackReplicaCount = 0;
     for (int i = 0; i < currentNodes.length; i++) {
       Node node = (Node) currentNodes[i];
@@ -265,7 +263,7 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
         replicaCount++;
       }
     }
-    return Pair.of(replicaCount, localRackReplicaCount);
+    return new int[] {replicaCount, localRackReplicaCount};
   }
 
   private void shuffleLocalRackReplicasAndReplicas(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodecTest.java
@@ -34,8 +34,8 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.nio.ByteBuffer;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.HashMap;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -128,7 +128,10 @@ public class VectorCodecTest {
   @Test
   @UseDataProvider("dataProvider")
   public void should_throw_on_encode_with_too_many_elements(TestDataContainer testData) {
-    Object[] doubled = ArrayUtils.addAll(testData.getValues(), testData.getValues());
+    Object[] first = testData.getValues();
+    Object[] second = testData.getValues();
+    Object[] doubled = Arrays.copyOf(first, first.length + second.length);
+    System.arraycopy(second, 0, doubled, first.length, second.length);
     TypeCodec<CqlVector<Object>> codec = getCodec(testData.getDataType());
     assertThatThrownBy(() -> codec.encode(CqlVector.newInstance(doubled), ProtocolVersion.DEFAULT))
         .isInstanceOf(IllegalArgumentException.class);

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <skipUnitTests>${skipTests}</skipUnitTests>
     <release.autopublish>false</release.autopublish>
     <pushChanges>false</pushChanges>
-    <mockitoopens.argline />
+    <mockitoopens.argline/>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary

- `commons-lang3` was a transitive dependency of the optional `gremlin-core` but used directly in production code (`DefaultLoadBalancingPolicy`), meaning consumers could hit `NoClassDefFoundError` at runtime if they didn't happen to have it on their classpath
- Replace `Pair<Integer, Integer>` with `int[]` in `moveReplicasToFront()` — the only production usage
- Replace `ArrayUtils.addAll()` with `Arrays.copyOf()`/`System.arraycopy()` in `VectorCodecTest` — the only test usage

Closes: https://github.com/scylladb/java-driver/issues/801
## Test plan

- [x] `DefaultLoadBalancingPolicy*` tests pass (232 tests)
- [x] `VectorCodecTest` passes (131 tests)
- [x] Full CI