### PR TITLE
4.x: PrivateLink Support Phase 3: Query Implementation, DNS Resolution & Unit Tests 🔌

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRouteProxy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRouteProxy.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Represents a client routes endpoint for cloud private-endpoint deployments (e.g. AWS PrivateLink,
+ * Azure Private Link, GCP Private Service Connect).
+ *
+ * <p>Each endpoint corresponds to a connection ID in the {@code system.client_routes} table, with
+ * an optional connection address (DNS name or IP) that overrides the {@code address} column from
+ * the table for the matching connection ID.
+ */
+@Immutable
+public final class ClientRouteProxy {
+
+  /**
+   * Pattern for valid hostnames and IP addresses: alphanumeric characters, dots, hyphens,
+   * underscores, colons (for IPv6), and brackets (for bracketed IPv6 notation). Strings that don't
+   * match will be rejected early rather than failing with a confusing DNS resolution error later.
+   */
+  private static final Pattern VALID_HOSTNAME_OR_IP = Pattern.compile("^[a-zA-Z0-9._:\\[\\]-]+$");
+
+  private final String connectionId;
+  private final String connectionAddr;
+
+  /**
+   * Creates a new endpoint with the given connection ID and no connection address.
+   *
+   * @param connectionId the connection ID (must not be null).
+   */
+  public ClientRouteProxy(@NonNull String connectionId) {
+    this(connectionId, null);
+  }
+
+  /**
+   * Creates a new endpoint with the given connection ID and connection address.
+   *
+   * @param connectionId the connection ID (must not be null).
+   * @param connectionAddr the DNS name or IP address used to override the {@code address} column
+   *     from the {@code system.client_routes} table for the matching {@code connection_id} (may be
+   *     null). Must be a plain hostname or IP address without a port (e.g. {@code
+   *     "my-cluster.example.com"} or {@code "10.0.1.5"}).
+   */
+  public ClientRouteProxy(@NonNull String connectionId, @Nullable String connectionAddr) {
+    this.connectionId = Objects.requireNonNull(connectionId, "connectionId must not be null");
+    if (connectionId.trim().isEmpty()) {
+      throw new IllegalArgumentException("connectionId must not be empty");
+    }
+    if (connectionAddr != null) {
+      if (connectionAddr.trim().isEmpty()) {
+        throw new IllegalArgumentException(
+            "connectionAddr must not be empty or blank when non-null");
+      }
+      if (containsPort(connectionAddr)) {
+        throw new IllegalArgumentException(
+            "connectionAddr must be a plain hostname or IP address without a port, got: "
+                + connectionAddr);
+      }
+      if (!VALID_HOSTNAME_OR_IP.matcher(connectionAddr).matches()) {
+        throw new IllegalArgumentException(
+            "connectionAddr contains invalid characters "
+                + "(expected hostname or IP address with only alphanumeric characters, "
+                + "dots, hyphens, underscores, colons, or brackets): "
+                + connectionAddr);
+      }
+    }
+    this.connectionAddr = connectionAddr;
+  }
+
+  /**
+   * Returns {@code true} if the address string appears to contain a port suffix. Handles plain
+   * {@code host:port} and IPv6 bracketed {@code [host]:port} notation.
+   */
+  private static boolean containsPort(@NonNull String addr) {
+    if (addr.startsWith("[")) {
+      // IPv6 bracketed notation: [host]:port
+      int closeBracket = addr.indexOf(']');
+      return closeBracket > 0
+          && closeBracket + 1 < addr.length()
+          && addr.charAt(closeBracket + 1) == ':';
+    }
+    int colonIdx = addr.lastIndexOf(':');
+    if (colonIdx < 0) {
+      return false;
+    }
+    // Leading colon (e.g. ":9042") — treat as port-only, no valid hostname
+    if (colonIdx == 0) {
+      return true;
+    }
+    // Multiple colons means bare IPv6 address (e.g. "::1"), not host:port
+    return addr.indexOf(':') == colonIdx;
+  }
+
+  /** Returns the connection ID for this endpoint. */
+  @NonNull
+  public String getConnectionId() {
+    return connectionId;
+  }
+
+  /**
+   * Returns the connection address for this endpoint, or null if not specified.
+   *
+   * <p>This is a plain hostname or IP address (e.g. {@code "my-cluster.example.com"} or {@code
+   * "10.0.1.5"}). When provided, the {@code address} column from the {@code system.client_routes}
+   * table is overridden with this value for the matching {@code connection_id}.
+   */
+  @Nullable
+  public String getConnectionAddr() {
+    return connectionAddr;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ClientRouteProxy)) {
+      return false;
+    }
+    ClientRouteProxy that = (ClientRouteProxy) o;
+    return connectionId.equals(that.connectionId)
+        && Objects.equals(connectionAddr, that.connectionAddr);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(connectionId, connectionAddr);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientRouteProxy{"
+        + "connectionId='"
+        + connectionId
+        + "'"
+        + (connectionAddr != null ? ", connectionAddr='" + connectionAddr + "'" : "")
+        + "}";
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Configuration for client routes, used in cloud private-endpoint deployments.
+ *
+ * <p>Client routes enable the driver to discover and connect to nodes through a load balancer (such
+ * as AWS PrivateLink, Azure Private Link, or GCP Private Service Connect) by reading endpoint
+ * mappings from the {@code system.client_routes} table. Each endpoint is identified by a connection
+ * ID and maps to specific node addresses.
+ *
+ * <p>This configuration is mutually exclusive with a user-provided {@link
+ * com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator}. If client routes are
+ * configured, the driver will use its internal client routes handler for address translation.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * ClientRoutesConfig config = ClientRoutesConfig.builder()
+ *     .addEndpoint(new ClientRouteProxy(
+ *         "12345678-1234-1234-1234-123456789012",
+ *         "my-cluster-endpoint.example.com"))
+ *     .build();
+ *
+ * CqlSession session = CqlSession.builder()
+ *     .withClientRoutesConfig(config)
+ *     .build();
+ * }</pre>
+ *
+ * @see SessionBuilder#withClientRoutesConfig(ClientRoutesConfig)
+ * @see ClientRouteProxy
+ */
+@Immutable
+public final class ClientRoutesConfig {
+
+  private static final String DEFAULT_TABLE_NAME = "system.client_routes";
+
+  /**
+   * Pattern for valid unquoted CQL table names: must start with a letter or underscore, followed by
+   * letters, digits, or underscores. Optionally qualified with a keyspace prefix using the same
+   * rules. Quoted identifiers (e.g. {@code "My-Table"}) are not supported.
+   */
+  private static final Pattern VALID_TABLE_NAME =
+      Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)?");
+
+  private final List<ClientRouteProxy> endpoints;
+  private final String tableName;
+
+  private ClientRoutesConfig(List<ClientRouteProxy> endpoints, String tableName) {
+    if (endpoints == null || endpoints.isEmpty()) {
+      throw new IllegalArgumentException("At least one endpoint must be specified");
+    }
+    Objects.requireNonNull(tableName, "tableName must not be null");
+    if (!VALID_TABLE_NAME.matcher(tableName).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid table name (must match [a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)?): "
+              + tableName);
+    }
+    this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
+    this.tableName = tableName;
+  }
+
+  /**
+   * Returns the list of configured endpoints.
+   *
+   * @return an immutable list of endpoints.
+   */
+  @NonNull
+  public List<ClientRouteProxy> getEndpoints() {
+    return endpoints;
+  }
+
+  /**
+   * Returns the name of the system table to query for client routes.
+   *
+   * @return the table name (defaults to {@code system.client_routes}).
+   */
+  @NonNull
+  public String getTableName() {
+    return tableName;
+  }
+
+  /**
+   * Creates a new builder for constructing a {@link ClientRoutesConfig}.
+   *
+   * @return a new builder instance.
+   */
+  @NonNull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ClientRoutesConfig)) {
+      return false;
+    }
+    ClientRoutesConfig that = (ClientRoutesConfig) o;
+    return endpoints.equals(that.endpoints) && tableName.equals(that.tableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(endpoints, tableName);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientRoutesConfig{"
+        + "endpoints="
+        + endpoints
+        + ", tableName='"
+        + tableName
+        + '\''
+        + '}';
+  }
+
+  /** Builder for {@link ClientRoutesConfig}. */
+  public static final class Builder {
+    private final List<ClientRouteProxy> endpoints = new ArrayList<>();
+    private final Set<String> seenConnectionIds = new HashSet<>();
+    private String tableName = DEFAULT_TABLE_NAME;
+
+    /**
+     * Adds an endpoint to the configuration.
+     *
+     * @param endpoint the endpoint to add (must not be null).
+     * @return this builder.
+     * @throws IllegalArgumentException if an endpoint with the same connection ID has already been
+     *     added.
+     */
+    @NonNull
+    public Builder addEndpoint(@NonNull ClientRouteProxy endpoint) {
+      Objects.requireNonNull(endpoint, "endpoint must not be null");
+      if (!seenConnectionIds.add(endpoint.getConnectionId())) {
+        throw new IllegalArgumentException(
+            "Duplicate connection ID: " + endpoint.getConnectionId());
+      }
+      this.endpoints.add(endpoint);
+      return this;
+    }
+
+    /**
+     * Sets the endpoints for the configuration, replacing any previously added endpoints.
+     *
+     * @param endpoints the endpoints to set (must not be null or empty).
+     * @return this builder.
+     */
+    @NonNull
+    public Builder withEndpoints(@NonNull List<ClientRouteProxy> endpoints) {
+      Objects.requireNonNull(endpoints, "endpoints must not be null");
+      if (endpoints.isEmpty()) {
+        throw new IllegalArgumentException("endpoints must not be empty");
+      }
+      this.endpoints.clear();
+      this.seenConnectionIds.clear();
+      for (ClientRouteProxy endpoint : endpoints) {
+        addEndpoint(endpoint);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the name of the system table to query for client routes.
+     *
+     * <p>This is primarily useful for testing. If not set, the driver will use the default table
+     * name from the configuration ({@code system.client_routes}).
+     *
+     * @param tableName the table name to use (must not be null).
+     * @return this builder.
+     * @throws NullPointerException if {@code tableName} is null.
+     */
+    @VisibleForTesting
+    @NonNull
+    Builder withTableName(@NonNull String tableName) {
+      this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
+      return this;
+    }
+
+    /**
+     * Builds the {@link ClientRoutesConfig} with the configured endpoints and table name.
+     *
+     * @return the new configuration instance.
+     * @throws IllegalArgumentException if no endpoints have been added.
+     */
+    @NonNull
+    public ClientRoutesConfig build() {
+      return new ClientRoutesConfig(endpoints, tableName);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1073,7 +1073,31 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: string
    */
   LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD(
-      "advanced.load-balancing-policy.default-lwt-request-routing-method");
+      "advanced.load-balancing-policy.default-lwt-request-routing-method"),
+
+  /**
+   * The list of client-routes endpoints for cloud private-endpoint deployments (e.g. AWS
+   * PrivateLink, Azure Private Link, GCP Private Service Connect).
+   *
+   * <p>Each element is a HOCON object with the following fields:
+   *
+   * <ul>
+   *   <li>{@code connection-id} (string, required) – opaque string that identifies the cloud
+   *       private-endpoint connection in the {@code system.client_routes} table.
+   *   <li>{@code connection-addr} (string, optional) – DNS name or IP address that overrides the
+   *       {@code address} column from the {@code system.client_routes} table for the matching
+   *       {@code connection_id}. Must not include a port (e.g. {@code "host.example.com"} or {@code
+   *       "10.0.1.5"}).
+   * </ul>
+   *
+   * <p>This option is read as a raw HOCON list-of-objects; it cannot be read via the flat {@link
+   * com.datastax.oss.driver.api.core.config.DriverExecutionProfile} typed getters. Parsing is
+   * performed directly from the underlying Typesafe {@code Config} object inside {@code
+   * DefaultDriverContext}.
+   *
+   * <p>Value type: list of HOCON objects
+   */
+  CLIENT_ROUTES_ENDPOINTS("advanced.client-routes.endpoints");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -396,6 +396,8 @@ public class OptionsMap implements Serializable {
     map.put(
         TypedDriverOption.LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD,
         "PRESERVE_REPLICA_ORDER");
+    // CLIENT_ROUTES_ENDPOINTS is intentionally omitted: it is a list-of-objects (compound HOCON
+    // values) with no sensible scalar default, analogous to how CONFIG_RELOAD_INTERVAL is omitted.
   }
 
   @Immutable

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -939,6 +939,11 @@ public class TypedDriverOption<ValueT> {
           DefaultDriverOption.LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD,
           GenericType.STRING);
 
+  // Note: DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS intentionally has no typed equivalent here
+  // because its HOCON value is a list of compound objects (not a flat scalar type supported by the
+  // DriverExecutionProfile API); it is excluded from the TypedDriverOptionTest consistency check
+  // accordingly.
+
   private static Iterable<TypedDriverOption<?>> introspectBuiltInValues() {
     try {
       ImmutableList.Builder<TypedDriverOption<?>> result = ImmutableList.builder();

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.api.core.session;
 
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistanceEvaluator;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
@@ -71,6 +72,7 @@ public class ProgrammaticArguments {
   private final String startupApplicationVersion;
   private final MutableCodecRegistry codecRegistry;
   private final Object metricRegistry;
+  private final ClientRoutesConfig clientRoutesConfig;
 
   private ProgrammaticArguments(
       @NonNull List<TypeCodec<?>> typeCodecs,
@@ -88,7 +90,8 @@ public class ProgrammaticArguments {
       @Nullable String startupApplicationName,
       @Nullable String startupApplicationVersion,
       @Nullable MutableCodecRegistry codecRegistry,
-      @Nullable Object metricRegistry) {
+      @Nullable Object metricRegistry,
+      @Nullable ClientRoutesConfig clientRoutesConfig) {
 
     this.typeCodecs = typeCodecs;
     this.nodeStateListener = nodeStateListener;
@@ -106,6 +109,7 @@ public class ProgrammaticArguments {
     this.startupApplicationVersion = startupApplicationVersion;
     this.codecRegistry = codecRegistry;
     this.metricRegistry = metricRegistry;
+    this.clientRoutesConfig = clientRoutesConfig;
   }
 
   @NonNull
@@ -190,6 +194,11 @@ public class ProgrammaticArguments {
     return metricRegistry;
   }
 
+  @Nullable
+  public ClientRoutesConfig getClientRoutesConfig() {
+    return clientRoutesConfig;
+  }
+
   public static class Builder {
 
     private final ImmutableList.Builder<TypeCodec<?>> typeCodecsBuilder = ImmutableList.builder();
@@ -210,6 +219,7 @@ public class ProgrammaticArguments {
     private String startupApplicationVersion;
     private MutableCodecRegistry codecRegistry;
     private Object metricRegistry;
+    private ClientRoutesConfig clientRoutesConfig;
 
     @NonNull
     public Builder addTypeCodecs(@NonNull TypeCodec<?>... typeCodecs) {
@@ -411,6 +421,12 @@ public class ProgrammaticArguments {
     }
 
     @NonNull
+    public Builder withClientRoutesConfig(@Nullable ClientRoutesConfig clientRoutesConfig) {
+      this.clientRoutesConfig = clientRoutesConfig;
+      return this;
+    }
+
+    @NonNull
     public ProgrammaticArguments build() {
       return new ProgrammaticArguments(
           typeCodecsBuilder.build(),
@@ -428,7 +444,8 @@ public class ProgrammaticArguments {
           startupApplicationName,
           startupApplicationVersion,
           codecRegistry,
-          metricRegistry);
+          metricRegistry,
+          clientRoutesConfig);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
 import com.datastax.oss.driver.api.core.auth.PlainTextAuthProviderBase;
 import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
@@ -98,7 +99,6 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   protected Set<EndPoint> programmaticContactPoints = new HashSet<>();
   protected CqlIdentifier keyspace;
   protected Callable<InputStream> cloudConfigInputStream;
-
   protected ProgrammaticArguments.Builder programmaticArgumentsBuilder =
       ProgrammaticArguments.builder();
   private boolean programmaticSslFactory = false;
@@ -736,6 +736,42 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   }
 
   /**
+   * Configures this session to use client routes for cloud private-endpoint deployments.
+   *
+   * <p>Client routes enable the driver to discover and connect to nodes through a load balancer
+   * (such as AWS PrivateLink, Azure Private Link, or GCP Private Service Connect) by reading
+   * endpoint mappings from the {@code system.client_routes} table. Each endpoint is identified by a
+   * connection ID and maps to specific node addresses.
+   *
+   * <p>This configuration is <b>mutually exclusive</b> with a user-provided {@link
+   * com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator}. If both are specified,
+   * an {@link IllegalStateException} is thrown when the session is built.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * ClientRoutesConfig config = ClientRoutesConfig.builder()
+   *     .addEndpoint(new ClientRouteProxy(
+   *         "12345678-1234-1234-1234-123456789012",
+   *         "my-cluster-endpoint.example.com"))
+   *     .build();
+   *
+   * CqlSession session = CqlSession.builder()
+   *     .withClientRoutesConfig(config)
+   *     .build();
+   * }</pre>
+   *
+   * @param clientRoutesConfig the client routes configuration to use, or {@code null} to disable
+   *     client routes.
+   * @see ClientRoutesConfig
+   */
+  @NonNull
+  public SelfT withClientRoutesConfig(@Nullable ClientRoutesConfig clientRoutesConfig) {
+    this.programmaticArgumentsBuilder.withClientRoutesConfig(clientRoutesConfig);
+    return self;
+  }
+
+  /**
    * A unique identifier for the created session.
    *
    * <p>It will be sent in the {@code STARTUP} protocol message, under the key {@code CLIENT_ID},
@@ -829,6 +865,7 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
     CompletableFutures.propagateCancellation(wrapStage, buildStage);
     return wrapStage;
   }
+
   /**
    * Convenience method to call {@link #buildAsync()} and block on the result.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
@@ -30,8 +30,14 @@ import org.slf4j.LoggerFactory;
  * using its native transport port.
  *
  * <p>The translator can be used for scenarios when all nodes are behind some kind of proxy, and it
- * is not tailored for one concrete use case. One can use this, for example, for AWS PrivateLink as
- * all nodes would be exposed to consumer - behind one hostname pointing to AWS Endpoint.
+ * is not tailored for one concrete use case. One can use this, for example, for cloud private
+ * endpoint services (such as AWS PrivateLink, Azure Private Link, or GCP Private Service Connect)
+ * where all nodes are exposed to the consumer behind one hostname pointing to a single load
+ * balancer endpoint.
+ *
+ * <p>For cloud private-endpoint deployments with per-node routing, see the client routes feature
+ * ({@link com.datastax.oss.driver.api.core.config.ClientRoutesConfig}) instead. This translator is
+ * suitable when all nodes share a single hostname.
  */
 public class FixedHostNameAddressTranslator implements AddressTranslator {
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -57,6 +57,7 @@ import io.netty.channel.ChannelPipeline;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -218,6 +219,14 @@ public class ChannelFactory {
       List<ProtocolVersion> attemptedVersions,
       CompletableFuture<DriverChannel> resultFuture) {
 
+    SocketAddress resolvedAddress;
+    try {
+      resolvedAddress = endPoint.resolve();
+    } catch (Exception e) {
+      resultFuture.completeExceptionally(e);
+      return;
+    }
+
     NettyOptions nettyOptions = context.getNettyOptions();
 
     Bootstrap bootstrap =
@@ -238,7 +247,7 @@ public class ChannelFactory {
             shardId,
             endPoint);
       }
-      connectFuture = bootstrap.connect(endPoint.resolve());
+      connectFuture = bootstrap.connect(resolvedAddress);
     } else {
       int localPort =
           PortAllocator.getNextAvailablePort(shardingInfo.getShardsCount(), shardId, context);
@@ -247,9 +256,9 @@ public class ChannelFactory {
             "Could not find free port for shard {} at {}. Falling back to arbitrary local port.",
             shardId,
             endPoint);
-        connectFuture = bootstrap.connect(endPoint.resolve());
+        connectFuture = bootstrap.connect(resolvedAddress);
       } else {
-        connectFuture = bootstrap.connect(endPoint.resolve(), new InetSocketAddress(localPort));
+        connectFuture = bootstrap.connect(resolvedAddress, new InetSocketAddress(localPort));
       }
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
@@ -170,10 +170,12 @@ class ProtocolInitHandler extends ConnectInitHandler {
     private Message request;
     private Authenticator authenticator;
     private ByteBuffer authResponseToken;
+    private final List<String> registerEventTypes;
 
     InitRequest(ChannelHandlerContext ctx) {
       super(ctx, timeoutMillis);
       this.step = querySupportedOptions ? Step.OPTIONS : Step.STARTUP;
+      this.registerEventTypes = options.eventTypes;
     }
 
     @Override
@@ -200,7 +202,7 @@ class ProtocolInitHandler extends ConnectInitHandler {
         case AUTH_RESPONSE:
           return request = new AuthResponse(authResponseToken);
         case REGISTER:
-          return request = new Register(options.eventTypes);
+          return request = new Register(registerEventTypes);
         default:
           throw new AssertionError("unhandled step: " + step);
       }
@@ -323,7 +325,7 @@ class ProtocolInitHandler extends ConnectInitHandler {
             if (options.keyspace != null) {
               step = Step.SET_KEYSPACE;
               send();
-            } else if (!options.eventTypes.isEmpty()) {
+            } else if (!registerEventTypes.isEmpty()) {
               step = Step.REGISTER;
               send();
             } else {
@@ -331,7 +333,7 @@ class ProtocolInitHandler extends ConnectInitHandler {
             }
           }
         } else if (step == Step.SET_KEYSPACE && response instanceof SetKeyspace) {
-          if (!options.eventTypes.isEmpty()) {
+          if (!registerEventTypes.isEmpty()) {
             step = Step.REGISTER;
             send();
           } else {
@@ -359,6 +361,17 @@ class ProtocolInitHandler extends ConnectInitHandler {
           } else if (step == Step.SET_KEYSPACE
               && error.code == ProtocolConstants.ErrorCode.INVALID) {
             fail(new InvalidKeyspaceException(error.message));
+          } else if (step == Step.REGISTER
+              && error.code == ErrorCode.PROTOCOL_ERROR
+              && error.message.contains(ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE)) {
+            // The server rejected CLIENT_ROUTES_CHANGE as an unknown event type.
+            // Fail the connection so that the caller (ClientRoutesTopologyMonitor.init())
+            // gets a clear error instead of silently degrading.
+            fail(
+                "Server does not support CLIENT_ROUTES_CHANGE event "
+                    + "(requires ScyllaDB Enterprise >= 2026.1). "
+                    + "Either upgrade the server or remove the client routes configuration.",
+                null);
           } else {
             failOnUnexpected(error);
           }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/clientroutes/ClientRouteRecord.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/clientroutes/ClientRouteRecord.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.clientroutes;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.UUID;
+import net.jcip.annotations.Immutable;
+
+@Immutable
+public class ClientRouteRecord {
+
+  private final UUID hostId;
+  private final String hostname;
+  private final int port;
+
+  public ClientRouteRecord(@NonNull UUID hostId, @NonNull String hostname, int port) {
+    this.hostId = Objects.requireNonNull(hostId, "hostId must not be null");
+    this.hostname = Objects.requireNonNull(hostname, "hostname must not be null");
+    if (hostname.isEmpty()) {
+      throw new IllegalArgumentException("hostname must not be empty");
+    }
+    if (port < 1 || port > 65535) {
+      throw new IllegalArgumentException("port must be between 1 and 65535, got: " + port);
+    }
+    this.port = port;
+  }
+
+  @NonNull
+  public UUID getHostId() {
+    return hostId;
+  }
+
+  @NonNull
+  public String getHostname() {
+    return hostname;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ClientRouteRecord)) {
+      return false;
+    }
+    ClientRouteRecord that = (ClientRouteRecord) o;
+    return port == that.port && hostId.equals(that.hostId) && hostname.equals(that.hostname);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostId, hostname, port);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientRouteRecord{"
+        + "hostId="
+        + hostId
+        + ", hostname='"
+        + hostname
+        + '\''
+        + ", port="
+        + port
+        + '}';
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfig.java
@@ -31,6 +31,7 @@ import com.typesafe.config.ConfigOriginFactory;
 import com.typesafe.config.ConfigValue;
 import com.typesafe.config.ConfigValueFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
@@ -163,6 +164,24 @@ public class TypesafeDriverConfig implements DriverConfig {
   @Override
   public Map<String, ? extends DriverExecutionProfile> getProfiles() {
     return profiles;
+  }
+
+  /**
+   * Returns the raw Typesafe {@link Config} backing the given profile, or {@code null} if the
+   * profile is not a Typesafe-based profile.
+   *
+   * <p>This method is public so that other internal components in different packages (e.g., {@code
+   * DefaultDriverContext}) can perform Typesafe-specific operations such as {@code getConfigList()}
+   * that are not available through the {@link DriverExecutionProfile} API. It is intentionally
+   * restricted to the {@code internal} package hierarchy and should not be considered part of the
+   * public driver API.
+   */
+  @Nullable
+  public static Config getRawConfig(@NonNull DriverExecutionProfile profile) {
+    if (profile instanceof TypesafeDriverExecutionProfile) {
+      return ((TypesafeDriverExecutionProfile) profile).getEffectiveOptions();
+    }
+    return null;
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -28,6 +28,8 @@ import com.datastax.dse.protocol.internal.ProtocolV4ClientCodecsForDse;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
@@ -52,10 +54,13 @@ import com.datastax.oss.driver.internal.core.ConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.DefaultProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
+import com.datastax.oss.driver.internal.core.addresstranslation.PassThroughAddressTranslator;
 import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer;
 import com.datastax.oss.driver.internal.core.channel.WriteCoalescer;
+import com.datastax.oss.driver.internal.core.config.typesafe.TypesafeDriverConfig;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
+import com.datastax.oss.driver.internal.core.metadata.ClientRoutesTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.CloudTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.DefaultTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
@@ -102,6 +107,9 @@ import com.datastax.oss.protocol.internal.ProtocolV3ClientCodecs;
 import com.datastax.oss.protocol.internal.ProtocolV5ClientCodecs;
 import com.datastax.oss.protocol.internal.ProtocolV6ClientCodecs;
 import com.datastax.oss.protocol.internal.SegmentCodec;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.netty.buffer.ByteBuf;
@@ -140,6 +148,8 @@ public class DefaultDriverContext implements InternalDriverContext {
 
   private static final Logger LOG = LoggerFactory.getLogger(InternalDriverContext.class);
   private static final AtomicInteger SESSION_NAME_COUNTER = new AtomicInteger();
+  private static final String CLIENT_ROUTES_HOCON_EXAMPLE =
+      "{ connection-id = \"<connection-id>\", connection-addr = \"host.example.com\" }";
 
   protected final CycleDetector cycleDetector =
       new CycleDetector("Detected cycle in context initialization");
@@ -188,6 +198,8 @@ public class DefaultDriverContext implements InternalDriverContext {
       new LazyReference<>("sslHandlerFactory", this::buildSslHandlerFactory, cycleDetector);
   private final LazyReference<ChannelFactory> channelFactoryRef =
       new LazyReference<>("channelFactory", this::buildChannelFactory, cycleDetector);
+  private final LazyReference<Optional<ClientRoutesConfig>> clientRoutesConfigRef =
+      new LazyReference<>("clientRoutesConfig", this::buildClientRoutesConfig, cycleDetector);
   private final LazyReference<TopologyMonitor> topologyMonitorRef =
       new LazyReference<>("topologyMonitor", this::buildTopologyMonitor, cycleDetector);
   private final LazyReference<MetadataManager> metadataManagerRef =
@@ -239,6 +251,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   private final Map<String, NodeDistanceEvaluator> nodeDistanceEvaluatorsFromBuilder;
   private final ClassLoader classLoader;
   private final InetSocketAddress cloudProxyAddress;
+  private final ClientRoutesConfig clientRoutesConfigFromBuilder;
   private final LazyReference<RequestLogFormatter> requestLogFormatterRef =
       new LazyReference<>("requestLogFormatter", this::buildRequestLogFormatter, cycleDetector);
   private final UUID startupClientId;
@@ -294,6 +307,7 @@ public class DefaultDriverContext implements InternalDriverContext {
     this.nodeDistanceEvaluatorsFromBuilder = programmaticArguments.getNodeDistanceEvaluators();
     this.classLoader = programmaticArguments.getClassLoader();
     this.cloudProxyAddress = programmaticArguments.getCloudProxyAddress();
+    this.clientRoutesConfigFromBuilder = programmaticArguments.getClientRoutesConfig();
     this.startupClientId = programmaticArguments.getStartupClientId();
     this.startupApplicationName = programmaticArguments.getStartupApplicationName();
     this.startupApplicationVersion = programmaticArguments.getStartupApplicationVersion();
@@ -418,6 +432,122 @@ public class DefaultDriverContext implements InternalDriverContext {
                         DefaultDriverOption.ADDRESS_TRANSLATOR_CLASS)));
   }
 
+  /**
+   * Resolves the effective {@link ClientRoutesConfig} by merging the programmatic configuration
+   * with the HOCON file-based configuration. The programmatic configuration takes precedence; if
+   * both are present a warning is logged. The result is cached after the first call.
+   *
+   * @return {@code null} when client routes are not configured at all.
+   */
+  @Nullable
+  protected ClientRoutesConfig resolveClientRoutesConfig() {
+    return clientRoutesConfigRef.get().orElse(null);
+  }
+
+  private Optional<ClientRoutesConfig> buildClientRoutesConfig() {
+    ClientRoutesConfig configFromFile = buildClientRoutesConfigFromFile();
+    if (clientRoutesConfigFromBuilder != null) {
+      if (configFromFile != null) {
+        LOG.warn(
+            "[{}] Both programmatic ClientRoutesConfig and '{}' were provided. "
+                + "The programmatic configuration takes precedence.",
+            getSessionName(),
+            DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS.getPath());
+      }
+      return Optional.of(clientRoutesConfigFromBuilder);
+    }
+    return Optional.ofNullable(configFromFile);
+  }
+
+  /**
+   * Reads the {@code advanced.client-routes} section from the HOCON configuration and builds a
+   * {@link ClientRoutesConfig}, or returns {@code null} if {@code endpoints} is not defined.
+   *
+   * <p>The {@code endpoints} value is a HOCON list of objects; it cannot be read through the flat
+   * {@link com.datastax.oss.driver.api.core.config.DriverExecutionProfile} typed API, so we access
+   * the underlying Typesafe {@link Config} directly via {@link TypesafeDriverConfig#getRawConfig}.
+   */
+  @Nullable
+  // Package-private to allow unit-testing without a live cluster.
+  ClientRoutesConfig buildClientRoutesConfigFromFile() {
+    DriverExecutionProfile defaultProfile = config.getDefaultProfile();
+    if (!defaultProfile.isDefined(DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS)) {
+      return null;
+    }
+
+    Config rawConfig = TypesafeDriverConfig.getRawConfig(defaultProfile);
+    if (rawConfig == null) {
+      // Non-Typesafe config backend: endpoints option is marked as defined but we cannot parse
+      // the compound-object list. Warn and skip.
+      LOG.warn(
+          "[{}] '{}' is defined but the underlying config implementation is not Typesafe-based; "
+              + "config-file client routes cannot be parsed. Use the programmatic API instead.",
+          getSessionName(),
+          DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS.getPath());
+      return null;
+    }
+
+    String endpointsPath = DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS.getPath();
+    ConfigList endpointsList;
+    try {
+      endpointsList = rawConfig.getList(endpointsPath);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Failed to read '%s' from configuration: %s. "
+                  + "Expected a list of objects, each with a required 'connection-id' field "
+                  + "and an optional 'connection-addr' field (DNS name or IP address), for example: "
+                  + "%s = [%s]",
+              endpointsPath, e.getMessage(), endpointsPath, CLIENT_ROUTES_HOCON_EXAMPLE),
+          e);
+    }
+
+    if (endpointsList.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "'%s' is set but contains no entries; at least one endpoint is required. "
+                  + "Each entry must be a HOCON object with a 'connection-id' field (string) "
+                  + "and an optional 'connection-addr' field (DNS name or IP address), for example: "
+                  + "%s = [%s]",
+              endpointsPath, endpointsPath, CLIENT_ROUTES_HOCON_EXAMPLE));
+    }
+
+    ClientRoutesConfig.Builder builder = ClientRoutesConfig.builder();
+
+    for (int i = 0; i < endpointsList.size(); i++) {
+      if (!(endpointsList.get(i) instanceof ConfigObject)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "'%s[%d]' must be a HOCON object but got a %s. "
+                    + "Each entry must have a required 'connection-id' field (string) "
+                    + "and an optional 'connection-addr' field (DNS name or IP address), for example: "
+                    + "%s. Got: %s",
+                endpointsPath,
+                i,
+                endpointsList.get(i).valueType(),
+                CLIENT_ROUTES_HOCON_EXAMPLE,
+                endpointsList.get(i)));
+      }
+      Config entry = ((ConfigObject) endpointsList.get(i)).toConfig();
+
+      if (!entry.hasPath("connection-id")) {
+        throw new IllegalArgumentException(
+            String.format(
+                "'%s[%d]' is missing the required 'connection-id' field. "
+                    + "Each entry must be a HOCON object with a 'connection-id' field (string) "
+                    + "and an optional 'connection-addr' field (DNS name or IP address), for example: "
+                    + "%s",
+                endpointsPath, i, CLIENT_ROUTES_HOCON_EXAMPLE));
+      }
+      String connectionId = entry.getString("connection-id");
+      String connectionAddr =
+          entry.hasPath("connection-addr") ? entry.getString("connection-addr") : null;
+      builder.addEndpoint(new ClientRouteProxy(connectionId, connectionAddr));
+    }
+
+    return builder.build();
+  }
+
   protected Optional<SslEngineFactory> buildSslEngineFactory(SslEngineFactory factoryFromBuilder) {
     return (factoryFromBuilder != null)
         ? Optional.of(factoryFromBuilder)
@@ -492,10 +622,52 @@ public class DefaultDriverContext implements InternalDriverContext {
   }
 
   protected TopologyMonitor buildTopologyMonitor() {
-    if (cloudProxyAddress == null) {
-      return new DefaultTopologyMonitor(this);
+    ClientRoutesConfig clientRoutesConfig = resolveClientRoutesConfig();
+    validateClientRoutesConfiguration(clientRoutesConfig);
+
+    if (cloudProxyAddress != null) {
+      return new CloudTopologyMonitor(this, cloudProxyAddress);
     }
-    return new CloudTopologyMonitor(this, cloudProxyAddress);
+    if (clientRoutesConfig != null) {
+      return new ClientRoutesTopologyMonitor(this, clientRoutesConfig);
+    }
+    return new DefaultTopologyMonitor(this);
+  }
+
+  private void validateClientRoutesConfiguration(ClientRoutesConfig clientRoutesConfig) {
+    if (clientRoutesConfig == null) {
+      return;
+    }
+    if (cloudProxyAddress != null) {
+      throw new IllegalStateException(
+          "Both a secure connect bundle and client routes configuration were provided. "
+              + "They are mutually exclusive. Please use either a secure connect bundle OR "
+              + "client routes configuration, but not both.");
+    }
+    DriverExecutionProfile defaultProfile = getConfig().getDefaultProfile();
+    if (defaultProfile.isDefined(DefaultDriverOption.ADDRESS_TRANSLATOR_CLASS)) {
+      String className = defaultProfile.getString(DefaultDriverOption.ADDRESS_TRANSLATOR_CLASS);
+      Class<?> translatorClass =
+          Reflection.loadClass(
+              getClassLoader(),
+              className,
+              "com.datastax.oss.driver.internal.core.addresstranslation");
+      if (translatorClass == null) {
+        throw new IllegalStateException(
+            String.format(
+                "Could not load AddressTranslator class '%s'. "
+                    + "Verify the class exists and is on the classpath.",
+                className));
+      }
+      if (!PassThroughAddressTranslator.class.isAssignableFrom(translatorClass)) {
+        throw new IllegalStateException(
+            String.format(
+                "Both client routes configuration and a custom AddressTranslator ('%s') were "
+                    + "provided. They are mutually exclusive. Please use either client routes "
+                    + "OR a custom AddressTranslator, but not both.",
+                translatorClass.getName()));
+      }
+    }
   }
 
   protected MetadataManager buildMetadataManager() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -31,6 +31,8 @@ import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.channel.DriverChannelOptions;
 import com.datastax.oss.driver.internal.core.channel.EventCallback;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metadata.ClientRoutesTopologyMonitor;
+import com.datastax.oss.driver.internal.core.metadata.ClientRoutesUpdateEvent;
 import com.datastax.oss.driver.internal.core.metadata.DefaultTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.DistanceEvent;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
@@ -45,6 +47,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.response.Event;
+import com.datastax.oss.protocol.internal.response.event.ClientRoutesChangeEvent;
 import com.datastax.oss.protocol.internal.response.event.SchemaChangeEvent;
 import com.datastax.oss.protocol.internal.response.event.StatusChangeEvent;
 import com.datastax.oss.protocol.internal.response.event.TopologyChangeEvent;
@@ -190,6 +193,9 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
         case ProtocolConstants.EventType.SCHEMA_CHANGE:
           processSchemaChange(event);
           break;
+        case ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE:
+          processClientRoutesChange(event);
+          break;
         default:
           LOG.warn("[{}] Unsupported event type: {}", logPrefix, event.type);
       }
@@ -242,6 +248,14 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
             });
   }
 
+  private void processClientRoutesChange(Event event) {
+    ClientRoutesChangeEvent crce = (ClientRoutesChangeEvent) event;
+    LOG.debug("[{}] Received CLIENT_ROUTES_CHANGE event: {}", logPrefix, crce);
+    context
+        .getEventBus()
+        .fire(new ClientRoutesUpdateEvent(crce.changeType, crce.connectionIds, crce.hostIds));
+  }
+
   private class SingleThreaded {
     private final InternalDriverContext context;
     private final DriverConfig config;
@@ -292,7 +306,10 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       }
       initWasCalled = true;
       try {
-        ImmutableList<String> eventTypes = buildEventTypes(listenToClusterEvents);
+        boolean listenClientRoutesEvents =
+            context.getTopologyMonitor() instanceof ClientRoutesTopologyMonitor;
+        ImmutableList<String> eventTypes =
+            buildEventTypes(listenToClusterEvents, listenClientRoutesEvents);
         LOG.debug("[{}] Initializing with event types {}", logPrefix, eventTypes);
         channelOptions =
             DriverChannelOptions.builder()
@@ -467,42 +484,61 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
 
       // Otherwise, perform a full refresh (we don't know how long we were disconnected)
       if (!isFirstConnection) {
-        context
-            .getMetadataManager()
-            .refreshNodes()
-            .whenComplete(
-                (result, error) -> {
-                  if (error != null) {
-                    LOG.debug("[{}] Error while refreshing node list", logPrefix, error);
-                  } else {
-                    try {
-                      // A failed node list refresh at startup is not fatal, so this might be the
-                      // first successful refresh; make sure the LBP gets initialized (this is a
-                      // no-op if it was initialized already).
-                      context.getLoadBalancingPolicyWrapper().init();
-                      context
-                          .getMetadataManager()
-                          .refreshSchema(null, false, true)
-                          .whenComplete(
-                              (metadata, schemaError) -> {
-                                if (schemaError != null) {
-                                  Loggers.warnWithException(
-                                      LOG,
-                                      "[{}] Unexpected error while refreshing schema after a "
-                                          + "successful reconnection, keeping previous version",
-                                      logPrefix,
-                                      schemaError);
-                                }
-                              });
-                    } catch (Throwable t) {
-                      Loggers.warnWithException(
-                          LOG,
-                          "[{}] Unexpected error on control connection reconnect",
-                          logPrefix,
-                          t);
-                    }
-                  }
-                });
+        // If client routes are active, wait for the routes refresh to complete before refreshing
+        // nodes, so that buildNodeEndPoint sees up-to-date route data.
+        CompletionStage<Void> routesReady;
+        if (context.getTopologyMonitor() instanceof ClientRoutesTopologyMonitor) {
+          routesReady = ((ClientRoutesTopologyMonitor) context.getTopologyMonitor()).refresh();
+        } else {
+          routesReady = CompletableFuture.completedFuture(null);
+        }
+
+        routesReady.whenComplete(
+            (routesResult, routesError) -> {
+              if (routesError != null) {
+                LOG.debug(
+                    "[{}] Error while refreshing client routes on reconnect",
+                    logPrefix,
+                    routesError);
+              }
+              context
+                  .getMetadataManager()
+                  .refreshNodes()
+                  .whenComplete(
+                      (result, error) -> {
+                        if (error != null) {
+                          LOG.debug("[{}] Error while refreshing node list", logPrefix, error);
+                        } else {
+                          try {
+                            // A failed node list refresh at startup is not fatal, so this might
+                            // be the first successful refresh; make sure the LBP gets initialized
+                            // (this is a no-op if it was initialized already).
+                            context.getLoadBalancingPolicyWrapper().init();
+                            context
+                                .getMetadataManager()
+                                .refreshSchema(null, false, true)
+                                .whenComplete(
+                                    (metadata, schemaError) -> {
+                                      if (schemaError != null) {
+                                        Loggers.warnWithException(
+                                            LOG,
+                                            "[{}] Unexpected error while refreshing schema after"
+                                                + " a successful reconnection, keeping previous"
+                                                + " version",
+                                            logPrefix,
+                                            schemaError);
+                                      }
+                                    });
+                          } catch (Throwable t) {
+                            Loggers.warnWithException(
+                                LOG,
+                                "[{}] Unexpected error on control connection reconnect",
+                                logPrefix,
+                                t);
+                          }
+                        }
+                      });
+            });
       }
     }
 
@@ -595,7 +631,7 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     if (error instanceof AllNodesFailedException) {
       Collection<List<Throwable>> errors =
           ((AllNodesFailedException) error).getAllErrors().values();
-      if (errors.size() == 0) {
+      if (errors.isEmpty()) {
         return false;
       }
       for (List<Throwable> nodeErrors : errors) {
@@ -609,13 +645,17 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     return true;
   }
 
-  private static ImmutableList<String> buildEventTypes(boolean listenClusterEvents) {
+  private static ImmutableList<String> buildEventTypes(
+      boolean listenClusterEvents, boolean listenClientRoutesEvents) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
     builder.add(ProtocolConstants.EventType.SCHEMA_CHANGE);
     if (listenClusterEvents) {
       builder
           .add(ProtocolConstants.EventType.STATUS_CHANGE)
           .add(ProtocolConstants.EventType.TOPOLOGY_CHANGE);
+    }
+    if (listenClientRoutesEvents) {
+      builder.add(ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE);
     }
     return builder.build();
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesEndPoint.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Objects;
+import java.util.UUID;
+
+public class ClientRoutesEndPoint implements EndPoint {
+  private final UUID hostId;
+  private final ClientRoutesTopologyMonitor topologyMonitor;
+  private final String metricPrefix;
+  @NonNull private final EndPoint fallbackEndPoint;
+
+  /**
+   * @param topologyMonitor the topology monitor used to resolve the endpoint address on demand.
+   * @param hostId the host UUID identifying this node in the cluster.
+   * @param broadcastInetAddress the node's broadcast address (from system.peers or system.local),
+   *     used to build a stable metric prefix. May be {@code null} if the address could not be
+   *     determined, in which case the hostId is used as the metric prefix instead.
+   * @param fallbackEndPoint the default endpoint to fall back to when {@code
+   *     topologyMonitor.resolve()} returns {@code null}, i.e. when this node is not accessed via a
+   *     cloud private endpoint. Must not be {@code null}.
+   */
+  public ClientRoutesEndPoint(
+      @NonNull ClientRoutesTopologyMonitor topologyMonitor,
+      @NonNull UUID hostId,
+      @Nullable InetAddress broadcastInetAddress,
+      @NonNull EndPoint fallbackEndPoint) {
+    this.topologyMonitor =
+        Objects.requireNonNull(topologyMonitor, "Topology monitor cannot be null");
+    this.hostId = Objects.requireNonNull(hostId, "HOST uuid cannot be null");
+    this.fallbackEndPoint =
+        Objects.requireNonNull(fallbackEndPoint, "Fallback endpoint cannot be null");
+    this.metricPrefix = buildMetricPrefix(broadcastInetAddress, hostId);
+  }
+
+  @NonNull
+  public UUID getHostId() {
+    return hostId;
+  }
+
+  @NonNull
+  @Override
+  public SocketAddress resolve() {
+    try {
+      InetSocketAddress address = topologyMonitor.resolve(hostId);
+      if (address != null) {
+        return address;
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("DNS resolution failed for host_id=" + hostId, e);
+    }
+    return fallbackEndPoint.resolve();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other instanceof ClientRoutesEndPoint) {
+      ClientRoutesEndPoint that = (ClientRoutesEndPoint) other;
+      return this.hostId.equals(that.hostId);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostId);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientRoutesEndPoint(" + hostId + ")";
+  }
+
+  @NonNull
+  @Override
+  public String asMetricPrefix() {
+    return metricPrefix;
+  }
+
+  private static String buildMetricPrefix(@Nullable InetAddress address, @NonNull UUID hostId) {
+    if (address == null) {
+      return hostId.toString();
+    }
+    // getHostAddress() returns clean IP without leading slash:
+    //   IPv4: "127.0.0.1"   IPv6: "0:0:0:0:0:0:0:1"
+    // Replace dots for IPv4; colons are kept for IPv6 (consistent with DefaultEndPoint)
+    return address.getHostAddress().replace('.', '_') + '_' + hostId;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -1,0 +1,677 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.clientroutes.ClientRouteRecord;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ThreadSafe
+public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesTopologyMonitor.class);
+
+  private static final String SELECT_ROUTES_COLUMNS =
+      "SELECT host_id, address, port, tls_port, connection_id FROM %s";
+
+  /** Disables result-set paging, matching the convention used by {@link DefaultTopologyMonitor}. */
+  private static final int NO_PAGING = -1;
+
+  /** Maximum number of CAS attempts when acquiring the in-flight refresh slot. */
+  private static final int MAX_CAS_ATTEMPTS = 30;
+
+  /** Initial backoff delay (in milliseconds) between CAS retry attempts. */
+  private static final long BACKOFF_START_MS = 100;
+
+  /** Maximum backoff delay (in milliseconds) between CAS retry attempts. */
+  private static final long BACKOFF_MAX_MS = 60_000;
+
+  /**
+   * Number of consecutive empty full-refresh results before clearing the cache. This guards against
+   * stale routes being served indefinitely after legitimate route removal.
+   */
+  private static final int MAX_CONSECUTIVE_EMPTY_RESULTS = 3;
+
+  private final ClientRoutesConfig config;
+  private final List<String> configuredConnectionIds;
+  private final Map<String, String> connectionAddrOverrides;
+  private final String logPrefix;
+  private final AtomicReference<Map<UUID, ClientRouteRecord>> resolvedRoutesCache;
+  private final boolean useSSL;
+  private volatile boolean closed = false;
+  private final AtomicInteger consecutiveEmptyResults = new AtomicInteger(0);
+
+  private final AtomicReference<CompletionStage<Void>> inFlightRefresh = new AtomicReference<>();
+  private final AtomicReference<RefreshRequest> queuedRefresh = new AtomicReference<>();
+
+  /**
+   * Holds coalesced parameters for a queued refresh. At most one request is queued; new arrivals
+   * are merged into the existing queued request via {@link #coalesce}.
+   */
+  static class RefreshRequest {
+    @Nullable final List<String> connectionIds;
+    @Nullable final List<String> hostIds;
+
+    RefreshRequest(@Nullable List<String> connectionIds, @Nullable List<String> hostIds) {
+      this.connectionIds = connectionIds;
+      this.hostIds = hostIds;
+    }
+
+    boolean isFull() {
+      return hostIds == null || hostIds.isEmpty();
+    }
+
+    /** Merges two requests. Full refresh subsumes targeted; two targeted merge their IDs. */
+    RefreshRequest coalesce(RefreshRequest other) {
+      if (this.isFull() || other.isFull()) {
+        return new RefreshRequest(null, null);
+      }
+      LinkedHashSet<String> mergedHosts = new LinkedHashSet<>(this.hostIds);
+      mergedHosts.addAll(other.hostIds);
+      LinkedHashSet<String> mergedConns = new LinkedHashSet<>();
+      if (this.connectionIds != null) {
+        mergedConns.addAll(this.connectionIds);
+      }
+      if (other.connectionIds != null) {
+        mergedConns.addAll(other.connectionIds);
+      }
+      List<String> connIds = mergedConns.isEmpty() ? null : new ArrayList<>(mergedConns);
+      return new RefreshRequest(connIds, new ArrayList<>(mergedHosts));
+    }
+  }
+
+  private volatile Object clientRoutesUpdateKey;
+
+  public ClientRoutesTopologyMonitor(
+      @NonNull InternalDriverContext context, @NonNull ClientRoutesConfig config) {
+    super(context);
+    this.config = config;
+    this.configuredConnectionIds =
+        Collections.unmodifiableList(
+            config.getEndpoints().stream()
+                .map(ClientRouteProxy::getConnectionId)
+                .collect(Collectors.toList()));
+    this.connectionAddrOverrides =
+        Collections.unmodifiableMap(
+            config.getEndpoints().stream()
+                .filter(ep -> ep.getConnectionAddr() != null)
+                .collect(
+                    Collectors.toMap(
+                        ClientRouteProxy::getConnectionId, ClientRouteProxy::getConnectionAddr)));
+    this.logPrefix = context.getSessionName();
+    this.resolvedRoutesCache = new AtomicReference<>(Collections.emptyMap());
+    this.useSSL = context.getSslEngineFactory().isPresent();
+  }
+
+  @Override
+  public CompletionStage<Void> init() {
+    if (closed) {
+      return CompletableFuture.completedFuture(null);
+    }
+    this.clientRoutesUpdateKey =
+        context
+            .getEventBus()
+            .register(ClientRoutesUpdateEvent.class, this::onClientRoutesUpdateEvent);
+    if (closed) {
+      // init() raced with closeAsync(): unregister listeners we just added
+      context.getEventBus().unregister(clientRoutesUpdateKey, ClientRoutesUpdateEvent.class);
+      return CompletableFuture.completedFuture(null);
+    }
+    // First establish the control connection (super.init()), then pre-load client routes so that
+    // buildNodeEndPoint (called during the subsequent refreshNodes) can use ClientRoutesEndPoint.
+    // If the server does not support CLIENT_ROUTES_CHANGE, the control connection will fail with
+    // a ConnectionInitException and the error propagates naturally.
+    return super.init()
+        .thenCompose(ignored -> queryClientRoutesAndCache(null, null))
+        .whenComplete(
+            (result, error) -> {
+              if (error != null) {
+                context
+                    .getEventBus()
+                    .unregister(clientRoutesUpdateKey, ClientRoutesUpdateEvent.class);
+              }
+            });
+  }
+
+  /** Returns the {@link ClientRoutesConfig} this handler was built from. */
+  @NonNull
+  public ClientRoutesConfig getClientRoutesConfig() {
+    return config;
+  }
+
+  @VisibleForTesting
+  Map<UUID, ClientRouteRecord> getResolvedRoutes() {
+    return resolvedRoutesCache.get();
+  }
+
+  @VisibleForTesting
+  void setResolvedRoutes(Map<UUID, ClientRouteRecord> routes) {
+    resolvedRoutesCache.set(Collections.unmodifiableMap(new HashMap<>(routes)));
+  }
+
+  @Nullable
+  public InetSocketAddress resolve(@NonNull UUID hostId)
+      throws IllegalStateException, UnknownHostException {
+    if (closed) {
+      throw new IllegalStateException("Topology monitor is closed");
+    }
+    ClientRouteRecord route = resolvedRoutesCache.get().get(hostId);
+    if (route == null) {
+      return null; // no client route for this node — caller falls back to default
+    }
+
+    return new InetSocketAddress(resolveAddress(route.getHostname()), route.getPort());
+  }
+
+  /**
+   * Refreshes the client routes cache by querying the configured client routes table. Errors are
+   * logged but do not propagate, so that periodic refreshes don't interrupt driver operation.
+   *
+   * <p>If another refresh is already in-flight, this request is queued and coalesced. The returned
+   * future completes when <em>a</em> refresh finishes — not necessarily the one triggered by this
+   * call. Callers must not assume the cache reflects their specific request upon completion.
+   */
+  public CompletionStage<Void> refresh() {
+    if (closed) {
+      return CompletableFuture.completedFuture(null);
+    }
+    return queryClientRoutesAndCache(null, null);
+  }
+
+  private CompletionStage<Void> queryClientRoutesAndCache(
+      @Nullable List<String> eventConnectionIds, @Nullable List<String> eventHostIds) {
+    CompletableFuture<Void> sentinel = new CompletableFuture<>();
+
+    // Try to acquire the in-flight slot via CAS with exponential backoff.
+    // The contention window is tiny (nanoseconds between CAS and get()), so this loop
+    // almost never exceeds a single attempt. The backoff is a safety net to avoid
+    // spinning under pathological contention.
+    long backoffMs = BACKOFF_START_MS;
+    for (int attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      if (inFlightRefresh.compareAndSet(null, sentinel)) {
+        return executeRefresh(sentinel, eventConnectionIds, eventHostIds);
+      }
+      CompletionStage<Void> existing = inFlightRefresh.get();
+      if (existing != null) {
+        // Another refresh is in-flight — queue this request (coalescing with any pending one).
+        RefreshRequest incoming = new RefreshRequest(eventConnectionIds, eventHostIds);
+        queuedRefresh.getAndUpdate(q -> q == null ? incoming : q.coalesce(incoming));
+        LOG.debug("[{}] Client routes refresh in progress, request queued", logPrefix);
+        return existing;
+      }
+      // Slot was cleared between CAS and get(); back off before retrying.
+      try {
+        Thread.sleep(backoffMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOG.debug("[{}] Client routes refresh interrupted during backoff", logPrefix);
+        return CompletableFuture.completedFuture(null);
+      }
+      backoffMs = Math.min(backoffMs * 2, BACKOFF_MAX_MS);
+    }
+    LOG.warn(
+        "[{}] Client routes refresh dropped: CAS contention after {} attempts",
+        logPrefix,
+        MAX_CAS_ATTEMPTS);
+    CompletionStage<Void> existing = inFlightRefresh.get();
+    if (existing != null) {
+      return existing;
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Executes the actual CQL query and updates the routes cache. Called only after successfully
+   * acquiring the in-flight slot.
+   */
+  private CompletionStage<Void> executeRefresh(
+      CompletableFuture<Void> sentinel,
+      @Nullable List<String> eventConnectionIds,
+      @Nullable List<String> eventHostIds) {
+
+    DriverChannel channel = context.getControlConnection().channel();
+    if (channel == null) {
+      LOG.warn("[{}] Control connection channel is null, cannot query client routes", logPrefix);
+      completeAndDrain(sentinel);
+      return sentinel;
+    }
+
+    String query = buildQuery(config, configuredConnectionIds, eventConnectionIds, eventHostIds);
+    // A targeted refresh (host IDs known) merges into the existing cache rather than replacing it
+    boolean isTargetedRefresh = eventHostIds != null && !eventHostIds.isEmpty();
+
+    Duration timeout =
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT);
+
+    try {
+      runAdminQuery(channel, query, timeout)
+          .thenAccept(
+              adminResult -> {
+                Map<UUID, ClientRouteRecord> newRoutes = new HashMap<>();
+                for (AdminRow row : adminResult) {
+                  if (row.isNull("host_id") || row.isNull("address")) {
+                    LOG.warn("[{}] Skipping incomplete client_routes row: {}", logPrefix, row);
+                    continue;
+                  }
+                  UUID hostId = Objects.requireNonNull(row.getUuid("host_id"));
+                  String address = Objects.requireNonNull(row.getString("address"));
+
+                  // Select port based on SSL configuration at record creation time.
+                  // Skip the record if the required port column is absent.
+                  Integer effectivePort;
+                  if (useSSL) {
+                    effectivePort = row.isNull("tls_port") ? null : row.getInteger("tls_port");
+                  } else {
+                    effectivePort = row.isNull("port") ? null : row.getInteger("port");
+                  }
+                  if (effectivePort == null) {
+                    LOG.error(
+                        "[{}] Skipping client route for host_id={} ({}): "
+                            + "required port column ({}) is not set in client routes table",
+                        logPrefix,
+                        hostId,
+                        address,
+                        useSSL ? "tls_port" : "port");
+                    continue;
+                  }
+
+                  // Apply connectionAddr override if configured for this connection_id
+                  String connId =
+                      row.contains("connection_id") && !row.isNull("connection_id")
+                          ? row.getString("connection_id")
+                          : null;
+                  if (connId != null) {
+                    String override = connectionAddrOverrides.get(connId);
+                    if (override != null) {
+                      address = override;
+                    }
+                  }
+
+                  newRoutes.put(hostId, new ClientRouteRecord(hostId, address, effectivePort));
+                }
+
+                if (isTargetedRefresh) {
+                  // Merge: update only the returned host IDs, keep all others unchanged
+                  mergeRoutes(newRoutes);
+                  // Remove stale routes: host IDs present in the event but absent from query
+                  // results have been deleted server-side (e.g. node decommission).
+                  for (String hostIdStr : eventHostIds) {
+                    UUID hostId;
+                    try {
+                      hostId = UUID.fromString(hostIdStr);
+                    } catch (IllegalArgumentException e) {
+                      LOG.warn(
+                          "[{}] Skipping route with malformed host_id: {}",
+                          logPrefix,
+                          hostIdStr,
+                          e);
+                      continue;
+                    }
+                    if (!newRoutes.containsKey(hostId)) {
+                      removeRoute(hostId);
+                    }
+                  }
+                  LOG.debug(
+                      "[{}] Merged {} client routes (targeted refresh)",
+                      logPrefix,
+                      newRoutes.size());
+                } else if (newRoutes.isEmpty() && !resolvedRoutesCache.get().isEmpty()) {
+                  int emptyCount = consecutiveEmptyResults.incrementAndGet();
+                  if (emptyCount >= MAX_CONSECUTIVE_EMPTY_RESULTS) {
+                    // Too many consecutive empties -- routes were likely removed server-side.
+                    int staleSize = resolvedRoutesCache.get().size();
+                    resolvedRoutesCache.set(Collections.emptyMap());
+                    consecutiveEmptyResults.set(0);
+                    LOG.warn(
+                        "[{}] Client routes query returned 0 rows {} consecutive times; "
+                            + "clearing {} stale cached routes",
+                        logPrefix,
+                        emptyCount,
+                        staleSize);
+                  } else {
+                    // Guard against replacing a valid cache with empty results.
+                    // This can happen when an async reconnect-triggered refresh queries a node
+                    // that hasn't received the latest routes yet (eventual consistency).
+                    LOG.debug(
+                        "[{}] Client routes query returned 0 rows ({}/{}); "
+                            + "keeping {} existing cached routes to avoid race condition",
+                        logPrefix,
+                        emptyCount,
+                        MAX_CONSECUTIVE_EMPTY_RESULTS,
+                        resolvedRoutesCache.get().size());
+                  }
+                } else {
+                  consecutiveEmptyResults.set(0);
+                  resolvedRoutesCache.set(Collections.unmodifiableMap(newRoutes));
+                  LOG.debug(
+                      "[{}] Updated client routes: {} routes loaded", logPrefix, newRoutes.size());
+                }
+              })
+          .exceptionally(
+              e -> {
+                LOG.error("[{}] Failed to query client routes: {}", logPrefix, e.getMessage(), e);
+                return null;
+              })
+          .whenComplete((v, t) -> completeAndDrain(sentinel));
+      return sentinel;
+    } catch (Exception e) {
+      LOG.warn("[{}] Exception while querying client routes: {}", logPrefix, e.getMessage(), e);
+      completeAndDrain(sentinel);
+      return sentinel;
+    }
+  }
+
+  /**
+   * Completes the in-flight sentinel and drains any queued refresh request. The drain re-arms the
+   * slot directly (no CAS needed — we still hold it), avoiding contention with new callers. Must be
+   * called exactly once per acquired slot.
+   */
+  private void completeAndDrain(CompletableFuture<Void> sentinel) {
+    RefreshRequest next = queuedRefresh.getAndSet(null);
+    if (next != null && !closed) {
+      // Re-arm the slot with a new sentinel before releasing the old one,
+      // so no window exists where the slot is empty while a drain is pending.
+      CompletableFuture<Void> nextSentinel = new CompletableFuture<>();
+      inFlightRefresh.set(nextSentinel);
+      sentinel.complete(null);
+      LOG.debug("[{}] Draining queued client routes refresh", logPrefix);
+      executeRefresh(nextSentinel, next.connectionIds, next.hostIds);
+    } else {
+      inFlightRefresh.set(null);
+      sentinel.complete(null);
+    }
+  }
+
+  private void onClientRoutesUpdateEvent(ClientRoutesUpdateEvent event) {
+    if (closed) {
+      return;
+    }
+    LOG.debug("[{}] Received {}, refreshing routes", logPrefix, event);
+    queryClientRoutesAndCache(event.getConnectionIds(), event.getHostIds());
+  }
+
+  /**
+   * Overrides the default port discovery to use the port from the client routes cache instead of
+   * the control connection channel. When connecting through an NLB proxy, the channel port is the
+   * proxy port, not the real server port. The {@code system.client_routes} table has the correct
+   * port.
+   *
+   * <p>All nodes in a Scylla/Cassandra cluster use the same native transport port, so any route's
+   * port is correct. We use the minimum host_id for deterministic selection.
+   */
+  @Override
+  protected void savePort(DriverChannel channel) {
+    if (port < 0) {
+      Map<UUID, ClientRouteRecord> routes = resolvedRoutesCache.get();
+      if (!routes.isEmpty()) {
+        // Pick the route with the smallest host_id for deterministic behavior.
+        UUID minId = null;
+        ClientRouteRecord chosen = null;
+        for (Map.Entry<UUID, ClientRouteRecord> entry : routes.entrySet()) {
+          if (minId == null || entry.getKey().compareTo(minId) < 0) {
+            minId = entry.getKey();
+            chosen = entry.getValue();
+          }
+        }
+        if (chosen != null && chosen.getPort() > 0) {
+          port = chosen.getPort();
+          return;
+        }
+      }
+    }
+    super.savePort(channel);
+  }
+
+  @NonNull
+  @Override
+  protected EndPoint buildNodeEndPoint(
+      @NonNull AdminRow row,
+      @Nullable InetSocketAddress broadcastRpcAddress,
+      @NonNull EndPoint localEndPoint) {
+    UUID hostId = row.getUuid("host_id");
+    if (hostId == null) {
+      LOG.warn(
+          "[{}] host_id is null in system row for address {} — cannot assign a client route. "
+              + "This may indicate corrupted system tables. "
+              + "Falling back to default endpoint resolution.",
+          logPrefix,
+          broadcastRpcAddress);
+      return super.buildNodeEndPoint(row, broadcastRpcAddress, localEndPoint);
+    }
+    EndPoint fallback = super.buildNodeEndPoint(row, broadcastRpcAddress, localEndPoint);
+    InetAddress broadcastInetAddress = null;
+    if (broadcastRpcAddress != null) {
+      broadcastInetAddress = broadcastRpcAddress.getAddress();
+    }
+    if (broadcastInetAddress == null) {
+      broadcastInetAddress = row.getInetAddress("broadcast_address");
+    }
+    if (broadcastInetAddress == null) {
+      broadcastInetAddress = row.getInetAddress("peer");
+    }
+    return new ClientRoutesEndPoint(this, hostId, broadcastInetAddress, fallback);
+  }
+
+  /**
+   * Builds the CQL query to fetch client routes.
+   *
+   * <ul>
+   *   <li>Both connection IDs and host IDs present → {@code WHERE connection_id IN (...) AND
+   *       host_id IN (...)} — no {@code ALLOW FILTERING} needed (both partition key components
+   *       provided)
+   *   <li>Connection IDs only → {@code WHERE connection_id IN (...) ALLOW FILTERING}; uses event
+   *       connection IDs when present, otherwise falls back to all configured connection IDs
+   *   <li>Neither → full scan with {@code ALLOW FILTERING} (should not occur in practice)
+   * </ul>
+   */
+  @NonNull
+  private static String buildQuery(
+      @NonNull ClientRoutesConfig config,
+      @NonNull List<String> configuredConnectionIds,
+      @Nullable List<String> eventConnectionIds,
+      @Nullable List<String> eventHostIds) {
+
+    // Use event connection IDs when present, otherwise fall back to all configured IDs
+    List<String> connectionIds =
+        (eventConnectionIds != null && !eventConnectionIds.isEmpty())
+            ? eventConnectionIds
+            : configuredConnectionIds;
+
+    boolean hasConnectionIds = !connectionIds.isEmpty();
+    boolean hasHostIds = eventHostIds != null && !eventHostIds.isEmpty();
+
+    StringBuilder stmt =
+        new StringBuilder(String.format(SELECT_ROUTES_COLUMNS, config.getTableName()));
+
+    if (hasConnectionIds) {
+      // Prepared statements cannot be used here because AdminRequestHandler only supports
+      // plain-text queries (it is designed for system-level queries that bypass the normal
+      // request pipeline). Connection IDs are escaped by doubling single quotes.
+      String quoted =
+          connectionIds.stream()
+              .map(ClientRoutesTopologyMonitor::cqlQuoteLiteral)
+              .collect(Collectors.joining(", "));
+      stmt.append(" WHERE connection_id IN (").append(quoted).append(")");
+    }
+
+    if (hasHostIds) {
+      String validatedHostIds =
+          eventHostIds.stream()
+              .map(
+                  id -> {
+                    try {
+                      return UUID.fromString(id).toString();
+                    } catch (IllegalArgumentException e) {
+                      throw new IllegalArgumentException(
+                          "Invalid host ID (expected UUID format): " + id, e);
+                    }
+                  })
+              .collect(Collectors.joining(", "));
+      stmt.append(hasConnectionIds ? " AND" : " WHERE");
+      stmt.append(" host_id IN (").append(validatedHostIds).append(")");
+    }
+
+    // ALLOW FILTERING is required unless both connection_id and host_id are provided
+    // (matching gocql: isFullScan = len(hostIDs) == 0 || len(connectionIDs) == 0)
+    boolean isFullScan = !hasHostIds || !hasConnectionIds;
+    if (isFullScan) {
+      stmt.append(" ALLOW FILTERING");
+    }
+
+    return stmt.toString();
+  }
+
+  /** Escapes a CQL string literal by doubling single quotes. */
+  @NonNull
+  private static String cqlQuoteLiteral(@NonNull String value) {
+    return "'" + value.replace("'", "''") + "'";
+  }
+
+  /**
+   * Merges freshly-queried routes into the cache:
+   *
+   * <ul>
+   *   <li>Route unchanged → keep existing entry as-is (no unnecessary churn)
+   *   <li>Route changed (hostname or ports differ) → replace
+   *   <li>Route not yet in cache → append
+   * </ul>
+   *
+   * <p>The update is applied via a CAS loop. On collision the candidate is merged with the
+   * concurrent winner before retrying, matching gocql's {@code MergeWithResolved} retry loop.
+   */
+  void mergeRoutes(Map<UUID, ClientRouteRecord> incoming) {
+    Map<UUID, ClientRouteRecord> current;
+    Map<UUID, ClientRouteRecord> candidate;
+    // 10 retries is more than enough (matches gocql's ceiling)
+    for (int attempt = 0; attempt < 10; attempt++) {
+      current = resolvedRoutesCache.get();
+      candidate = new HashMap<>(current);
+
+      for (Map.Entry<UUID, ClientRouteRecord> entry : incoming.entrySet()) {
+        UUID hostId = entry.getKey();
+        ClientRouteRecord next = entry.getValue();
+        ClientRouteRecord existing = candidate.get(hostId);
+
+        if (existing == null) {
+          // New route — append it
+          candidate.put(hostId, next);
+        } else if (!existing.equals(next)) {
+          candidate.put(hostId, next);
+        }
+      }
+
+      if (candidate.equals(current)) {
+        return; // no changes — skip CAS
+      }
+      if (resolvedRoutesCache.compareAndSet(current, Collections.unmodifiableMap(candidate))) {
+        return;
+      }
+      // CAS collision: another thread updated the cache concurrently.
+      // Treat our candidate as the "incoming" side and merge it into whatever won,
+      // then retry — matches gocql's MergeWithResolved loop.
+      incoming = candidate;
+    }
+    LOG.warn("[{}] Failed to update client routes cache after 10 CAS attempts", logPrefix);
+  }
+
+  /**
+   * Removes a single route from the cache (e.g. after a node decommission). Uses a CAS loop
+   * identical to {@link #mergeRoutes}.
+   */
+  void removeRoute(UUID hostId) {
+    for (int attempt = 0; attempt < 10; attempt++) {
+      Map<UUID, ClientRouteRecord> current = resolvedRoutesCache.get();
+      if (!current.containsKey(hostId)) {
+        return; // already absent
+      }
+      Map<UUID, ClientRouteRecord> candidate = new HashMap<>(current);
+      candidate.remove(hostId);
+      if (resolvedRoutesCache.compareAndSet(current, Collections.unmodifiableMap(candidate))) {
+        LOG.debug("[{}] Removed stale client route for host_id={}", logPrefix, hostId);
+        return;
+      }
+    }
+    LOG.warn(
+        "[{}] Failed to remove client route for host_id={} after 10 CAS attempts",
+        logPrefix,
+        hostId);
+  }
+
+  /**
+   * Executes a CQL admin query on the given channel. Extracted as a protected method so that unit
+   * tests can override it to capture the query string and return stubbed results without touching
+   * the network.
+   */
+  @NonNull
+  protected CompletionStage<AdminResult> runAdminQuery(
+      @NonNull DriverChannel channel, @NonNull String queryString, @NonNull Duration timeout) {
+    return AdminRequestHandler.query(channel, queryString, timeout, NO_PAGING, logPrefix).start();
+  }
+
+  @NonNull
+  @Override
+  public CompletionStage<Void> closeAsync() {
+    closed = true;
+    if (clientRoutesUpdateKey != null) {
+      context.getEventBus().unregister(clientRoutesUpdateKey, ClientRoutesUpdateEvent.class);
+    }
+    LOG.debug("[{}] ClientRoutesTopologyMonitor closed", logPrefix);
+    return super.closeAsync();
+  }
+
+  /**
+   * Resolves a hostname to an {@link InetAddress}. Extracted as a protected method so that unit
+   * tests can override it to return stubbed addresses without hitting the network.
+   */
+  @NonNull
+  protected InetAddress resolveAddress(@NonNull String hostname) throws UnknownHostException {
+    return InetAddress.getByName(hostname);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesUpdateEvent.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesUpdateEvent.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Fired on the internal event bus when a {@code CLIENT_ROUTES_CHANGE} protocol event is received on
+ * the control connection. The {@link ClientRoutesTopologyMonitor} listens for this event and
+ * triggers a refresh of the client routes cache.
+ *
+ * <p>Carries the data from the protocol event:
+ *
+ * <ul>
+ *   <li>{@link #changeType} — the type of change (e.g. {@code "UPDATED"})
+ *   <li>{@link #connectionIds} — opaque string identifiers of the affected connections
+ *   <li>{@link #hostIds} — UUIDs of the affected hosts
+ * </ul>
+ */
+@Immutable
+public class ClientRoutesUpdateEvent {
+
+  private final String changeType;
+  private final List<String> connectionIds;
+  private final List<String> hostIds;
+
+  public ClientRoutesUpdateEvent(
+      @NonNull String changeType,
+      @NonNull List<String> connectionIds,
+      @NonNull List<String> hostIds) {
+    this.changeType = Objects.requireNonNull(changeType, "changeType must not be null");
+    this.connectionIds =
+        Collections.unmodifiableList(
+            new ArrayList<>(
+                Objects.requireNonNull(connectionIds, "connectionIds must not be null")));
+    this.hostIds =
+        Collections.unmodifiableList(
+            new ArrayList<>(Objects.requireNonNull(hostIds, "hostIds must not be null")));
+  }
+
+  /** Returns the type of change (e.g. {@code "UPDATED"}). */
+  @NonNull
+  public String getChangeType() {
+    return changeType;
+  }
+
+  /** Returns the connection IDs affected by this change. */
+  @NonNull
+  public List<String> getConnectionIds() {
+    return connectionIds;
+  }
+
+  /** Returns the host IDs affected by this change. */
+  @NonNull
+  public List<String> getHostIds() {
+    return hostIds;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ClientRoutesUpdateEvent)) return false;
+    ClientRoutesUpdateEvent that = (ClientRoutesUpdateEvent) o;
+    return changeType.equals(that.changeType)
+        && connectionIds.equals(that.connectionIds)
+        && hostIds.equals(that.hostIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(changeType, connectionIds, hostIds);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientRoutesUpdateEvent("
+        + "changeType='"
+        + changeType
+        + "', connectionIds="
+        + connectionIds
+        + ", hostIds="
+        + hostIds
+        + ")";
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -75,7 +75,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   private static final String NATIVE_TRANSPORT_PORT = "native_transport_port";
 
   private final String logPrefix;
-  private final InternalDriverContext context;
+  protected final InternalDriverContext context;
   private final ControlConnection controlConnection;
   private final Duration timeout;
   private final boolean reconnectOnInit;
@@ -429,7 +429,10 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
           broadcastRpcAddress, "broadcastRpcAddress cannot be null for a peer row");
       // Deployments that use a custom EndPoint implementation will need their own TopologyMonitor.
       // One simple approach is to extend this class and override this method.
-      return new DefaultEndPoint(context.getAddressTranslator().translate(broadcastRpcAddress));
+
+      InetSocketAddress translatedAddress =
+          context.getAddressTranslator().translate(broadcastRpcAddress);
+      return new DefaultEndPoint(translatedAddress);
     } else {
       // Don't rely on system.local.rpc_address for the control node, because it mistakenly
       // reports the normal RPC address instead of the broadcast one (CASSANDRA-11181). We
@@ -476,7 +479,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   // Current versions of Cassandra (3.11 at the time of writing), require the same port for all
   // nodes. As a consequence, the port is not stored in system tables.
   // We save it the first time we get a control connection channel.
-  private void savePort(DriverChannel channel) {
+  protected void savePort(DriverChannel channel) {
     if (port < 0) {
       SocketAddress address = channel.getEndPoint().resolve();
       if (address instanceof InetSocketAddress) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
@@ -84,6 +84,36 @@ public class Reflection {
   }
 
   /**
+   * Loads a class by name, trying default packages if the name is unqualified (contains no dot).
+   *
+   * <p>If {@code className} contains a dot it is treated as fully qualified and loaded directly.
+   * Otherwise each element of {@code defaultPackages} is prepended in order until a class is found.
+   *
+   * @param classLoader the class loader to use, or null to use the driver's class loader.
+   * @param className the name of the class to load, either fully qualified or unqualified.
+   * @param defaultPackages the default packages to prepend to the class name if it's not qualified.
+   *     They will be tried in order, the first one that matches an existing class will be used.
+   * @return null if the class does not exist or could not be loaded with any of the attempted
+   *     names.
+   */
+  @Nullable
+  public static Class<?> loadClass(
+      @Nullable ClassLoader classLoader,
+      @NonNull String className,
+      @NonNull String... defaultPackages) {
+    if (className.contains(".")) {
+      return loadClass(classLoader, className);
+    }
+    for (String defaultPackage : defaultPackages) {
+      Class<?> clazz = loadClass(classLoader, defaultPackage + "." + className);
+      if (clazz != null) {
+        return clazz;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Tries to create an instance of a class, given an option defined in the driver configuration.
    *
    * <p>For example:

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1110,6 +1110,44 @@ datastax-java-driver {
     # advertised-hostname = mycustomhostname
   }
 
+  # Client routes configuration for cloud private-endpoint deployments
+  # (e.g. AWS PrivateLink, Azure Private Link, GCP Private Service Connect).
+  #
+  # Client routes enable the driver to discover and connect to nodes through a load balancer such
+  # as AWS PrivateLink, Azure Private Link, or GCP Private Service Connect.  The driver reads
+  # per-node endpoint mappings from the `system.client_routes` table and translates node addresses
+  # by Host ID instead of by IP address.
+  #
+  # This section is mutually exclusive with a non-default advanced.address-translator. If both are
+  # set an IllegalStateException is thrown at session startup.
+  #
+  # Required: no (client routes are disabled when this section is absent or `endpoints` is unset)
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  advanced.client-routes {
+
+    # The list of private-endpoint connections to use.  At least one entry is required when
+    # client routes are enabled.  Each entry is a HOCON object with the following fields:
+    #
+    #   connection-id   (string, required) – opaque string identifying the connection in
+    #                   system.client_routes.  Must match a `connection_id` row in that table.
+    #
+    #   connection-addr (string, optional) – DNS name or IP address that overrides the `address`
+    #                   column from system.client_routes for the matching connection_id.
+    #                   Must not include a port (e.g. "cluster.example.com" or "10.0.1.5").
+    #                   When absent the driver uses the address column from the table as-is.
+    #
+    # Example:
+    #   endpoints = [
+    #     { connection-id = "my-connection-1", connection-addr = "cluster.example.com" },
+    #     { connection-id = "my-connection-2" }
+    #   ]
+    #
+    # Required: yes (if client routes are to be used)
+    # endpoints = []
+
+  }
+
   # Whether to resolve the addresses passed to `basic.contact-points`.
   #
   # If this is true, addresses are created with `InetSocketAddress(String, int)`: the host name will

--- a/core/src/test/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfigTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class ClientRoutesConfigTest {
+
+  @Test
+  public void should_build_config_with_single_endpoint() {
+    String connectionId = "conn-id-1";
+    String connectionAddr = "my-privatelink.us-east-1.aws.scylladb.com";
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, connectionAddr))
+            .build();
+
+    assertThat(config.getEndpoints()).hasSize(1);
+    assertThat(config.getEndpoints().get(0).getConnectionId()).isEqualTo(connectionId);
+    assertThat(config.getEndpoints().get(0).getConnectionAddr()).isEqualTo(connectionAddr);
+    assertThat(config.getTableName()).isEqualTo("system.client_routes");
+  }
+
+  @Test
+  public void should_build_config_with_multiple_endpoints() {
+    String connectionId1 = "conn-id-1";
+    String connectionId2 = "conn-id-2";
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId1, "host1"))
+            .addEndpoint(new ClientRouteProxy(connectionId2, "host2"))
+            .build();
+
+    assertThat(config.getEndpoints()).hasSize(2);
+    assertThat(config.getEndpoints().get(0).getConnectionId()).isEqualTo(connectionId1);
+    assertThat(config.getEndpoints().get(1).getConnectionId()).isEqualTo(connectionId2);
+  }
+
+  @Test
+  public void should_build_config_with_custom_table_name() {
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1"))
+            .withTableName("custom.client_routes_test")
+            .build();
+
+    assertThat(config.getTableName()).isEqualTo("custom.client_routes_test");
+  }
+
+  @Test
+  public void should_fail_when_no_endpoints_provided() {
+    assertThatThrownBy(() -> ClientRoutesConfig.builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("At least one endpoint must be specified");
+  }
+
+  @Test
+  public void should_create_endpoint_without_connection_address() {
+    String connectionId = "conn-id-1";
+    ClientRouteProxy endpoint = new ClientRouteProxy(connectionId);
+
+    assertThat(endpoint.getConnectionId()).isEqualTo(connectionId);
+    assertThat(endpoint.getConnectionAddr()).isNull();
+  }
+
+  @Test
+  public void should_create_endpoint_with_connection_address() {
+    String connectionId = "conn-id-1";
+    String connectionAddr = "host";
+    ClientRouteProxy endpoint = new ClientRouteProxy(connectionId, connectionAddr);
+
+    assertThat(endpoint.getConnectionId()).isEqualTo(connectionId);
+    assertThat(endpoint.getConnectionAddr()).isEqualTo(connectionAddr);
+  }
+
+  @Test
+  public void should_fail_when_connection_id_is_null() {
+    assertThatThrownBy(() -> new ClientRouteProxy(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("connectionId must not be null");
+  }
+
+  @Test
+  public void should_reject_empty_connection_id() {
+    assertThatThrownBy(() -> new ClientRouteProxy(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("connectionId must not be empty");
+  }
+
+  @Test
+  public void should_reject_blank_connection_id() {
+    assertThatThrownBy(() -> new ClientRouteProxy("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("connectionId must not be empty");
+  }
+
+  @Test
+  public void should_reject_blank_connection_addr() {
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "  "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("connectionAddr must not be empty");
+  }
+
+  @Test
+  public void should_reject_duplicate_connection_ids() {
+    assertThatThrownBy(
+            () ->
+                ClientRoutesConfig.builder()
+                    .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+                    .addEndpoint(new ClientRouteProxy("conn-id-1", "host2"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate connection ID");
+  }
+
+  @Test
+  public void should_reject_invalid_table_name() {
+    assertThatThrownBy(
+            () ->
+                ClientRoutesConfig.builder()
+                    .addEndpoint(new ClientRouteProxy("conn-id-1"))
+                    .withTableName("system.client_routes; DROP TABLE foo")
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid table name");
+  }
+
+  @Test
+  public void should_accept_valid_table_names() {
+    // Qualified name
+    ClientRoutesConfig config1 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1"))
+            .withTableName("my_keyspace.my_table")
+            .build();
+    assertThat(config1.getTableName()).isEqualTo("my_keyspace.my_table");
+
+    // Unqualified name
+    ClientRoutesConfig config2 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1"))
+            .withTableName("client_routes")
+            .build();
+    assertThat(config2.getTableName()).isEqualTo("client_routes");
+  }
+
+  @Test
+  public void should_reject_null_table_name() {
+    assertThatThrownBy(
+            () ->
+                ClientRoutesConfig.builder()
+                    .addEndpoint(new ClientRouteProxy("conn-id-1"))
+                    .withTableName(null)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("tableName must not be null");
+  }
+
+  @Test
+  public void should_replace_endpoints_with_withEndpoints() {
+    String connectionId1 = "conn-id-1";
+    String connectionId2 = "conn-id-2";
+    String connectionId3 = "conn-id-3";
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId1))
+            .withEndpoints(
+                java.util.Arrays.asList(
+                    new ClientRouteProxy(connectionId2), new ClientRouteProxy(connectionId3)))
+            .build();
+
+    assertThat(config.getEndpoints()).hasSize(2);
+    assertThat(config.getEndpoints().get(0).getConnectionId()).isEqualTo(connectionId2);
+    assertThat(config.getEndpoints().get(1).getConnectionId()).isEqualTo(connectionId3);
+  }
+
+  @Test
+  public void should_reject_connection_addr_with_port() {
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "host.example.com:9042"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("without a port");
+  }
+
+  @Test
+  public void should_reject_ipv6_bracketed_connection_addr_with_port() {
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "[::1]:9042"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("without a port");
+  }
+
+  @Test
+  public void should_reject_connection_addr_with_leading_colon_port() {
+    // ":9042" is a port-only string with no hostname — must be rejected
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", ":9042"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("without a port");
+  }
+
+  @Test
+  public void should_accept_plain_hostname_connection_addr() {
+    ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "host.example.com");
+    assertThat(ep.getConnectionAddr()).isEqualTo("host.example.com");
+  }
+
+  @Test
+  public void should_accept_ipv4_connection_addr() {
+    ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "10.0.1.5");
+    assertThat(ep.getConnectionAddr()).isEqualTo("10.0.1.5");
+  }
+
+  @Test
+  public void should_accept_bare_ipv6_connection_addr() {
+    // Bare IPv6 contains multiple colons — should NOT be treated as host:port
+    ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "::1");
+    assertThat(ep.getConnectionAddr()).isEqualTo("::1");
+  }
+
+  @Test
+  public void should_reject_connection_addr_with_spaces() {
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "host name.example.com"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid characters");
+  }
+
+  @Test
+  public void should_reject_connection_addr_with_special_characters() {
+    assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "host!@#.example.com"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid characters");
+  }
+
+  @Test
+  public void should_equal_same_contact_point() {
+    ClientRouteProxy ep1 = new ClientRouteProxy("conn-id-1", "host1");
+    ClientRouteProxy ep2 = new ClientRouteProxy("conn-id-1", "host1");
+    assertThat(ep1).isEqualTo(ep2);
+    assertThat(ep1.hashCode()).isEqualTo(ep2.hashCode());
+  }
+
+  @Test
+  public void should_not_equal_different_connection_id() {
+    ClientRouteProxy ep1 = new ClientRouteProxy("conn-id-1", "host1");
+    ClientRouteProxy ep2 = new ClientRouteProxy("conn-id-2", "host1");
+    assertThat(ep1).isNotEqualTo(ep2);
+  }
+
+  @Test
+  public void should_not_equal_different_connection_addr() {
+    ClientRouteProxy ep1 = new ClientRouteProxy("conn-id-1", "host1");
+    ClientRouteProxy ep2 = new ClientRouteProxy("conn-id-1", "host2");
+    assertThat(ep1).isNotEqualTo(ep2);
+  }
+
+  @Test
+  public void should_equal_same_config() {
+    ClientRoutesConfig cfg1 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .build();
+    ClientRoutesConfig cfg2 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .build();
+    assertThat(cfg1).isEqualTo(cfg2);
+    assertThat(cfg1.hashCode()).isEqualTo(cfg2.hashCode());
+  }
+
+  @Test
+  public void should_not_equal_different_config_endpoints() {
+    ClientRoutesConfig cfg1 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .build();
+    ClientRoutesConfig cfg2 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-2", "host2"))
+            .build();
+    assertThat(cfg1).isNotEqualTo(cfg2);
+  }
+
+  @Test
+  public void should_return_unmodifiable_endpoints_list() {
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .build();
+
+    assertThatThrownBy(() -> config.getEndpoints().add(new ClientRouteProxy("conn-id-2")))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void should_not_equal_config_with_different_table_name() {
+    ClientRoutesConfig cfg1 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .build();
+    ClientRoutesConfig cfg2 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy("conn-id-1", "host1"))
+            .withTableName("custom.my_routes")
+            .build();
+    assertThat(cfg1).isNotEqualTo(cfg2);
+  }
+
+  @Test
+  public void should_not_equal_proxy_with_null_vs_non_null_connection_addr() {
+    ClientRouteProxy ep1 = new ClientRouteProxy("conn-id-1");
+    ClientRouteProxy ep2 = new ClientRouteProxy("conn-id-1", "host1");
+    assertThat(ep1).isNotEqualTo(ep2);
+    assertThat(ep2).isNotEqualTo(ep1);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/api/core/config/TypedDriverOptionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/config/TypedDriverOptionTest.java
@@ -44,7 +44,10 @@ public class TypedDriverOptionTest {
         ImmutableSet.of(
             DefaultDriverOption.LOAD_BALANCING_POLICY,
             DefaultDriverOption.RETRY_POLICY,
-            DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY);
+            DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY,
+            // CLIENT_ROUTES_ENDPOINTS is a HOCON list-of-objects: it cannot be represented as a
+            // flat TypedDriverOption scalar/list, so it is excluded from this check.
+            DefaultDriverOption.CLIENT_ROUTES_ENDPOINTS);
 
     for (DriverOption option :
         ImmutableSet.<DriverOption>builder()

--- a/core/src/test/java/com/datastax/oss/driver/api/core/session/ClientRoutesSessionBuilderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/session/ClientRoutesSessionBuilderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.UUID;
+import org.junit.Test;
+
+public class ClientRoutesSessionBuilderTest {
+
+  // ---------------------------------------------------------------------------
+  // SessionBuilder integration tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void should_set_client_routes_config_programmatically() {
+    String connectionId = UUID.randomUUID().toString();
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, "host"))
+            .build();
+
+    TestSessionBuilder builder = new TestSessionBuilder();
+    builder.withClientRoutesConfig(config);
+
+    assertThat(builder.programmaticArgumentsBuilder.build().getClientRoutesConfig())
+        .isEqualTo(config);
+  }
+
+  @Test
+  public void should_allow_null_client_routes_config() {
+    TestSessionBuilder builder = new TestSessionBuilder();
+    builder.withClientRoutesConfig(null);
+
+    assertThat(builder.programmaticArgumentsBuilder.build().getClientRoutesConfig()).isNull();
+  }
+
+  @Test
+  public void should_preserve_config_through_chained_builder_calls() {
+    String connectionId1 = UUID.randomUUID().toString();
+    String connectionId2 = UUID.randomUUID().toString();
+    ClientRoutesConfig config1 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId1, "host1"))
+            .build();
+    ClientRoutesConfig config2 =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId2, "host2"))
+            .build();
+
+    TestSessionBuilder builder = new TestSessionBuilder();
+    builder.withClientRoutesConfig(config1);
+    builder.withClientRoutesConfig(config2);
+
+    // Last call wins
+    assertThat(builder.programmaticArgumentsBuilder.build().getClientRoutesConfig())
+        .isEqualTo(config2);
+  }
+
+  @Test
+  public void should_override_config_with_null() {
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(UUID.randomUUID().toString(), "host"))
+            .build();
+
+    TestSessionBuilder builder = new TestSessionBuilder();
+    builder.withClientRoutesConfig(config);
+    builder.withClientRoutesConfig(null);
+
+    assertThat(builder.programmaticArgumentsBuilder.build().getClientRoutesConfig()).isNull();
+  }
+
+  /** Test subclass to access protected fields. */
+  private static class TestSessionBuilder extends SessionBuilder<TestSessionBuilder, CqlSession> {
+    @Override
+    protected CqlSession wrap(@NonNull CqlSession defaultSession) {
+      return mock(CqlSession.class);
+    }
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
@@ -36,6 +36,7 @@ import com.datastax.oss.driver.api.core.auth.AuthenticationException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.connection.ConnectionInitException;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.DefaultProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
@@ -45,6 +46,7 @@ import com.datastax.oss.driver.internal.core.metadata.TestNodeFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.ProtocolConstants.ErrorCode;
 import com.datastax.oss.protocol.internal.request.AuthResponse;
 import com.datastax.oss.protocol.internal.request.Options;
 import com.datastax.oss.protocol.internal.request.Query;
@@ -648,5 +650,57 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
 
     logger.detachAppender(appender);
     logger.setLevel(levelBefore);
+  }
+
+  @Test
+  public void should_fail_connection_when_client_routes_change_rejected() {
+    List<String> eventTypes =
+        ImmutableList.of(
+            ProtocolConstants.EventType.SCHEMA_CHANGE,
+            ProtocolConstants.EventType.STATUS_CHANGE,
+            ProtocolConstants.EventType.TOPOLOGY_CHANGE,
+            ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE);
+    EventCallback eventCallback = mock(EventCallback.class);
+    DriverChannelOptions driverChannelOptions =
+        DriverChannelOptions.builder().withEvents(eventTypes, eventCallback).build();
+    channel
+        .pipeline()
+        .addLast(
+            ChannelFactory.INIT_HANDLER_NAME,
+            new ProtocolInitHandler(
+                internalDriverContext,
+                DefaultProtocolVersion.V4,
+                null,
+                END_POINT,
+                driverChannelOptions,
+                heartbeatHandler,
+                false));
+
+    ChannelFuture connectFuture = channel.connect(new InetSocketAddress("localhost", 9042));
+
+    // STARTUP
+    writeInboundFrame(readOutboundFrame(), new Ready());
+    // Cluster name check
+    writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("someClusterName"));
+
+    // REGISTER attempt includes CLIENT_ROUTES_CHANGE
+    Frame registerFrame = readOutboundFrame();
+    assertThat(registerFrame.message).isInstanceOf(Register.class);
+    Register firstRegister = (Register) registerFrame.message;
+    assertThat(firstRegister.eventTypes).contains(ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE);
+
+    // Server rejects with PROTOCOL_ERROR mentioning CLIENT_ROUTES_CHANGE
+    writeInboundFrame(
+        registerFrame,
+        new Error(
+            ErrorCode.PROTOCOL_ERROR,
+            "Unknown event type: " + ProtocolConstants.EventType.CLIENT_ROUTES_CHANGE));
+
+    // Connection must fail with a clear error message
+    assertThat(connectFuture).isFailed();
+    assertThat(connectFuture.cause())
+        .isInstanceOf(ConnectionInitException.class)
+        .hasMessageContaining("CLIENT_ROUTES_CHANGE")
+        .hasMessageContaining("ScyllaDB Enterprise >= 2026.1");
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/ClientRoutesConfigFromFileTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/ClientRoutesConfigFromFileTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
+import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
+import com.datastax.oss.driver.internal.core.metadata.ClientRoutesTopologyMonitor;
+import com.typesafe.config.ConfigFactory;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit tests for config-file-based client routes parsing in {@link DefaultDriverContext}.
+ *
+ * <p>Each test builds a minimal {@link DefaultDriverContext} from an inline HOCON snippet and
+ * verifies that {@link DefaultDriverContext#buildClientRoutesConfigFromFile()} correctly parses (or
+ * rejects) the {@code advanced.client-routes} section.
+ *
+ * <p>Note: {@code connection-addr} must be a plain DNS name or IP address (e.g. {@code
+ * "cluster.example.com"} or {@code "10.0.1.5"}). It must not include a port.
+ */
+public class ClientRoutesConfigFromFileTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesConfigFromFileTest.class);
+
+  private final List<DefaultDriverContext> createdContexts = new ArrayList<>();
+
+  @After
+  public void tearDown() {
+    for (DefaultDriverContext ctx : createdContexts) {
+      try {
+        ctx.getNettyOptions().onClose().syncUninterruptibly();
+      } catch (Exception e) {
+        LOG.warn("Error closing DefaultDriverContext during test tearDown", e);
+      }
+    }
+    createdContexts.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a {@link DefaultDriverContext} whose configuration is the driver's {@code
+   * reference.conf} merged on top of the supplied extra HOCON string.
+   */
+  private DefaultDriverContext contextFromHocon(String extraHocon) {
+    return contextFromHocon(extraHocon, ProgrammaticArguments.builder().build());
+  }
+
+  private DefaultDriverContext contextFromHocon(
+      String extraHocon, ProgrammaticArguments programmaticArguments) {
+    DriverConfigLoader loader =
+        new DefaultDriverConfigLoader(
+            () -> {
+              ConfigFactory.invalidateCaches();
+              return ConfigFactory.parseString(extraHocon)
+                  .withFallback(
+                      ConfigFactory.defaultReference()
+                          .getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH));
+            });
+    DefaultDriverContext ctx = new DefaultDriverContext(loader, programmaticArguments);
+    createdContexts.add(ctx);
+    return ctx;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Happy-path: endpoint parsing
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void should_parse_single_endpoint_without_addr() {
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]");
+
+    ClientRoutesConfig cfg = ctx.buildClientRoutesConfigFromFile();
+
+    assertThat(cfg).isNotNull();
+    assertThat(cfg.getEndpoints()).hasSize(1);
+    ClientRouteProxy ep = cfg.getEndpoints().get(0);
+    assertThat(ep.getConnectionId()).isEqualTo("11111111-1111-1111-1111-111111111111");
+    assertThat(ep.getConnectionAddr()).isNull();
+  }
+
+  @Test
+  public void should_parse_single_endpoint_with_addr() {
+    // connection-addr is a plain hostname — no port
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\","
+                + "    connection-addr = \"cluster.example.com\" }"
+                + "]");
+
+    ClientRoutesConfig cfg = ctx.buildClientRoutesConfigFromFile();
+
+    assertThat(cfg).isNotNull();
+    List<ClientRouteProxy> eps = cfg.getEndpoints();
+    assertThat(eps).hasSize(1);
+    assertThat(eps.get(0).getConnectionId()).isEqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    assertThat(eps.get(0).getConnectionAddr()).isEqualTo("cluster.example.com");
+  }
+
+  @Test
+  public void should_parse_multiple_endpoints() {
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\","
+                + "    connection-addr = \"node1.example.com\" },"
+                + "  { connection-id = \"22222222-2222-2222-2222-222222222222\" }"
+                + "]");
+
+    ClientRoutesConfig cfg = ctx.buildClientRoutesConfigFromFile();
+
+    assertThat(cfg).isNotNull();
+    assertThat(cfg.getEndpoints()).hasSize(2);
+    assertThat(cfg.getEndpoints().get(0).getConnectionId())
+        .isEqualTo("11111111-1111-1111-1111-111111111111");
+    assertThat(cfg.getEndpoints().get(0).getConnectionAddr()).isEqualTo("node1.example.com");
+    assertThat(cfg.getEndpoints().get(1).getConnectionId())
+        .isEqualTo("22222222-2222-2222-2222-222222222222");
+    assertThat(cfg.getEndpoints().get(1).getConnectionAddr()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Happy-path: scalar options
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void should_always_use_default_table_name() {
+    // Even if table-name is present in the HOCON (legacy config), it must be ignored —
+    // the table name is no longer a file-config property.
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes {\n"
+                + "  endpoints = [{ connection-id = \"11111111-1111-1111-1111-111111111111\" }]\n"
+                + "  table-name = \"test.should_be_ignored\"\n"
+                + "}");
+
+    assertThat(ctx.buildClientRoutesConfigFromFile().getTableName())
+        .isEqualTo("system.client_routes");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Absent / disabled
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void should_return_null_when_endpoints_not_configured() {
+    // No endpoints key — reference.conf comments it out, so client routes are disabled
+    DefaultDriverContext ctx = contextFromHocon("");
+
+    assertThat(ctx.buildClientRoutesConfigFromFile()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error cases
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void should_throw_when_endpoints_list_is_empty() {
+    DefaultDriverContext ctx = contextFromHocon("advanced.client-routes.endpoints = []");
+
+    assertThatThrownBy(ctx::buildClientRoutesConfigFromFile)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("no entries");
+  }
+
+  @Test
+  public void should_throw_when_endpoint_missing_connection_id() {
+    // connection-addr without connection-id should fail validation
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = [{ connection-addr = \"host.example.com\" }]");
+
+    assertThatThrownBy(ctx::buildClientRoutesConfigFromFile)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("connection-id");
+  }
+
+  @Test
+  public void should_allow_client_routes_with_unqualified_passthrough_address_translator() {
+    // Unqualified short name — default package resolution must find PassThroughAddressTranslator
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]\n"
+                + "advanced.address-translator.class = PassThroughAddressTranslator");
+
+    assertThat(ctx.getTopologyMonitor()).isInstanceOf(ClientRoutesTopologyMonitor.class);
+  }
+
+  @Test
+  public void should_allow_client_routes_with_qualified_passthrough_address_translator() {
+    // Fully-qualified name — direct class load, no package prefix appended
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]\n"
+                + "advanced.address-translator.class ="
+                + " com.datastax.oss.driver.internal.core.addresstranslation"
+                + ".PassThroughAddressTranslator");
+
+    assertThat(ctx.getTopologyMonitor()).isInstanceOf(ClientRoutesTopologyMonitor.class);
+  }
+
+  @Test
+  public void should_throw_when_secure_connect_bundle_and_client_routes_both_configured() {
+    ProgrammaticArguments args =
+        ProgrammaticArguments.builder()
+            .withCloudProxyAddress(new InetSocketAddress("127.0.0.1", 9042))
+            .build();
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]",
+            args);
+
+    assertThatThrownBy(ctx::getTopologyMonitor)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("secure connect bundle")
+        .hasMessageContaining("client routes");
+  }
+
+  @Test
+  public void should_throw_when_client_routes_and_unloadable_address_translator_class() {
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]\n"
+                + "advanced.address-translator.class ="
+                + " com.nonexistent.FakeAddressTranslator");
+
+    assertThatThrownBy(ctx::getTopologyMonitor)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Could not load AddressTranslator class")
+        .hasMessageContaining("com.nonexistent.FakeAddressTranslator");
+  }
+
+  @Test
+  public void should_throw_when_client_routes_and_custom_address_translator() {
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\" }"
+                + "]\n"
+                + "advanced.address-translator.class = Ec2MultiRegionAddressTranslator");
+
+    assertThatThrownBy(ctx::getTopologyMonitor)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Both client routes configuration and a custom AddressTranslator")
+        .hasMessageContaining("Ec2MultiRegionAddressTranslator");
+  }
+
+  @Test
+  public void should_throw_when_duplicate_connection_ids_in_config() {
+    DefaultDriverContext ctx =
+        contextFromHocon(
+            "advanced.client-routes.endpoints = ["
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\","
+                + "    connection-addr = \"host1.example.com\" },"
+                + "  { connection-id = \"11111111-1111-1111-1111-111111111111\","
+                + "    connection-addr = \"host2.example.com\" }"
+                + "]");
+
+    assertThatThrownBy(ctx::buildClientRoutesConfigFromFile)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate connection ID");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AdminResultTestHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AdminResultTestHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
+
+/** Test utility for constructing {@link AdminResult} mocks without network access. */
+public class AdminResultTestHelper {
+
+  /**
+   * Returns a mock {@link AdminResult} whose iterator yields the given rows. Suitable for
+   * single-page results; pagination ({@code hasNextPage}/{@code nextPage}) is not stubbed.
+   */
+  public static AdminResult mockResult(AdminRow... rows) {
+    AdminResult result = mock(AdminResult.class);
+    when(result.iterator()).thenAnswer(invocation -> Iterators.forArray(rows));
+    return result;
+  }
+
+  private AdminResultTestHelper() {}
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesEndPointTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesEndPointTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientRoutesEndPointTest {
+
+  @Mock private ClientRoutesTopologyMonitor topologyMonitor;
+  @Mock private EndPoint fallbackEndPoint;
+
+  // ---- resolve() ----------------------------------------------------------
+
+  @Test
+  public void should_resolve_via_topology_monitor() throws UnknownHostException {
+    UUID hostId = UUID.randomUUID();
+    InetSocketAddress expected = new InetSocketAddress("127.0.0.1", 9042);
+    when(topologyMonitor.resolve(hostId)).thenReturn(expected);
+
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep.resolve()).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_fallback_when_resolve_returns_null() throws UnknownHostException {
+    UUID hostId = UUID.randomUUID();
+    InetSocketAddress fallbackAddr = new InetSocketAddress("10.0.0.1", 9042);
+    when(topologyMonitor.resolve(hostId)).thenReturn(null);
+    when(fallbackEndPoint.resolve()).thenReturn(fallbackAddr);
+
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep.resolve()).isEqualTo(fallbackAddr);
+  }
+
+  @Test
+  public void should_wrap_io_exceptions_in_unchecked_io_exception() throws UnknownHostException {
+    UUID hostId = UUID.randomUUID();
+    when(topologyMonitor.resolve(hostId)).thenThrow(new UnknownHostException("no-such-host"));
+
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThatThrownBy(ep::resolve)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasCauseInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void should_reflect_route_changes_on_subsequent_resolve() throws UnknownHostException {
+    UUID hostId = UUID.randomUUID();
+    InetSocketAddress addr1 = new InetSocketAddress("127.0.0.1", 9042);
+    InetSocketAddress addr2 = new InetSocketAddress("10.0.0.1", 9043);
+    when(topologyMonitor.resolve(hostId)).thenReturn(addr1);
+
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep.resolve()).isEqualTo(addr1);
+
+    // Simulate route update in the topology monitor
+    when(topologyMonitor.resolve(hostId)).thenReturn(addr2);
+
+    assertThat(ep.resolve()).isEqualTo(addr2);
+  }
+
+  // ---- equals / hashCode --------------------------------------------------
+
+  @Test
+  public void should_be_equal_when_same_host_id() {
+    UUID hostId = UUID.randomUUID();
+    ClientRoutesEndPoint ep1 =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+    ClientRoutesEndPoint ep2 =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep1).isEqualTo(ep2);
+    assertThat(ep1.hashCode()).isEqualTo(ep2.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_different_host_id() {
+    ClientRoutesEndPoint ep1 =
+        new ClientRoutesEndPoint(topologyMonitor, UUID.randomUUID(), null, fallbackEndPoint);
+    ClientRoutesEndPoint ep2 =
+        new ClientRoutesEndPoint(topologyMonitor, UUID.randomUUID(), null, fallbackEndPoint);
+
+    assertThat(ep1).isNotEqualTo(ep2);
+  }
+
+  @Test
+  public void should_not_be_equal_to_non_client_routes_endpoint() {
+    UUID hostId = UUID.randomUUID();
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep).isNotEqualTo("not an endpoint");
+    assertThat(ep).isNotEqualTo(null);
+  }
+
+  // ---- asMetricPrefix() ---------------------------------------------------
+
+  @Test
+  public void should_use_host_id_as_metric_prefix_when_address_is_null() {
+    UUID hostId = UUID.randomUUID();
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep.asMetricPrefix()).isEqualTo(hostId.toString());
+  }
+
+  @Test
+  public void should_format_ipv4_metric_prefix() throws Exception {
+    UUID hostId = UUID.randomUUID();
+    InetAddress ipv4 = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, ipv4, fallbackEndPoint);
+
+    assertThat(ep.asMetricPrefix()).isEqualTo("10_0_0_1_" + hostId);
+  }
+
+  @Test
+  public void should_format_ipv6_metric_prefix() throws Exception {
+    UUID hostId = UUID.randomUUID();
+    InetAddress ipv6 =
+        InetAddress.getByAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, ipv6, fallbackEndPoint);
+
+    // IPv6 keeps colons (consistent with DefaultEndPoint), dots replaced by underscores
+    assertThat(ep.asMetricPrefix()).isEqualTo("0:0:0:0:0:0:0:1_" + hostId);
+  }
+
+  // ---- toString() ---------------------------------------------------------
+
+  @Test
+  public void should_return_host_id_as_string() {
+    UUID hostId = UUID.randomUUID();
+    ClientRoutesEndPoint ep =
+        new ClientRoutesEndPoint(topologyMonitor, hostId, null, fallbackEndPoint);
+
+    assertThat(ep.toString()).isEqualTo("ClientRoutesEndPoint(" + hostId + ")");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -1,0 +1,1349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.clientroutes.ClientRouteRecord;
+import com.datastax.oss.driver.internal.core.context.EventBus;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.control.ControlConnection;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientRoutesTopologyMonitorTest {
+
+  @Mock private InternalDriverContext context;
+  @Mock private ControlConnection controlConnection;
+  @Mock private DriverConfig driverConfig;
+  @Mock private DriverExecutionProfile defaultProfile;
+
+  private TestableClientRoutesTopologyMonitor handler;
+
+  /**
+   * Subclass exposing package-private {@code resolvedRoutesCache} so tests can inject test data
+   * without actually executing admin queries.
+   *
+   * <p>Also overrides {@link #runAdminQuery} to capture issued query strings and return an empty
+   * result, so tests can verify which queries were executed without touching the network.
+   */
+  @SuppressWarnings("NewClassNamingConvention")
+  static class TestableClientRoutesTopologyMonitor extends ClientRoutesTopologyMonitor {
+    final List<String> capturedQueries = new ArrayList<>();
+
+    private static final AdminResult EMPTY_RESULT = AdminResultTestHelper.mockResult();
+
+    volatile AdminResult nextQueryResult = EMPTY_RESULT;
+    volatile boolean failNextQuery = false;
+
+    TestableClientRoutesTopologyMonitor(InternalDriverContext ctx, ClientRoutesConfig cfg) {
+      super(ctx, cfg);
+    }
+
+    void setRoutes(Map<UUID, ClientRouteRecord> routes) {
+      setResolvedRoutes(routes);
+    }
+
+    Map<UUID, ClientRouteRecord> getRoutes() {
+      return getResolvedRoutes();
+    }
+
+    void mergeRoutesForTest(Map<UUID, ClientRouteRecord> incoming) {
+      mergeRoutes(incoming);
+    }
+
+    void removeRouteForTest(UUID hostId) {
+      removeRoute(hostId);
+    }
+
+    void setNextQueryResult(AdminResult result) {
+      this.nextQueryResult = result;
+    }
+
+    String lastCapturedQuery() {
+      return capturedQueries.get(capturedQueries.size() - 1);
+    }
+
+    @Override
+    @NonNull
+    protected CompletionStage<AdminResult> runAdminQuery(
+        @NonNull DriverChannel channel, @NonNull String queryString, @NonNull Duration timeout) {
+      capturedQueries.add(queryString);
+      if (failNextQuery) {
+        CompletableFuture<AdminResult> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("simulated failure"));
+        return failed;
+      }
+      return CompletableFuture.completedFuture(nextQueryResult);
+    }
+  }
+
+  private EventBus eventBus;
+  private String connectionId;
+
+  @Before
+  public void setup() {
+    eventBus = new EventBus("test");
+    connectionId = UUID.randomUUID().toString();
+
+    when(context.getSessionName()).thenReturn("test-session");
+    when(context.getEventBus()).thenReturn(eventBus);
+    when(context.getControlConnection()).thenReturn(controlConnection);
+    when(context.getConfig()).thenReturn(driverConfig);
+    when(driverConfig.getDefaultProfile()).thenReturn(defaultProfile);
+    when(defaultProfile.getDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT))
+        .thenReturn(Duration.ofSeconds(5));
+    when(defaultProfile.getBoolean(DefaultDriverOption.RECONNECT_ON_INIT)).thenReturn(false);
+    when(context.getSslEngineFactory()).thenReturn(Optional.empty());
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, "host1"))
+            .build();
+    handler = new TestableClientRoutesTopologyMonitor(context, config);
+  }
+
+  /**
+   * Stubs the control connection for init and calls {@link
+   * TestableClientRoutesTopologyMonitor#init()}. Only tests that exercise the reconnect / event
+   * path need this; tests that manipulate the routes cache directly should not call it.
+   */
+  private void initHandler() {
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    handler.init();
+  }
+
+  // ---- resolve() -------------------------------------------------------
+
+  @Test
+  public void should_return_null_for_unknown_host_id() throws UnknownHostException {
+    assertThat(handler.resolve(UUID.randomUUID())).isNull();
+  }
+
+  @Test
+  public void should_resolve_known_host_id() throws UnknownHostException {
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    InetSocketAddress result = handler.resolve(hostId);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_throw_after_close() {
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    handler.close();
+
+    assertThatThrownBy(() -> handler.resolve(hostId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+  }
+
+  @Test
+  public void should_throw_for_unresolvable_hostname() {
+    UUID hostId = UUID.randomUUID();
+    // Use a hostname guaranteed not to resolve
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId, new ClientRouteRecord(hostId, "this.host.does.not.exist.invalid", 9042)));
+
+    assertThatThrownBy(() -> handler.resolve(hostId)).isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void should_refresh_updates_routes() throws UnknownHostException {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+
+    handler.setRoutes(ImmutableMap.of(hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042)));
+    assertThat(handler.resolve(hostId1)).isNotNull();
+    assertThat(handler.resolve(hostId2)).isNull();
+
+    // Simulate a refresh that swaps in a different set of routes
+    handler.setRoutes(ImmutableMap.of(hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+
+    assertThat(handler.resolve(hostId1)).isNull();
+    assertThat(handler.resolve(hostId2)).isNotNull();
+  }
+
+  // ---- Merge behavior tests -----------------------------------------------
+
+  @Test
+  public void should_preserve_existing_routes_on_merge() throws UnknownHostException {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    UUID hostId3 = UUID.randomUUID();
+
+    // Initial routes: hostId1 and hostId2
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+
+    // Verify initial state
+    assertThat(handler.resolve(hostId1).getPort()).isEqualTo(9042);
+    assertThat(handler.resolve(hostId2).getPort()).isEqualTo(9042);
+    assertThat(handler.resolve(hostId3)).isNull();
+
+    // Simulate a targeted merge that adds hostId3
+    Map<UUID, ClientRouteRecord> incoming = new HashMap<>();
+    incoming.put(hostId3, new ClientRouteRecord(hostId3, "127.0.0.3", 9043));
+    handler.mergeRoutesForTest(incoming);
+
+    // All three hosts should now be resolvable
+    assertThat(handler.resolve(hostId1).getPort()).isEqualTo(9042);
+    assertThat(handler.resolve(hostId2).getPort()).isEqualTo(9042);
+    assertThat(handler.resolve(hostId3).getPort()).isEqualTo(9043);
+  }
+
+  @Test
+  public void should_update_existing_route_on_merge() throws UnknownHostException {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+
+    // Initial routes
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+
+    // Verify initial port
+    assertThat(handler.resolve(hostId1).getPort()).isEqualTo(9042);
+    assertThat(handler.resolve(hostId2).getPort()).isEqualTo(9042);
+
+    // Simulate a targeted update that changes hostId1's port
+    Map<UUID, ClientRouteRecord> incoming = new HashMap<>();
+    incoming.put(hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9999));
+    handler.mergeRoutesForTest(incoming);
+
+    // hostId1 should have new port, hostId2 should be unchanged
+    assertThat(handler.resolve(hostId1).getPort()).isEqualTo(9999);
+    assertThat(handler.resolve(hostId2).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_return_configured_connection_ids() {
+    // The handler was created with one endpoint in setup()
+    ClientRoutesConfig cfg = handler.getClientRoutesConfig();
+    assertThat(cfg.getEndpoints()).hasSize(1);
+    assertThat(cfg.getEndpoints().get(0).getConnectionId()).isNotNull();
+  }
+
+  // ---- Reconnect re-query tests -------------------------------------------
+
+  @Test
+  public void should_query_routes_on_init() {
+    // init() pre-loads routes; verify one query was issued
+    initHandler();
+
+    assertThat(handler.capturedQueries).hasSize(1);
+    String query = handler.capturedQueries.get(0);
+    assertThat(query)
+        .startsWith(
+            "SELECT host_id, address, port, tls_port, connection_id FROM system.client_routes");
+  }
+
+  @Test
+  public void should_requery_routes_on_refresh() {
+    // init() issues the first query; refresh() should issue another
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    // Simulate reconnect-triggered refresh (called by ControlConnection.onSuccessfulReconnect)
+    handler.refresh();
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 1);
+  }
+
+  @Test
+  public void should_issue_full_scan_query_on_refresh() {
+    initHandler();
+
+    handler.refresh();
+
+    // refresh() triggers queryClientRoutesAndCache(null, null) — a full scan scoped to the
+    // configured connection IDs, with ALLOW FILTERING (no host_id filter)
+    assertThat(handler.lastCapturedQuery())
+        .contains("WHERE connection_id IN (")
+        .contains(connectionId)
+        .contains("ALLOW FILTERING")
+        .doesNotContain("host_id IN");
+  }
+
+  @Test
+  public void should_issue_targeted_query_on_client_routes_change_event_with_both_ids() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    String hostId = UUID.randomUUID().toString();
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList(connectionId), Collections.singletonList(hostId));
+    eventBus.fire(event);
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 1);
+    // Both partition key components provided → no ALLOW FILTERING
+    assertThat(handler.lastCapturedQuery())
+        .contains("WHERE connection_id IN (")
+        .contains("AND host_id IN (")
+        .doesNotContain("ALLOW FILTERING");
+  }
+
+  @Test
+  public void should_not_requery_routes_on_refresh_after_close() throws Exception {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    handler.close();
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // close() sets the closed flag — refresh is a no-op
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit);
+  }
+
+  @Test
+  public void should_not_requery_routes_on_change_event_after_close() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    handler.close();
+
+    String hostId = UUID.randomUUID().toString();
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList(connectionId), Collections.singletonList(hostId)));
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit);
+  }
+
+  @Test
+  public void should_requery_routes_on_multiple_refreshes() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    handler.refresh();
+    handler.refresh();
+    handler.refresh();
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 3);
+  }
+
+  // ---- Query building edge cases ------------------------------------------
+
+  @Test
+  public void should_issue_connection_ids_only_query_on_change_event_with_no_host_ids() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList(connectionId), Collections.emptyList());
+    eventBus.fire(event);
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 1);
+    assertThat(handler.lastCapturedQuery())
+        .contains("WHERE connection_id IN (")
+        .contains("ALLOW FILTERING")
+        .doesNotContain("host_id IN");
+  }
+
+  @Test
+  public void should_fall_back_to_configured_connection_ids_on_empty_change_event() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent("UPDATED", Collections.emptyList(), Collections.emptyList());
+    eventBus.fire(event);
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 1);
+    assertThat(handler.lastCapturedQuery())
+        .contains(connectionId)
+        .contains("ALLOW FILTERING")
+        .doesNotContain("host_id IN");
+  }
+
+  // ---- CQL injection prevention tests ------------------------------------
+
+  @Test
+  public void should_escape_single_quotes_in_connection_ids() {
+    String maliciousId = "id') OR 1=1 --";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(maliciousId, "host1"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    h.init();
+
+    // Single quotes in the connection ID must be escaped (doubled)
+    assertThat(h.lastCapturedQuery()).contains("'id'') OR 1=1 --'");
+  }
+
+  @Test
+  public void should_reject_invalid_host_id_format() {
+    initHandler();
+
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList("not-a-uuid; DROP TABLE foo"));
+
+    assertThatThrownBy(() -> eventBus.fire(event))
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid host ID");
+  }
+
+  @Test
+  public void should_accept_valid_uuid_host_ids() {
+    initHandler();
+    int queriesAfterInit = handler.capturedQueries.size();
+
+    String hostId = UUID.randomUUID().toString();
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList(connectionId), Collections.singletonList(hostId));
+    eventBus.fire(event);
+
+    assertThat(handler.capturedQueries).hasSize(queriesAfterInit + 1);
+    assertThat(handler.lastCapturedQuery()).contains("host_id IN (" + hostId + ")");
+  }
+
+  // ---- Refresh queue tests --------------------------------------------------
+
+  /**
+   * Creates a handler whose first post-init query blocks on a delayed future. Subsequent queries
+   * (from queue drains) complete immediately with the provided empty result.
+   */
+  private TestableClientRoutesTopologyMonitor createDelayedHandler(
+      CompletableFuture<AdminResult> delayedFuture, AdminResult emptyResult) {
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, "host1"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config) {
+          volatile boolean initDone = false;
+          volatile boolean firstPostInitDone = false;
+
+          @Override
+          @NonNull
+          protected CompletionStage<AdminResult> runAdminQuery(
+              @NonNull DriverChannel channel,
+              @NonNull String queryString,
+              @NonNull Duration timeout) {
+            capturedQueries.add(queryString);
+            if (!initDone) {
+              initDone = true;
+              return CompletableFuture.completedFuture(emptyResult);
+            }
+            if (!firstPostInitDone) {
+              firstPostInitDone = true;
+              return delayedFuture;
+            }
+            return CompletableFuture.completedFuture(emptyResult);
+          }
+        };
+
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    h.init();
+    return h;
+  }
+
+  @Test
+  public void should_queue_and_drain_concurrent_refresh_requests() throws Exception {
+    CompletableFuture<AdminResult> delayedFuture = new CompletableFuture<>();
+    AdminResult emptyResult = AdminResultTestHelper.mockResult();
+    TestableClientRoutesTopologyMonitor h = createDelayedHandler(delayedFuture, emptyResult);
+    int queriesAfterInit = h.capturedQueries.size();
+
+    // Fire two refresh requests while the first is still in-flight
+    h.refresh();
+    h.refresh();
+
+    // Only one query issued so far; the second is queued
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    // Complete the in-flight query — the queued request should drain and fire a second query
+    delayedFuture.complete(emptyResult);
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 2);
+  }
+
+  @Test
+  public void should_coalesce_two_full_refreshes_into_one() throws Exception {
+    CompletableFuture<AdminResult> delayedFuture = new CompletableFuture<>();
+    AdminResult emptyResult = AdminResultTestHelper.mockResult();
+    TestableClientRoutesTopologyMonitor h = createDelayedHandler(delayedFuture, emptyResult);
+    int queriesAfterInit = h.capturedQueries.size();
+
+    // Three full refreshes while the first is in-flight
+    h.refresh();
+    h.refresh();
+    h.refresh();
+
+    // Only one query in-flight; the other two coalesce into a single queued request
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    delayedFuture.complete(emptyResult);
+
+    // Drain fires exactly one more query (not two)
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 2);
+  }
+
+  @Test
+  public void should_coalesce_targeted_refreshes_and_merge_host_ids() throws Exception {
+    CompletableFuture<AdminResult> delayedFuture = new CompletableFuture<>();
+    AdminResult emptyResult = AdminResultTestHelper.mockResult();
+    TestableClientRoutesTopologyMonitor h = createDelayedHandler(delayedFuture, emptyResult);
+    int queriesAfterInit = h.capturedQueries.size();
+
+    // Start a full refresh (blocks on delayedFuture)
+    h.refresh();
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    // Queue two targeted events with different host IDs
+    String hostIdA = UUID.randomUUID().toString();
+    String hostIdB = UUID.randomUUID().toString();
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostIdA)));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostIdB)));
+
+    // Still one query in-flight; two events coalesced into one queued request
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    delayedFuture.complete(emptyResult);
+
+    // Drain fires one query containing both host IDs
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 2);
+    String drainedQuery = h.lastCapturedQuery();
+    assertThat(drainedQuery).contains("host_id IN (");
+    assertThat(drainedQuery).contains(hostIdA);
+    assertThat(drainedQuery).contains(hostIdB);
+  }
+
+  @Test
+  public void should_upgrade_queued_targeted_to_full_when_full_arrives() throws Exception {
+    CompletableFuture<AdminResult> delayedFuture = new CompletableFuture<>();
+    AdminResult emptyResult = AdminResultTestHelper.mockResult();
+    TestableClientRoutesTopologyMonitor h = createDelayedHandler(delayedFuture, emptyResult);
+    int queriesAfterInit = h.capturedQueries.size();
+
+    // Start a targeted refresh (blocks on delayedFuture)
+    String hostId = UUID.randomUUID().toString();
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList(connectionId), Collections.singletonList(hostId)));
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    // Queue a full refresh — should upgrade the queued request
+    h.refresh();
+
+    delayedFuture.complete(emptyResult);
+
+    // The drained query should be a full refresh (no host_id filter, has ALLOW FILTERING)
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 2);
+    String drainedQuery = h.lastCapturedQuery();
+    assertThat(drainedQuery).doesNotContain("host_id IN");
+    assertThat(drainedQuery).contains("ALLOW FILTERING");
+  }
+
+  @Test
+  public void should_not_drain_queued_refresh_after_close() throws Exception {
+    CompletableFuture<AdminResult> delayedFuture = new CompletableFuture<>();
+    AdminResult emptyResult = AdminResultTestHelper.mockResult();
+    TestableClientRoutesTopologyMonitor h = createDelayedHandler(delayedFuture, emptyResult);
+    int queriesAfterInit = h.capturedQueries.size();
+
+    // Start a refresh (blocks on delayedFuture), then queue another
+    h.refresh();
+    h.refresh();
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+
+    // Close before the in-flight refresh completes
+    h.close();
+    delayedFuture.complete(emptyResult);
+
+    // Queued request should NOT drain — only the original in-flight query ran
+    assertThat(h.capturedQueries).hasSize(queriesAfterInit + 1);
+  }
+
+  // ---- Concurrent mergeRoutes CAS retry test --------------------------------
+
+  @Test
+  public void should_handle_concurrent_merge_routes() throws Exception {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    UUID hostId3 = UUID.randomUUID();
+
+    handler.setRoutes(ImmutableMap.of(hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042)));
+
+    // CyclicBarrier forces both threads to reach the merge call at roughly the same time,
+    // maximising the chance of actual CAS contention on the routes cache.
+    CyclicBarrier barrier = new CyclicBarrier(2);
+
+    // Run two concurrent merges
+    Thread t1 =
+        new Thread(
+            () -> {
+              try {
+                barrier.await();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              Map<UUID, ClientRouteRecord> incoming = new HashMap<>();
+              incoming.put(hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042));
+              handler.mergeRoutesForTest(incoming);
+            });
+    Thread t2 =
+        new Thread(
+            () -> {
+              try {
+                barrier.await();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              Map<UUID, ClientRouteRecord> incoming = new HashMap<>();
+              incoming.put(hostId3, new ClientRouteRecord(hostId3, "127.0.0.3", 9042));
+              handler.mergeRoutesForTest(incoming);
+            });
+
+    t1.start();
+    t2.start();
+    t1.join(5000);
+    t2.join(5000);
+
+    // All three hosts should be present regardless of CAS retry ordering
+    assertThat(handler.getRoutes()).containsKeys(hostId1, hostId2, hostId3);
+  }
+
+  // ---- Null control connection channel ------------------------------------
+
+  @Test
+  public void should_not_throw_when_control_connection_channel_is_null() throws Exception {
+    // controlConnection.channel() is not stubbed in setup(), so it returns null by default
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // No exception; routes cache unchanged (still empty)
+    assertThat(handler.getRoutes()).isEmpty();
+  }
+
+  // ---- connectionAddr override tests ---------------------------------------
+
+  @Test
+  public void should_apply_connection_addr_override_when_connection_id_matches() throws Exception {
+    String connId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("original.example.com");
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(true);
+    when(row.isNull("connection_id")).thenReturn(false);
+    when(row.getString("connection_id")).thenReturn(connId);
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsKey(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("override.example.com");
+  }
+
+  @Test
+  public void should_not_apply_override_when_connection_id_does_not_match() throws Exception {
+    String configConnId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(configConnId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("original.example.com");
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(true);
+    when(row.isNull("connection_id")).thenReturn(false);
+    when(row.getString("connection_id")).thenReturn("conn-2");
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsKey(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("original.example.com");
+  }
+
+  @Test
+  public void should_not_apply_override_when_connection_id_absent() throws Exception {
+    String configConnId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(configConnId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("original.example.com");
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(false);
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsKey(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("original.example.com");
+  }
+
+  @Test
+  public void should_selectively_apply_override_to_matching_routes_only() throws Exception {
+    String connId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId1 = UUID.randomUUID();
+    AdminRow matchingRow = Mockito.mock(AdminRow.class);
+    when(matchingRow.isNull("host_id")).thenReturn(false);
+    when(matchingRow.isNull("address")).thenReturn(false);
+    when(matchingRow.isNull("port")).thenReturn(false);
+    when(matchingRow.getUuid("host_id")).thenReturn(hostId1);
+    when(matchingRow.getString("address")).thenReturn("original-1.example.com");
+    when(matchingRow.getInteger("port")).thenReturn(9042);
+    when(matchingRow.contains("connection_id")).thenReturn(true);
+    when(matchingRow.isNull("connection_id")).thenReturn(false);
+    when(matchingRow.getString("connection_id")).thenReturn(connId);
+
+    UUID hostId2 = UUID.randomUUID();
+    AdminRow nonMatchingRow = Mockito.mock(AdminRow.class);
+    when(nonMatchingRow.isNull("host_id")).thenReturn(false);
+    when(nonMatchingRow.isNull("address")).thenReturn(false);
+    when(nonMatchingRow.isNull("port")).thenReturn(false);
+    when(nonMatchingRow.getUuid("host_id")).thenReturn(hostId2);
+    when(nonMatchingRow.getString("address")).thenReturn("original-2.example.com");
+    when(nonMatchingRow.getInteger("port")).thenReturn(9042);
+    when(nonMatchingRow.contains("connection_id")).thenReturn(true);
+    when(nonMatchingRow.isNull("connection_id")).thenReturn(false);
+    when(nonMatchingRow.getString("connection_id")).thenReturn("conn-other");
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(matchingRow, nonMatchingRow));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes().get(hostId1).getHostname()).isEqualTo("override.example.com");
+    assertThat(h.getRoutes().get(hostId2).getHostname()).isEqualTo("original-2.example.com");
+  }
+
+  // ---- Row parsing tests --------------------------------------------------
+
+  @Test
+  public void should_skip_rows_with_null_required_fields_and_still_process_valid_rows()
+      throws Exception {
+    UUID validHostId = UUID.randomUUID();
+
+    AdminRow nullRow = Mockito.mock(AdminRow.class);
+    when(nullRow.isNull("host_id")).thenReturn(true);
+
+    AdminRow validRow = Mockito.mock(AdminRow.class);
+    when(validRow.isNull("host_id")).thenReturn(false);
+    when(validRow.isNull("address")).thenReturn(false);
+    when(validRow.isNull("port")).thenReturn(false);
+    when(validRow.getUuid("host_id")).thenReturn(validHostId);
+    when(validRow.getString("address")).thenReturn("127.0.0.1");
+    when(validRow.getInteger("port")).thenReturn(9042);
+    when(validRow.contains("connection_id")).thenReturn(false);
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(nullRow, validRow));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(validHostId);
+    assertThat(handler.getRoutes().get(validHostId).getHostname()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  public void should_use_regular_port_when_ssl_disabled() throws Exception {
+    // Default handler has SSL disabled — should pick the regular port column
+    UUID hostId = UUID.randomUUID();
+
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("127.0.0.1");
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(false);
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsKey(hostId);
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_use_tls_port_when_ssl_enabled() throws Exception {
+    // Recreate handler with SSL enabled
+    when(context.getSslEngineFactory())
+        .thenReturn(
+            Optional.of(Mockito.mock(com.datastax.oss.driver.api.core.ssl.SslEngineFactory.class)));
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(UUID.randomUUID().toString(), "host1"))
+            .build();
+    TestableClientRoutesTopologyMonitor sslHandler =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("127.0.0.1");
+    when(row.isNull("tls_port")).thenReturn(false);
+    when(row.getInteger("tls_port")).thenReturn(9142);
+    when(row.contains("connection_id")).thenReturn(false);
+
+    sslHandler.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    sslHandler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(sslHandler.getRoutes()).containsKey(hostId);
+    assertThat(sslHandler.getRoutes().get(hostId).getPort()).isEqualTo(9142);
+  }
+
+  @Test
+  public void should_skip_route_when_ssl_enabled_but_tls_port_absent() throws Exception {
+    // Recreate handler with SSL enabled
+    when(context.getSslEngineFactory())
+        .thenReturn(
+            Optional.of(Mockito.mock(com.datastax.oss.driver.api.core.ssl.SslEngineFactory.class)));
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(UUID.randomUUID().toString(), "host1"))
+            .build();
+    TestableClientRoutesTopologyMonitor sslHandler =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("127.0.0.1");
+    // tls_port is null (default Mockito behavior for isNull) → route should be skipped
+
+    sslHandler.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    sslHandler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // tls_port absent with SSL enabled → route must be skipped
+    assertThat(sslHandler.getRoutes()).doesNotContainKey(hostId);
+  }
+
+  @Test
+  public void should_skip_route_when_port_is_null() throws Exception {
+    UUID hostId = UUID.randomUUID();
+
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(true);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.getString("address")).thenReturn("127.0.0.1");
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // port is null → route must be skipped
+    assertThat(handler.getRoutes()).doesNotContainKey(hostId);
+  }
+
+  // ---- Empty-result cache guard tests ------------------------------------
+
+  @Test
+  public void should_not_replace_non_empty_cache_with_empty_query_result() throws Exception {
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    // Simulate a full refresh that returns 0 rows (e.g. routes not visible on the queried node)
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult());
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // Cache must be preserved — the empty result should not wipe valid routes
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_replace_empty_cache_with_empty_query_result() throws Exception {
+    assertThat(handler.getRoutes()).isEmpty();
+
+    // Full refresh with 0 rows when cache is also empty — no-op
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult());
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).isEmpty();
+  }
+
+  @Test
+  public void should_replace_non_empty_cache_with_non_empty_query_result() throws Exception {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042)));
+
+    // Full refresh returns a different route set
+    AdminRow newRow = Mockito.mock(AdminRow.class);
+    when(newRow.isNull("host_id")).thenReturn(false);
+    when(newRow.isNull("address")).thenReturn(false);
+    when(newRow.isNull("port")).thenReturn(false);
+    when(newRow.getUuid("host_id")).thenReturn(hostId2);
+    when(newRow.getString("address")).thenReturn("127.0.0.2");
+    when(newRow.getInteger("port")).thenReturn(9043);
+    when(newRow.contains("connection_id")).thenReturn(false);
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(newRow));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // Cache should be fully replaced with the new results
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId2);
+    assertThat(handler.getRoutes().get(hostId2).getPort()).isEqualTo(9043);
+  }
+
+  // ---- error handling in queryAndResolveRoutes() --------------------------
+
+  @Test
+  public void should_not_propagate_exception_when_query_fails() throws Exception {
+    handler.failNextQuery = true;
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    // The stage must complete normally (no exception) even though the query failed.
+    CompletionStage<Void> stage = handler.refresh();
+    stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // The routes cache must remain untouched (still empty).
+    assertThat(handler.getRoutes()).isEmpty();
+  }
+
+  // ---- buildNodeEndPoint fallback -----------------------------------------
+
+  @Test
+  public void should_build_default_endpoint_when_host_id_is_null() {
+    // row.getUuid("host_id") returns null, triggering the hostId == null
+    // branch in buildNodeEndPoint which delegates to super.buildNodeEndPoint().
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.getUuid("host_id")).thenReturn(null);
+    when(row.contains("peer")).thenReturn(false); // local-node row → super returns localEndPoint
+    EndPoint localEndPoint = Mockito.mock(EndPoint.class);
+
+    EndPoint result = handler.buildNodeEndPoint(row, null, localEndPoint);
+
+    // hostId == null branch → super.buildNodeEndPoint() is called → returns localEndPoint
+    assertThat(result).isNotInstanceOf(ClientRoutesEndPoint.class);
+    assertThat(result).isSameAs(localEndPoint);
+  }
+
+  @Test
+  public void should_build_client_routes_endpoint_when_host_id_non_null() {
+    // Even with empty routes cache, a ClientRoutesEndPoint is created so it can
+    // resolve to PrivateLink address once the cache is populated.
+    assertThat(handler.getRoutes()).isEmpty();
+
+    UUID hostId = UUID.randomUUID();
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.contains("peer")).thenReturn(false);
+    EndPoint localEndPoint = Mockito.mock(EndPoint.class);
+
+    EndPoint result = handler.buildNodeEndPoint(row, null, localEndPoint);
+
+    assertThat(result).isInstanceOf(ClientRoutesEndPoint.class);
+    assertThat(((ClientRoutesEndPoint) result).getHostId()).isEqualTo(hostId);
+  }
+
+  // ---- Route removal tests --------------------------------------------------
+
+  @Test
+  public void should_remove_route_from_cache() throws UnknownHostException {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+
+    assertThat(handler.resolve(hostId1)).isNotNull();
+    assertThat(handler.resolve(hostId2)).isNotNull();
+
+    handler.removeRouteForTest(hostId1);
+
+    assertThat(handler.resolve(hostId1)).isNull();
+    assertThat(handler.resolve(hostId2)).isNotNull();
+  }
+
+  @Test
+  public void should_remove_stale_route_on_targeted_refresh() throws Exception {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+
+    // Pre-populate cache with two routes
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+    assertThat(handler.getRoutes()).containsKeys(hostId1, hostId2);
+
+    // Simulate a targeted refresh (CLIENT_ROUTES_CHANGE event) that mentions both host IDs,
+    // but the query result only returns hostId1 (hostId2 was decommissioned server-side).
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.isNull("address")).thenReturn(false);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId1);
+    when(row.getString("address")).thenReturn("127.0.0.1");
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(false);
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    handler.init();
+
+    // Fire a targeted event mentioning both host IDs
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            java.util.Arrays.asList(hostId1.toString(), hostId2.toString()));
+    eventBus.fire(event);
+
+    // hostId1 should still be present, hostId2 should have been removed
+    assertThat(handler.getRoutes()).containsKey(hostId1);
+    assertThat(handler.getRoutes()).doesNotContainKey(hostId2);
+  }
+
+  @Test
+  public void should_resolve_to_fallback_when_no_route_for_host_id() {
+    // Simulates a node that is not accessed via PrivateLink (no route in cache for its host_id).
+    // resolve() must return the regular endpoint address (the fallback), not throw.
+    UUID hostId = UUID.randomUUID();
+    InetSocketAddress fallbackAddress = new InetSocketAddress("127.0.0.99", 9999);
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.contains("peer")).thenReturn(false);
+    EndPoint localEndPoint = Mockito.mock(EndPoint.class);
+    when(localEndPoint.resolve()).thenReturn(fallbackAddress);
+
+    EndPoint endpoint = handler.buildNodeEndPoint(row, null, localEndPoint);
+    assertThat(endpoint).isInstanceOf(ClientRoutesEndPoint.class);
+
+    // Cache is empty (no PrivateLink route) → resolves to the regular endpoint address
+    SocketAddress resolved = ((ClientRoutesEndPoint) endpoint).resolve();
+    assertThat(resolved).isEqualTo(fallbackAddress);
+    Mockito.verify(localEndPoint).resolve();
+  }
+
+  // ---- savePort() --------------------------------------------------------
+
+  @Test
+  public void savePort_should_use_route_port_when_routes_available() {
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(
+            id1, new ClientRouteRecord(id1, "127.0.0.1", 19042),
+            id2, new ClientRouteRecord(id2, "127.0.0.2", 19042)));
+
+    DriverChannel channel = Mockito.mock(DriverChannel.class);
+    handler.savePort(channel);
+
+    assertThat(handler.port).isEqualTo(19042);
+  }
+
+  @Test
+  public void savePort_should_fall_through_to_super_when_routes_empty() {
+    // routes cache is empty by default
+    DriverChannel channel = Mockito.mock(DriverChannel.class);
+    EndPoint ep = Mockito.mock(EndPoint.class);
+    when(ep.resolve()).thenReturn(new InetSocketAddress("127.0.0.1", 9042));
+    when(channel.getEndPoint()).thenReturn(ep);
+
+    handler.savePort(channel);
+
+    assertThat(handler.port).isEqualTo(9042);
+  }
+
+  @Test
+  public void savePort_should_skip_when_port_already_set() {
+    handler.port = 12345;
+    UUID id = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(id, new ClientRouteRecord(id, "127.0.0.1", 19042)));
+
+    DriverChannel channel = Mockito.mock(DriverChannel.class);
+    handler.savePort(channel);
+
+    // Port remains unchanged
+    assertThat(handler.port).isEqualTo(12345);
+  }
+
+  // ---- Multi-endpoint tests -----------------------------------------------
+
+  @Test
+  public void should_use_in_clause_with_multiple_connection_ids() {
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    h.init();
+
+    String query = h.lastCapturedQuery();
+    assertThat(query)
+        .contains("WHERE connection_id IN (")
+        .contains("'" + connId1 + "'")
+        .contains("'" + connId2 + "'")
+        .contains("ALLOW FILTERING");
+  }
+
+  @Test
+  public void should_apply_correct_override_per_connection_id_with_multiple_endpoints()
+      throws Exception {
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId1 = UUID.randomUUID();
+    AdminRow row1 = Mockito.mock(AdminRow.class);
+    when(row1.isNull("host_id")).thenReturn(false);
+    when(row1.isNull("address")).thenReturn(false);
+    when(row1.isNull("port")).thenReturn(false);
+    when(row1.getUuid("host_id")).thenReturn(hostId1);
+    when(row1.getString("address")).thenReturn("10.0.0.1");
+    when(row1.getInteger("port")).thenReturn(9042);
+    when(row1.contains("connection_id")).thenReturn(true);
+    when(row1.isNull("connection_id")).thenReturn(false);
+    when(row1.getString("connection_id")).thenReturn(connId1);
+
+    UUID hostId2 = UUID.randomUUID();
+    AdminRow row2 = Mockito.mock(AdminRow.class);
+    when(row2.isNull("host_id")).thenReturn(false);
+    when(row2.isNull("address")).thenReturn(false);
+    when(row2.isNull("port")).thenReturn(false);
+    when(row2.getUuid("host_id")).thenReturn(hostId2);
+    when(row2.getString("address")).thenReturn("10.0.0.2");
+    when(row2.getInteger("port")).thenReturn(9042);
+    when(row2.contains("connection_id")).thenReturn(true);
+    when(row2.isNull("connection_id")).thenReturn(false);
+    when(row2.getString("connection_id")).thenReturn(connId2);
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row1, row2));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).hasSize(2);
+    assertThat(h.getRoutes().get(hostId1).getHostname()).isEqualTo("nlb1.example.com");
+    assertThat(h.getRoutes().get(hostId2).getHostname()).isEqualTo("nlb2.example.com");
+  }
+
+  @Test
+  public void should_merge_routes_from_multiple_connection_ids_correctly() throws Exception {
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    String connId3 = "conn-3";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId3, "nlb3.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    UUID hostId3 = UUID.randomUUID();
+
+    AdminRow row1 = Mockito.mock(AdminRow.class);
+    when(row1.isNull("host_id")).thenReturn(false);
+    when(row1.isNull("address")).thenReturn(false);
+    when(row1.isNull("port")).thenReturn(false);
+    when(row1.getUuid("host_id")).thenReturn(hostId1);
+    when(row1.getString("address")).thenReturn("10.0.0.1");
+    when(row1.getInteger("port")).thenReturn(9042);
+    when(row1.contains("connection_id")).thenReturn(true);
+    when(row1.isNull("connection_id")).thenReturn(false);
+    when(row1.getString("connection_id")).thenReturn(connId1);
+
+    AdminRow row2 = Mockito.mock(AdminRow.class);
+    when(row2.isNull("host_id")).thenReturn(false);
+    when(row2.isNull("address")).thenReturn(false);
+    when(row2.isNull("port")).thenReturn(false);
+    when(row2.getUuid("host_id")).thenReturn(hostId2);
+    when(row2.getString("address")).thenReturn("10.0.0.2");
+    when(row2.getInteger("port")).thenReturn(9043);
+    when(row2.contains("connection_id")).thenReturn(true);
+    when(row2.isNull("connection_id")).thenReturn(false);
+    when(row2.getString("connection_id")).thenReturn(connId2);
+
+    AdminRow row3 = Mockito.mock(AdminRow.class);
+    when(row3.isNull("host_id")).thenReturn(false);
+    when(row3.isNull("address")).thenReturn(false);
+    when(row3.isNull("port")).thenReturn(false);
+    when(row3.getUuid("host_id")).thenReturn(hostId3);
+    when(row3.getString("address")).thenReturn("10.0.0.3");
+    when(row3.getInteger("port")).thenReturn(9044);
+    when(row3.contains("connection_id")).thenReturn(true);
+    when(row3.isNull("connection_id")).thenReturn(false);
+    when(row3.getString("connection_id")).thenReturn(connId3);
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row1, row2, row3));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).hasSize(3);
+    assertThat(h.getRoutes().get(hostId1).getHostname()).isEqualTo("nlb1.example.com");
+    assertThat(h.getRoutes().get(hostId1).getPort()).isEqualTo(9042);
+    assertThat(h.getRoutes().get(hostId2).getHostname()).isEqualTo("nlb2.example.com");
+    assertThat(h.getRoutes().get(hostId2).getPort()).isEqualTo(9043);
+    assertThat(h.getRoutes().get(hostId3).getHostname()).isEqualTo("nlb3.example.com");
+    assertThat(h.getRoutes().get(hostId3).getPort()).isEqualTo(9044);
+
+    // Verify query uses IN clause with all three connection IDs
+    String query = h.lastCapturedQuery();
+    assertThat(query)
+        .contains("WHERE connection_id IN (")
+        .contains("'" + connId1 + "'")
+        .contains("'" + connId2 + "'")
+        .contains("'" + connId3 + "'");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesUpdateEventTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesUpdateEventTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ClientRoutesUpdateEventTest {
+
+  @Test
+  public void should_be_equal_when_same_fields() {
+    ClientRoutesUpdateEvent e1 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Arrays.asList("c1", "c2"), Arrays.asList("h1", "h2"));
+    ClientRoutesUpdateEvent e2 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Arrays.asList("c1", "c2"), Arrays.asList("h1", "h2"));
+
+    assertThat(e1).isEqualTo(e2);
+    assertThat(e1.hashCode()).isEqualTo(e2.hashCode());
+  }
+
+  @Test
+  public void should_not_be_equal_when_different_change_type() {
+    ClientRoutesUpdateEvent e1 =
+        new ClientRoutesUpdateEvent("UPDATED", Collections.emptyList(), Collections.emptyList());
+    ClientRoutesUpdateEvent e2 =
+        new ClientRoutesUpdateEvent("DELETED", Collections.emptyList(), Collections.emptyList());
+
+    assertThat(e1).isNotEqualTo(e2);
+  }
+
+  @Test
+  public void should_not_be_equal_when_different_connection_ids() {
+    ClientRoutesUpdateEvent e1 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList("c1"), Collections.emptyList());
+    ClientRoutesUpdateEvent e2 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList("c2"), Collections.emptyList());
+
+    assertThat(e1).isNotEqualTo(e2);
+  }
+
+  @Test
+  public void should_not_be_equal_when_different_host_ids() {
+    ClientRoutesUpdateEvent e1 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.emptyList(), Collections.singletonList("h1"));
+    ClientRoutesUpdateEvent e2 =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.emptyList(), Collections.singletonList("h2"));
+
+    assertThat(e1).isNotEqualTo(e2);
+  }
+
+  @Test
+  public void should_include_all_fields_in_toString() {
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent(
+            "UPDATED", Collections.singletonList("c1"), Collections.singletonList("h1"));
+
+    String str = event.toString();
+    assertThat(str).contains("UPDATED");
+    assertThat(str).contains("c1");
+    assertThat(str).contains("h1");
+  }
+
+  @Test
+  public void should_not_be_equal_to_null_or_other_type() {
+    ClientRoutesUpdateEvent event =
+        new ClientRoutesUpdateEvent("UPDATED", Collections.emptyList(), Collections.emptyList());
+
+    assertThat(event).isNotEqualTo(null);
+    assertThat(event).isNotEqualTo("not an event");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -50,7 +50,6 @@ import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
-import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
@@ -232,11 +231,13 @@ public class DefaultTopologyMonitorTest {
             });
     // The rpc_address in each row should have been tried, only the last row should have been
     // converted
+    // Note: getUuid("host_id") is called once in findInPeers for comparison
     verify(peer3).getUuid("host_id");
     verify(peer3, never()).getString(anyString());
 
     verify(peer2, times(2)).getUuid("host_id");
     verify(peer2).getString("data_center");
+    verify(peer2).getString("rack");
   }
 
   @Test
@@ -267,6 +268,7 @@ public class DefaultTopologyMonitorTest {
 
     verify(peer2, times(2)).getUuid("host_id");
     verify(peer2).getString("data_center");
+    verify(peer2).getString("rack");
   }
 
   @Test
@@ -300,6 +302,7 @@ public class DefaultTopologyMonitorTest {
 
     verify(peer1).getInetAddress("rpc_address");
     verify(peer1).getString("data_center");
+    verify(peer1).getString("rack");
   }
 
   @Test
@@ -333,6 +336,7 @@ public class DefaultTopologyMonitorTest {
 
     verify(peer1).getInetAddress("native_address");
     verify(peer1).getString("data_center");
+    verify(peer1).getString("rack");
   }
 
   @Test
@@ -782,9 +786,7 @@ public class DefaultTopologyMonitorTest {
   }
 
   private AdminResult mockResult(AdminRow... rows) {
-    AdminResult result = mock(AdminResult.class);
-    when(result.iterator()).thenReturn(Iterators.forArray(rows));
-    return result;
+    return AdminResultTestHelper.mockResult(rows);
   }
 
   private void assertLog(Level level, String message) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaQueriesTest.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.metadata.AdminResultTestHelper;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.time.Duration;
@@ -77,7 +78,7 @@ public abstract class SchemaQueriesTest {
   }
 
   protected static AdminResult mockResult(AdminRow... rows) {
-    return mockResult(null, rows);
+    return AdminResultTestHelper.mockResult(rows);
   }
 
   protected static AdminResult mockResult(AdminResult next, AdminRow... rows) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
@@ -1,0 +1,862 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.clientroutes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.IsolatedTests;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metadata.ClientRoutesTopologyMonitor;
+import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests for the PrivateLink client routes feature.
+ *
+ * <p>These tests require a ScyllaDB instance that exposes the {@code system.client_routes} table
+ * (introduced in scylladb/scylladb#27323). Routes are populated via the ScyllaDB REST API (port
+ * 10000, {@code /v2/client-routes}) rather than direct CQL writes to the system table.
+ *
+ * <p>The NLB simulation tests create ad-hoc CCM clusters with an NLB TCP proxy to verify end-to-end
+ * behaviour including node replacement, mixed proxy/direct topologies, and SSL with hostname
+ * verification through a proxy.
+ */
+@Category(IsolatedTests.class)
+@ScyllaRequirement(
+    minEnterprise = "2026.1",
+    description = "system.client_routes requires ScyllaDB Enterprise >= 2026.1")
+public class ClientRoutesIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesIT.class);
+
+  private static final int NLB_BASE_PORT = 29042;
+  private static final String NLB_ADDRESS = "127.254.254.254";
+  private static final String CONNECTION_ID = "11111111-1111-1111-1111-111111111111";
+  private static final String DC_NAME = "dc1";
+  private static final String CERT_PASSWORD = "testpass";
+
+  private static final BackendRequirementRule BACKEND_RULE = new BackendRequirementRule();
+
+  public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(1).build();
+
+  private static final SessionRule<CqlSession> SESSION_RULE =
+      SessionRule.builder(CCM_RULE).withKeyspace(false).build();
+
+  @ClassRule
+  public static final TestRule CHAIN =
+      RuleChain.outerRule(BACKEND_RULE).around(CCM_RULE).around(SESSION_RULE);
+
+  private String nodeAddress() {
+    return CCM_RULE.getCcmBridge().getNodeIpAddress(1);
+  }
+
+  private CqlSession openAdminSession() {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactEndPoints(CCM_RULE.getContactPoints())
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                    .build())
+            .build();
+  }
+
+  private void postRoute(String connectionId, UUID hostId, String address, int port)
+      throws IOException {
+    postRoute(connectionId, hostId, address, port, null);
+  }
+
+  private void postRoute(
+      String connectionId, UUID hostId, String address, int port, Integer tlsPort)
+      throws IOException {
+    StringBuilder json = new StringBuilder("[{");
+    json.append("\"connection_id\":\"").append(connectionId).append("\",");
+    json.append("\"host_id\":\"").append(hostId).append("\",");
+    json.append("\"address\":\"").append(address).append("\",");
+    json.append("\"port\":").append(port);
+    if (tlsPort != null) {
+      json.append(",\"tls_port\":").append(tlsPort);
+    }
+    json.append("}]");
+
+    CcmBridge ccm = CCM_RULE.getCcmBridge();
+    postJsonToApi("http://" + ccm.getNodeIpAddress(1) + ":10000/v2/client-routes", json.toString());
+  }
+
+  private void waitForRouteVisible(String connectionId) {
+    waitForRoutesVisibleOnNode(CCM_RULE.getCcmBridge(), 1, 1, null, connectionId);
+  }
+
+  private CqlSession openClientRoutesSession(ClientRoutesConfig config) {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactEndPoints(CCM_RULE.getContactPoints())
+            .withClientRoutesConfig(config)
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                    .build())
+            .build();
+  }
+
+  private ClientRoutesTopologyMonitor handlerOf(CqlSession session) {
+    ClientRoutesTopologyMonitor handler =
+        (ClientRoutesTopologyMonitor)
+            ((InternalDriverContext) session.getContext()).getTopologyMonitor();
+    assertThat(handler)
+        .as("ClientRoutesHandler must be non-null when ClientRoutesConfig is set")
+        .isNotNull();
+    return handler;
+  }
+
+  private void requireSystemClientRoutesTable(CqlSession admin) {
+    Row row =
+        admin
+            .execute(
+                "SELECT table_name FROM system_schema.tables"
+                    + " WHERE keyspace_name='system' AND table_name='client_routes'")
+            .one();
+    if (row == null) {
+      throw new AssumptionViolatedException(
+          "system.client_routes does not exist on this server — "
+              + "feature requires ScyllaDB Enterprise >= 2026.1 (not yet available on OSS). "
+              + "Skipping positive client-routes test.");
+    }
+  }
+
+  private InetSocketAddress tryResolve(ClientRoutesTopologyMonitor handler, UUID hostId) {
+    try {
+      return handler.resolve(hostId);
+    } catch (IllegalStateException e) {
+      return null;
+    } catch (UnknownHostException e) {
+      throw new RuntimeException("DNS resolution failed for host_id=" + hostId, e);
+    }
+  }
+
+  private static class NodeClassification {
+    final Map<UUID, InetSocketAddress> proxied = new HashMap<>();
+    final Map<UUID, InetSocketAddress> direct = new HashMap<>();
+    int proxiedConnected;
+    int directConnected;
+  }
+
+  private NodeClassification classifyNodes(CqlSession session) {
+    NodeClassification result = new NodeClassification();
+    for (Node node : session.getMetadata().getNodes().values()) {
+      InetSocketAddress addr = (InetSocketAddress) node.getEndPoint().resolve();
+      String ip = addr.getAddress().getHostAddress();
+      UUID hostId = node.getHostId();
+      boolean connected = node.getOpenConnections() > 0;
+      LOG.info(
+          "Node {} endpoint: {} (ip={}, port={}, connected={})",
+          hostId,
+          addr,
+          ip,
+          addr.getPort(),
+          connected);
+      if (NLB_ADDRESS.equals(ip)) {
+        result.proxied.put(hostId, addr);
+        if (connected) result.proxiedConnected++;
+      } else {
+        result.direct.put(hostId, addr);
+        if (connected) result.directConnected++;
+      }
+    }
+    return result;
+  }
+
+  private void assertNodeClassification(
+      CqlSession session, int expectedProxied, int expectedDirect) {
+    NodeClassification c = classifyNodes(session);
+    assertThat(c.proxied).as("Expected %d proxied nodes", expectedProxied).hasSize(expectedProxied);
+    assertThat(c.direct).as("Expected %d direct nodes", expectedDirect).hasSize(expectedDirect);
+    for (InetSocketAddress addr : c.direct.values()) {
+      assertThat(addr.getPort()).as("Direct node should use native transport port").isEqualTo(9042);
+    }
+  }
+
+  private void awaitConnectedNodes(CqlSession session, int expectedProxied, int expectedDirect) {
+    await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              NodeClassification c = classifyNodes(session);
+              LOG.info(
+                  "Waiting for connected nodes: proxied={}/{}, direct={}/{}",
+                  c.proxiedConnected,
+                  expectedProxied,
+                  c.directConnected,
+                  expectedDirect);
+              return c.proxiedConnected >= expectedProxied && c.directConnected >= expectedDirect;
+            });
+  }
+
+  private CqlSession openNlbSession(ClientRoutesConfig config, NlbSimulator nlb) {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactPoint(new InetSocketAddress(nlb.getBindAddress(), nlb.getDiscoveryPort()))
+            .withClientRoutesConfig(config)
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(15))
+                    .withDuration(
+                        DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(15))
+                    .withDuration(
+                        DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofSeconds(15))
+                    .build())
+            .build();
+  }
+
+  private void assertQueryWorks(CqlSession session) {
+    ResultSet rs = session.execute("SELECT release_version FROM system.local WHERE key='local'");
+    Row row = rs.one();
+    assertThat(row).as("Query via NLB should return a result").isNotNull();
+  }
+
+  private boolean querySucceeds(CqlSession session) {
+    try {
+      ResultSet rs = session.execute("SELECT release_version FROM system.local WHERE key='local'");
+      return rs.one() != null;
+    } catch (AllNodesFailedException e) {
+      return false;
+    } catch (Exception e) {
+      LOG.warn("querySucceeds: unexpected exception", e);
+      return false;
+    }
+  }
+
+  private Map<Integer, UUID> collectHostIds(CcmBridge ccm, int nodeCount) {
+    return collectHostIds(ccm, nodeCount, null);
+  }
+
+  private Map<Integer, UUID> collectHostIds(CcmBridge ccm, int nodeCount, String truststorePath) {
+    Map<Integer, UUID> hostIds = new HashMap<>();
+
+    Map<String, Integer> ipToNodeId = new HashMap<>();
+    for (int i = 1; i <= nodeCount; i++) {
+      ipToNodeId.put(ccm.getNodeIpAddress(i), i);
+    }
+
+    ProgrammaticDriverConfigLoaderBuilder loaderBuilder =
+        SessionUtils.configLoaderBuilder()
+            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10));
+    if (truststorePath != null) {
+      loaderBuilder
+          .withClass(DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, DefaultSslEngineFactory.class)
+          .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, true)
+          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PATH, truststorePath)
+          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, CERT_PASSWORD);
+    }
+
+    try (CqlSession adminSession =
+        (CqlSession)
+            SessionUtils.baseBuilder()
+                .addContactPoint(new InetSocketAddress(ccm.getNodeIpAddress(1), 9042))
+                .withConfigLoader(loaderBuilder.build())
+                .build()) {
+      for (Node node : adminSession.getMetadata().getNodes().values()) {
+        InetSocketAddress addr = (InetSocketAddress) node.getEndPoint().resolve();
+        String ip = addr.getAddress().getHostAddress();
+        Integer nodeId = ipToNodeId.get(ip);
+        if (nodeId != null && node.getHostId() != null) {
+          hostIds.put(nodeId, node.getHostId());
+        }
+      }
+    }
+
+    return hostIds;
+  }
+
+  private void postJsonToApi(String apiUrl, String jsonBody) throws IOException {
+    LOG.info("Posting to {}: {}", apiUrl, jsonBody);
+
+    HttpURLConnection conn = (HttpURLConnection) new URL(apiUrl).openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setDoOutput(true);
+      conn.setConnectTimeout(5000);
+      conn.setReadTimeout(5000);
+
+      try (OutputStream os = conn.getOutputStream()) {
+        os.write(jsonBody.getBytes(StandardCharsets.UTF_8));
+      }
+
+      int responseCode = conn.getResponseCode();
+      if (responseCode >= 400) {
+        StringBuilder errorBody = new StringBuilder();
+        try (BufferedReader br =
+            new BufferedReader(
+                new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
+          String line;
+          while ((line = br.readLine()) != null) {
+            errorBody.append(line);
+          }
+        }
+        throw new IOException(
+            "Failed to POST to " + apiUrl + ": HTTP " + responseCode + " - " + errorBody);
+      }
+
+      // Drain response body to allow connection reuse
+      try (InputStream is = conn.getInputStream()) {
+        byte[] buf = new byte[1024];
+        while (is.read(buf) >= 0) {
+          // discard
+        }
+      } catch (IOException ignored) {
+        // no body to drain
+      }
+
+      LOG.info("POST successful to {} (HTTP {})", apiUrl, responseCode);
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private void postClientRoutes(CcmBridge ccm, Map<Integer, UUID> hostIds, NlbSimulator nlb)
+      throws IOException {
+    if (hostIds.isEmpty()) {
+      throw new IllegalStateException("No active nodes to post routes to");
+    }
+
+    StringBuilder json = new StringBuilder("[");
+    boolean first = true;
+    for (Map.Entry<Integer, UUID> entry : hostIds.entrySet()) {
+      int nodeId = entry.getKey();
+      UUID hostId = entry.getValue();
+      int proxyPort = nlb.getNodePort(nodeId);
+
+      if (!first) json.append(",");
+      first = false;
+      json.append("{")
+          .append("\"connection_id\":\"")
+          .append(CONNECTION_ID)
+          .append("\",")
+          .append("\"host_id\":\"")
+          .append(hostId)
+          .append("\",")
+          .append("\"address\":\"")
+          .append(NLB_ADDRESS)
+          .append("\",")
+          .append("\"port\":")
+          .append(proxyPort)
+          .append("}");
+    }
+    json.append("]");
+
+    // Post to ALL active nodes to ensure routes are available cluster-wide,
+    // regardless of which node the NLB routes the control connection to.
+    // system.client_routes may use local storage or have replication delay,
+    // so posting to a single node risks the session connecting to a node
+    // that doesn't have the routes yet.
+    for (int nodeId : hostIds.keySet()) {
+      postJsonToApi(
+          "http://" + ccm.getNodeIpAddress(nodeId) + ":10000/v2/client-routes", json.toString());
+    }
+  }
+
+  private void waitForRoutesVisible(CcmBridge ccm, int expectedCount) {
+    waitForRoutesVisibleOnNode(ccm, 1, expectedCount, null, CONNECTION_ID);
+  }
+
+  private void waitForRoutesVisibleOnAllNodes(
+      CcmBridge ccm, Collection<Integer> nodeIds, int expectedCount) {
+    waitForRoutesVisibleOnAllNodes(ccm, nodeIds, expectedCount, null);
+  }
+
+  private void waitForRoutesVisibleOnAllNodes(
+      CcmBridge ccm, Collection<Integer> nodeIds, int expectedCount, String truststorePath) {
+    for (int nodeId : nodeIds) {
+      waitForRoutesVisibleOnNode(ccm, nodeId, expectedCount, truststorePath, CONNECTION_ID);
+    }
+  }
+
+  private void waitForRoutesVisibleOnNode(
+      CcmBridge ccm, int nodeId, int expectedCount, String truststorePath, String connectionId) {
+    ProgrammaticDriverConfigLoaderBuilder loaderBuilder =
+        SessionUtils.configLoaderBuilder()
+            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(5));
+    if (truststorePath != null) {
+      loaderBuilder
+          .withClass(DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, DefaultSslEngineFactory.class)
+          .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, true)
+          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PATH, truststorePath)
+          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, CERT_PASSWORD);
+    }
+    try (CqlSession adminSession =
+        (CqlSession)
+            SessionUtils.baseBuilder()
+                .addContactPoint(new InetSocketAddress(ccm.getNodeIpAddress(nodeId), 9042))
+                .withConfigLoader(loaderBuilder.build())
+                .build()) {
+      await()
+          .atMost(10, TimeUnit.SECONDS)
+          .pollInterval(500, TimeUnit.MILLISECONDS)
+          .until(
+              () -> {
+                ResultSet rs =
+                    adminSession.execute(
+                        SimpleStatement.newInstance(
+                            "SELECT * FROM system.client_routes WHERE connection_id = ?"
+                                + " ALLOW FILTERING",
+                            connectionId));
+                long count = rs.all().size();
+                LOG.info(
+                    "Waiting for routes on node {}: found {} of {} expected",
+                    nodeId,
+                    count,
+                    expectedCount);
+                return count >= expectedCount;
+              });
+    }
+  }
+
+  @Test
+  public void should_load_routes_from_table_on_init() throws Exception {
+    String connectionId = UUID.randomUUID().toString();
+    String nodeAddr = nodeAddress();
+
+    UUID hostId;
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+      Row localRow = admin.execute("SELECT host_id FROM system.local WHERE key='local'").one();
+      assertThat(localRow).isNotNull();
+      hostId = localRow.getUuid("host_id");
+      assertThat(hostId).isNotNull();
+    }
+
+    postRoute(connectionId, hostId, nodeAddr, 9042);
+    waitForRouteVisible(connectionId);
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+            .build();
+
+    try (CqlSession session = openClientRoutesSession(config)) {
+      ResultSet rs = session.execute("SELECT release_version FROM system.local WHERE key='local'");
+      assertThat(rs.one()).isNotNull();
+
+      InetSocketAddress translated = handlerOf(session).resolve(hostId);
+      assertThat(translated)
+          .as("Handler should have a translated address for host_id=%s", hostId)
+          .isNotNull();
+      assertThat(translated.getPort()).isEqualTo(9042);
+
+      LOG.info("Translated host_id={} -> {}", hostId, translated);
+    }
+  }
+
+  @Test
+  public void should_refresh_routes_after_table_update() throws Exception {
+    String connectionId = UUID.randomUUID().toString();
+    UUID hostId = UUID.randomUUID();
+    String nodeAddr = nodeAddress();
+
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+            .build();
+
+    try (CqlSession session = openClientRoutesSession(config)) {
+      ClientRoutesTopologyMonitor handler = handlerOf(session);
+
+      assertThat(handler.resolve(hostId)).isNull();
+
+      postRoute(connectionId, hostId, nodeAddr, 9042);
+      waitForRouteVisible(connectionId);
+      handler.refresh().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+      await()
+          .atMost(15, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> {
+                InetSocketAddress resolved = handler.resolve(hostId);
+                assertThat(resolved).isNotNull();
+                assertThat(resolved.getAddress().getHostAddress()).isEqualTo(nodeAddr);
+                assertThat(resolved.getPort()).isEqualTo(9042);
+              });
+    }
+  }
+
+  @Test
+  public void should_start_session_when_table_is_empty() throws UnknownHostException {
+    String nodeAddr = nodeAddress();
+    String connectionId = UUID.randomUUID().toString();
+
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+            .build();
+
+    try (CqlSession session = openClientRoutesSession(config)) {
+      ResultSet rs = session.execute("SELECT release_version FROM system.local WHERE key='local'");
+      assertThat(rs.one()).isNotNull();
+
+      // Route cache should be empty (no routes posted)
+      assertThat(handlerOf(session).resolve(UUID.randomUUID())).isNull();
+
+      // Session should still have connected nodes (via direct connection, not routes)
+      assertThat(session.getMetadata().getNodes())
+          .as("Session should have connected nodes even when routes table is empty")
+          .isNotEmpty();
+    }
+  }
+
+  @Test
+  public void should_select_non_ssl_port_when_ssl_not_configured() throws Exception {
+    String connectionId = UUID.randomUUID().toString();
+    UUID hostId = UUID.randomUUID();
+    String nodeAddr = nodeAddress();
+
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+
+    postRoute(connectionId, hostId, nodeAddr, 9042, 9142);
+    waitForRouteVisible(connectionId);
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+            .build();
+
+    try (CqlSession session = openClientRoutesSession(config)) {
+      ClientRoutesTopologyMonitor handler = handlerOf(session);
+
+      InetSocketAddress resolved = handler.resolve(hostId);
+      assertThat(resolved).isNotNull();
+      assertThat(resolved.getPort()).isEqualTo(9042);
+    }
+  }
+
+  @Test
+  public void should_refresh_routes_after_control_connection_reconnect() throws Exception {
+    String connectionId = UUID.randomUUID().toString();
+    UUID hostId = UUID.randomUUID();
+    String nodeAddr = nodeAddress();
+
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+            .build();
+
+    try (CqlSession session = openClientRoutesSession(config)) {
+      ClientRoutesTopologyMonitor handler = handlerOf(session);
+      assertThat(tryResolve(handler, hostId)).isNull();
+
+      postRoute(connectionId, hostId, nodeAddr, 9042);
+      waitForRouteVisible(connectionId);
+
+      ((InternalDriverContext) session.getContext()).getControlConnection().reconnectNow();
+
+      await().atMost(15, TimeUnit.SECONDS).until(() -> tryResolve(handler, hostId) != null);
+
+      assertThat(tryResolve(handler, hostId))
+          .as("Route should be available after reconnect and refresh for host_id=%s", hostId)
+          .isNotNull()
+          .extracting(InetSocketAddress::getPort)
+          .isEqualTo(9042);
+    }
+  }
+
+  @Test
+  public void should_survive_full_node_replacement_through_nlb() throws Exception {
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+    try (CcmBridge ccm = CcmBridge.builder().withNodes(2).build()) {
+      ccm.create();
+      ccm.start();
+
+      NlbSimulator nlb = new NlbSimulator(ccm, NLB_ADDRESS, NLB_BASE_PORT);
+      try {
+        nlb.addNode(1);
+        nlb.addNode(2);
+
+        Map<Integer, UUID> hostIds = collectHostIds(ccm, 2);
+        postClientRoutes(ccm, hostIds, nlb);
+        waitForRoutesVisibleOnAllNodes(ccm, hostIds.keySet(), hostIds.size());
+        ClientRoutesConfig config =
+            ClientRoutesConfig.builder()
+                .addEndpoint(new ClientRouteProxy(CONNECTION_ID, NLB_ADDRESS))
+                .build();
+
+        try (CqlSession session = openNlbSession(config, nlb)) {
+          assertQueryWorks(session);
+
+          assertThat(((InternalDriverContext) session.getContext()).getTopologyMonitor())
+              .isInstanceOf(ClientRoutesTopologyMonitor.class);
+          assertNodeClassification(session, 2, 0);
+          ccm.add(3, DC_NAME);
+          ccm.add(4, DC_NAME);
+
+          await()
+              .atMost(30, TimeUnit.SECONDS)
+              .pollInterval(2, TimeUnit.SECONDS)
+              .until(() -> session.getMetadata().getNodes().size() >= 4);
+
+          nlb.addNode(3);
+          nlb.addNode(4);
+
+          Map<Integer, UUID> allHostIds = collectHostIds(ccm, 4);
+          postClientRoutes(ccm, allHostIds, nlb);
+          awaitConnectedNodes(session, 4, 0);
+          assertQueryWorks(session);
+
+          ccm.decommission(1);
+          nlb.removeNode(1);
+          allHostIds.remove(1);
+          postClientRoutes(ccm, allHostIds, nlb);
+          waitForRoutesVisibleOnAllNodes(ccm, allHostIds.keySet(), allHostIds.size());
+
+          await()
+              .atMost(30, TimeUnit.SECONDS)
+              .pollInterval(2, TimeUnit.SECONDS)
+              .until(() -> querySucceeds(session) && session.getMetadata().getNodes().size() <= 3);
+
+          ccm.decommission(2);
+          nlb.removeNode(2);
+          allHostIds.remove(2);
+          postClientRoutes(ccm, allHostIds, nlb);
+          waitForRoutesVisibleOnAllNodes(ccm, allHostIds.keySet(), allHostIds.size());
+
+          await()
+              .atMost(30, TimeUnit.SECONDS)
+              .pollInterval(2, TimeUnit.SECONDS)
+              .until(() -> querySucceeds(session) && session.getMetadata().getNodes().size() <= 2);
+
+          awaitConnectedNodes(session, 2, 0);
+          assertQueryWorks(session);
+          assertNodeClassification(session, 2, 0);
+
+          for (int i = 0; i < 10; i++) {
+            assertQueryWorks(session);
+          }
+        }
+      } finally {
+        nlb.close();
+      }
+    }
+  }
+
+  @Test
+  public void should_select_tls_port_when_ssl_configured() throws Exception {
+    // Verify system.client_routes exists using the shared cluster (same Scylla version)
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+
+    // Create a dedicated SSL-enabled cluster
+    try (CcmBridge ccm = CcmBridge.builder().withNodes(1).withSsl().build()) {
+      ccm.create();
+      ccm.start();
+
+      String nodeAddr = ccm.getNodeIpAddress(1);
+      String truststorePath = CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath();
+      String truststorePassword = CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD;
+
+      // Collect host_id, post route, and wait for visibility using a single SSL admin session
+      String connectionId = UUID.randomUUID().toString();
+      UUID hostId;
+      try (CqlSession sslAdmin =
+          (CqlSession)
+              SessionUtils.baseBuilder()
+                  .addContactPoint(new InetSocketAddress(nodeAddr, 9042))
+                  .withConfigLoader(
+                      SessionUtils.configLoaderBuilder()
+                          .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                          .withClass(
+                              DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS,
+                              DefaultSslEngineFactory.class)
+                          .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
+                          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PATH, truststorePath)
+                          .withString(
+                              DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, truststorePassword)
+                          .build())
+                  .build()) {
+        Row localRow = sslAdmin.execute("SELECT host_id FROM system.local WHERE key='local'").one();
+        assertThat(localRow).isNotNull();
+        hostId = localRow.getUuid("host_id");
+        assertThat(hostId).isNotNull();
+
+        // Post route: port=19999 (invalid non-SSL) and tls_port=9042 (correct SSL port).
+        // If the handler incorrectly picks port instead of tls_port, connections will fail.
+        StringBuilder json = new StringBuilder("[{");
+        json.append("\"connection_id\":\"").append(connectionId).append("\",");
+        json.append("\"host_id\":\"").append(hostId).append("\",");
+        json.append("\"address\":\"").append(nodeAddr).append("\",");
+        json.append("\"port\":19999,\"tls_port\":9042}]");
+        postJsonToApi("http://" + nodeAddr + ":10000/v2/client-routes", json.toString());
+
+        // Wait for route visibility
+        await()
+            .atMost(10, TimeUnit.SECONDS)
+            .pollInterval(500, TimeUnit.MILLISECONDS)
+            .until(
+                () -> {
+                  ResultSet rs =
+                      sslAdmin.execute(
+                          SimpleStatement.newInstance(
+                              "SELECT * FROM system.client_routes WHERE connection_id = ?"
+                                  + " ALLOW FILTERING",
+                              connectionId));
+                  return rs.all().size() >= 1;
+                });
+      }
+
+      // Open session with SSL and client routes
+      ClientRoutesConfig config =
+          ClientRoutesConfig.builder()
+              .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+              .build();
+      try (CqlSession session =
+          (CqlSession)
+              SessionUtils.baseBuilder()
+                  .addContactPoint(new InetSocketAddress(nodeAddr, 9042))
+                  .withClientRoutesConfig(config)
+                  .withConfigLoader(
+                      SessionUtils.configLoaderBuilder()
+                          .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                          .withClass(
+                              DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS,
+                              DefaultSslEngineFactory.class)
+                          .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
+                          .withString(DefaultDriverOption.SSL_TRUSTSTORE_PATH, truststorePath)
+                          .withString(
+                              DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, truststorePassword)
+                          .build())
+                  .build()) {
+
+        ClientRoutesTopologyMonitor handler = handlerOf(session);
+        InetSocketAddress resolved = handler.resolve(hostId);
+        assertThat(resolved)
+            .as("Handler should resolve route for host_id=%s with SSL configured", hostId)
+            .isNotNull();
+        assertThat(resolved.getPort())
+            .as("Should select tls_port (9042) when SSL is configured, not port (19999)")
+            .isEqualTo(9042);
+
+        // Verify actual SSL query works through the client routes endpoint
+        ResultSet rs =
+            session.execute("SELECT release_version FROM system.local WHERE key='local'");
+        assertThat(rs.one()).isNotNull();
+      }
+    }
+  }
+
+  @Test
+  public void should_work_with_mixed_proxy_and_direct_nodes() throws Exception {
+    try (CqlSession admin = openAdminSession()) {
+      requireSystemClientRoutesTable(admin);
+    }
+    try (CcmBridge ccm = CcmBridge.builder().withNodes(3).build()) {
+      ccm.create();
+      ccm.start();
+
+      NlbSimulator nlb = new NlbSimulator(ccm, NLB_ADDRESS, NLB_BASE_PORT);
+      try {
+        nlb.addNode(1);
+
+        Map<Integer, UUID> allHostIds = collectHostIds(ccm, 3);
+
+        Map<Integer, UUID> proxiedHostIds = new HashMap<>();
+        proxiedHostIds.put(1, allHostIds.get(1));
+        postClientRoutes(ccm, proxiedHostIds, nlb);
+        waitForRoutesVisible(ccm, 1);
+
+        ClientRoutesConfig config =
+            ClientRoutesConfig.builder()
+                .addEndpoint(new ClientRouteProxy(CONNECTION_ID, NLB_ADDRESS))
+                .build();
+
+        try (CqlSession session = openNlbSession(config, nlb)) {
+          assertQueryWorks(session);
+          awaitConnectedNodes(session, 1, 2);
+          assertNodeClassification(session, 1, 2);
+
+          for (int i = 0; i < 20; i++) {
+            assertQueryWorks(session);
+          }
+        }
+      } finally {
+        nlb.close();
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesUnsupportedVersionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesUnsupportedVersionIT.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.clientroutes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
+import com.datastax.oss.driver.api.testinfra.ScyllaRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.IsolatedTests;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Negative integration test for the PrivateLink client routes feature.
+ *
+ * <p>This test class is intentionally <em>not</em> gated with a minimum version requirement: it
+ * must run on <em>older</em> ScyllaDB Enterprise versions (before 2026.1) where the {@code
+ * system.client_routes} table does not exist.
+ *
+ * <p>The single test here verifies that:
+ *
+ * <ol>
+ *   <li>{@code system.client_routes} is truly absent on the running server — if it is present, the
+ *       test fails loudly to signal that the version gate in {@link ClientRoutesIT} needs updating.
+ *   <li>The driver gracefully opens a session even when the table is missing (no crash on init).
+ *   <li>{@link ClientRoutesTopologyMonitor#resolve} throws for all host IDs — {@link
+ *       com.datastax.oss.driver.internal.core.metadata.ClientRoutesEndPoint} falls back to the
+ *       default endpoint transparently; the feature is not silently active.
+ * </ol>
+ *
+ * <p>This class is annotated with {@code @ScyllaOnly} because {@code system.client_routes} is
+ * specific to ScyllaDB Enterprise (not yet available on OSS) and has no equivalent in Apache
+ * Cassandra. The {@code maxEnterprise = "2026.1"} constraint ensures this test is skipped on
+ * versions that <em>do</em> support the feature (it would have nothing meaningful to assert there,
+ * and the positive tests in {@link ClientRoutesIT} cover that range).
+ */
+@Category(IsolatedTests.class)
+@ScyllaOnly(description = "system.client_routes is a ScyllaDB Enterprise-only feature")
+@ScyllaRequirement(
+    maxEnterprise = "2026.1",
+    description =
+        "Negative test for Enterprise versions where system.client_routes does not exist. "
+            + "Skipped on Enterprise >= 2026.1 (use ClientRoutesIT for those versions).")
+public class ClientRoutesUnsupportedVersionIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesUnsupportedVersionIT.class);
+
+  private static final BackendRequirementRule BACKEND_RULE = new BackendRequirementRule();
+
+  public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(1).build();
+
+  private static final SessionRule<CqlSession> SESSION_RULE =
+      SessionRule.builder(CCM_RULE).withKeyspace(false).build();
+
+  @ClassRule
+  public static final TestRule CHAIN =
+      RuleChain.outerRule(BACKEND_RULE).around(CCM_RULE).around(SESSION_RULE);
+
+  // ---- helpers -----------------------------------------------------------
+
+  private String nodeAddress() {
+    return CCM_RULE.getCcmBridge().getNodeIpAddress(1);
+  }
+
+  private CqlSession openAdminSession() {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactEndPoints(CCM_RULE.getContactPoints())
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                    .build())
+            .build();
+  }
+
+  private CqlSession openClientRoutesSession(ClientRoutesConfig config) {
+    return (CqlSession)
+        SessionUtils.baseBuilder()
+            .addContactEndPoints(CCM_RULE.getContactPoints())
+            .withClientRoutesConfig(config)
+            .withConfigLoader(
+                SessionUtils.configLoaderBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(10))
+                    .build())
+            .build();
+  }
+
+  // ---- test --------------------------------------------------------------
+
+  /**
+   * Verifies that on a ScyllaDB Enterprise version that predates the {@code system.client_routes}
+   * table (i.e. Enterprise &lt; 2026.1), the driver behaves correctly:
+   *
+   * <ul>
+   *   <li>The system table does <em>not</em> exist — confirmed via {@code system_schema.tables}.
+   *   <li>A session with {@link ClientRoutesConfig} can still be opened (graceful degradation).
+   *   <li>The {@link ClientRoutesTopologyMonitor} stays empty; {@code translate()} returns {@code
+   *       null}.
+   * </ul>
+   *
+   * <p>The assertion on the absent table acts as a built-in guard against stale version gates: if
+   * {@code system.client_routes} ever appears on a version thought to be unsupported, this test
+   * fails with a clear message rather than silently passing.
+   */
+  @Test
+  public void should_not_activate_on_unsupported_version() throws Exception {
+    // This test targets Scylla Enterprise only; OSS boundary is not yet confirmed.
+    if (!CcmBridge.SCYLLA_ENTERPRISE) {
+      throw new AssumptionViolatedException(
+          "Negative client-routes test targets Scylla Enterprise only "
+              + "(OSS feature boundary not yet confirmed). Skipping on OSS.");
+    }
+
+    try (CqlSession admin = openAdminSession()) {
+
+      // ── Step 1 ── confirm the table is genuinely absent ───────────────────────────────────────
+      // If system.client_routes already exists on this build, the maxEnterprise gate in this
+      // class's @ScyllaRequirement is wrong (or the feature shipped earlier than 2026.1).
+      // Fail with an explicit message so the gate can be corrected.
+      Row tableRow =
+          admin
+              .execute(
+                  "SELECT table_name FROM system_schema.tables"
+                      + " WHERE keyspace_name='system' AND table_name='client_routes'")
+              .one();
+      assertThat(tableRow)
+          .as(
+              "system.client_routes MUST NOT exist on Enterprise < 2026.1 — "
+                  + "if this assertion fails the @ScyllaRequirement(minEnterprise) gate in "
+                  + "ClientRoutesIT (or maxEnterprise here) is out of date and must be corrected.")
+          .isNull();
+
+      // ── Step 2 ── session must fail with a clear error ─────────────────────────────────────────
+      String connectionId = UUID.randomUUID().toString();
+      String nodeAddr = nodeAddress();
+
+      // Use the real default table name (system.client_routes) — no user-space mirror — so any
+      // successful query result would mean the feature is genuinely active (it should not be).
+      ClientRoutesConfig config =
+          ClientRoutesConfig.builder()
+              .addEndpoint(new ClientRouteProxy(connectionId, nodeAddr))
+              .build();
+
+      try (CqlSession session = openClientRoutesSession(config)) {
+        fail(
+            "Session must NOT open when client routes are configured but the server "
+                + "does not support CLIENT_ROUTES_CHANGE — expected an init failure "
+                + "with a clear error message");
+      } catch (Exception e) {
+        // The session init should fail with a message telling the user exactly what's wrong.
+        String message = getCauseChainMessages(e);
+        assertThat(message)
+            .as(
+                "Session init failure must mention CLIENT_ROUTES_CHANGE so the user knows "
+                    + "the server does not support the feature")
+            .contains("CLIENT_ROUTES_CHANGE");
+
+        LOG.info(
+            "Confirmed: session correctly refused to open on unsupported Enterprise {} — {}",
+            CCM_RULE.getCcmBridge().getScyllaUnparsedVersion().orElse("<unknown>"),
+            message);
+      }
+    }
+  }
+
+  /** Concatenates all messages in the exception cause chain. */
+  private static String getCauseChainMessages(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    while (t != null) {
+      if (t.getMessage() != null) {
+        sb.append(t.getMessage()).append(" | ");
+      }
+      t = t.getCause();
+    }
+    return sb.toString();
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.clientroutes;
+
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simulates a Network Load Balancer (NLB) for PrivateLink testing.
+ *
+ * <p>Provides:
+ *
+ * <ul>
+ *   <li>A <b>discovery port</b> that round-robins across all registered nodes (simulates the
+ *       cluster-level NLB endpoint).
+ *   <li>A <b>per-node port</b> for each registered node (simulates per-node NLB routing driven by
+ *       system.client_routes).
+ * </ul>
+ *
+ * <p>Nodes can be added and removed dynamically, mirroring real NLB reconfiguration during cluster
+ * topology changes.
+ */
+public class NlbSimulator implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(NlbSimulator.class);
+
+  private final CcmBridge ccmBridge;
+  private final String bindAddress;
+  private final int basePort;
+
+  // Discovery port proxy: round-robins across all nodes
+  private volatile RoundRobinProxy discoveryProxy;
+
+  // Per-node proxies: nodeId -> TcpProxy
+  private final Map<Integer, TcpProxy> nodeProxies =
+      Collections.synchronizedMap(new LinkedHashMap<>());
+  private final CopyOnWriteArrayList<Integer> activeNodes = new CopyOnWriteArrayList<>();
+
+  /**
+   * Creates an NLB simulator.
+   *
+   * @param ccmBridge the CCM bridge to get node addresses from
+   * @param bindAddress the IP address to bind proxy listeners on (e.g. "127.254.254.254")
+   * @param basePort the base port for NLB (discovery on basePort, per-node on basePort+nodeId)
+   */
+  public NlbSimulator(CcmBridge ccmBridge, String bindAddress, int basePort) {
+    this.ccmBridge = ccmBridge;
+    this.bindAddress = bindAddress;
+    this.basePort = basePort;
+  }
+
+  /** Returns the bind address used by this NLB simulator. */
+  public String getBindAddress() {
+    return bindAddress;
+  }
+
+  /** Returns the discovery port (the "cluster endpoint" that round-robins to all nodes). */
+  public int getDiscoveryPort() {
+    return basePort;
+  }
+
+  /** Returns the per-node proxy port for a given CCM node ID. */
+  public int getNodePort(int nodeId) {
+    return basePort + nodeId;
+  }
+
+  /** Returns the list of currently active node IDs. */
+  public List<Integer> getActiveNodes() {
+    return new ArrayList<>(activeNodes);
+  }
+
+  /**
+   * Adds a node to the NLB. Creates a per-node proxy and adds the node to the discovery round-robin
+   * pool.
+   */
+  public synchronized void addNode(int nodeId) throws IOException {
+    if (activeNodes.contains(nodeId)) {
+      LOG.warn("Node {} already registered in NLB", nodeId);
+      return;
+    }
+
+    String nodeIp = ccmBridge.getNodeIpAddress(nodeId);
+    InetSocketAddress nodeAddr = new InetSocketAddress(nodeIp, 9042);
+
+    // Create per-node proxy first, before updating state
+    int nodePort = getNodePort(nodeId);
+    TcpProxy proxy = new TcpProxy(bindAddress, nodePort, nodeAddr);
+
+    // Update state and rebuild discovery proxy; if rebuild fails, close the new proxy
+    activeNodes.add(nodeId);
+    nodeProxies.put(nodeId, proxy);
+    try {
+      rebuildDiscoveryProxy();
+    } catch (IOException e) {
+      activeNodes.remove(Integer.valueOf(nodeId));
+      nodeProxies.remove(nodeId);
+      proxy.close();
+      throw e;
+    }
+
+    LOG.info("NLB: added node{} ({}:{}) -> proxy port {}", nodeId, nodeIp, 9042, nodePort);
+  }
+
+  /** Removes a node from the NLB. Closes its per-node proxy and removes it from discovery. */
+  public synchronized void removeNode(int nodeId) throws IOException {
+    TcpProxy proxy = nodeProxies.remove(nodeId);
+    if (proxy != null) {
+      proxy.close();
+    }
+    activeNodes.remove(Integer.valueOf(nodeId));
+
+    // Rebuild discovery proxy with updated node list
+    rebuildDiscoveryProxy();
+
+    LOG.info("NLB: removed node{}", nodeId);
+  }
+
+  private void rebuildDiscoveryProxy() throws IOException {
+    RoundRobinProxy oldProxy = discoveryProxy;
+
+    if (activeNodes.isEmpty()) {
+      discoveryProxy = null;
+      if (oldProxy != null) {
+        oldProxy.close();
+      }
+      return;
+    }
+
+    // Build target list from active nodes
+    List<InetSocketAddress> targets = new ArrayList<>();
+    for (int nodeId : activeNodes) {
+      String nodeIp = ccmBridge.getNodeIpAddress(nodeId);
+      targets.add(new InetSocketAddress(nodeIp, 9042));
+    }
+
+    // Create new proxy before closing old one to avoid inconsistent state on failure
+    discoveryProxy = new RoundRobinProxy(bindAddress, basePort, targets);
+    if (oldProxy != null) {
+      oldProxy.close();
+    }
+    LOG.info(
+        "NLB: discovery proxy on port {} -> {} nodes: {}", basePort, targets.size(), activeNodes);
+  }
+
+  @Override
+  public synchronized void close() {
+    if (discoveryProxy != null) {
+      discoveryProxy.close();
+      discoveryProxy = null;
+    }
+    for (TcpProxy proxy : nodeProxies.values()) {
+      proxy.close();
+    }
+    nodeProxies.clear();
+    activeNodes.clear();
+    LOG.info("NLB simulator closed");
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/RoundRobinProxy.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/RoundRobinProxy.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.clientroutes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A TCP proxy that round-robins incoming connections across multiple backend targets. Each new
+ * connection is forwarded to the next backend in the list.
+ */
+public class RoundRobinProxy implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(RoundRobinProxy.class);
+  private static final int BUFFER_SIZE = 8192;
+
+  private final ServerSocket serverSocket;
+  private final List<InetSocketAddress> targets;
+  private final AtomicInteger counter = new AtomicInteger(0);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final CopyOnWriteArrayList<Socket> activeSockets = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<Thread> pipeThreads = new CopyOnWriteArrayList<>();
+  private final Thread acceptThread;
+
+  public RoundRobinProxy(String bindAddress, int listenPort, List<InetSocketAddress> targets)
+      throws IOException {
+    if (targets.isEmpty()) {
+      throw new IllegalArgumentException("At least one target required");
+    }
+    this.targets = targets;
+    this.serverSocket = new ServerSocket();
+    this.serverSocket.setReuseAddress(true);
+    this.serverSocket.bind(new InetSocketAddress(bindAddress, listenPort));
+    this.acceptThread =
+        new Thread(this::acceptLoop, "rr-proxy-accept-" + serverSocket.getLocalPort());
+    this.acceptThread.setDaemon(true);
+    this.acceptThread.start();
+    LOG.debug(
+        "RoundRobinProxy listening on {} -> {} targets", serverSocket.getLocalPort(), targets);
+  }
+
+  public int getLocalPort() {
+    return serverSocket.getLocalPort();
+  }
+
+  private void acceptLoop() {
+    while (!closed.get()) {
+      try {
+        Socket client = serverSocket.accept();
+        if (closed.get()) {
+          client.close();
+          break;
+        }
+        activeSockets.add(client);
+
+        InetSocketAddress target =
+            targets.get(Math.floorMod(counter.getAndIncrement(), targets.size()));
+        Socket remote = new Socket();
+        activeSockets.add(remote);
+        try {
+          remote.connect(target, 5000);
+        } catch (IOException e) {
+          closeQuietly(client);
+          closeQuietly(remote);
+          if (!closed.get()) {
+            LOG.warn("RoundRobinProxy connect to target failed", e);
+          }
+          continue;
+        }
+
+        Thread c2r =
+            new Thread(
+                () -> pipe(client, remote),
+                "rr-proxy-c2r-" + serverSocket.getLocalPort() + "-" + client.getPort());
+        Thread r2c =
+            new Thread(
+                () -> pipe(remote, client),
+                "rr-proxy-r2c-" + serverSocket.getLocalPort() + "-" + client.getPort());
+        c2r.setDaemon(true);
+        r2c.setDaemon(true);
+        pipeThreads.add(c2r);
+        pipeThreads.add(r2c);
+        c2r.start();
+        r2c.start();
+      } catch (SocketException e) {
+        if (!closed.get()) {
+          LOG.warn("RoundRobinProxy accept error", e);
+        }
+      } catch (IOException e) {
+        if (!closed.get()) {
+          LOG.warn("RoundRobinProxy accept error", e);
+        }
+      }
+    }
+  }
+
+  private void pipe(Socket from, Socket to) {
+    byte[] buf = new byte[BUFFER_SIZE];
+    try {
+      InputStream in = from.getInputStream();
+      OutputStream out = to.getOutputStream();
+      int n;
+      while ((n = in.read(buf)) >= 0) {
+        out.write(buf, 0, n);
+        out.flush();
+      }
+    } catch (IOException e) {
+      // expected when sockets close
+    } finally {
+      closeQuietly(from);
+      closeQuietly(to);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      closeQuietly(serverSocket);
+      for (Socket s : activeSockets) {
+        closeQuietly(s);
+      }
+      activeSockets.clear();
+      try {
+        acceptThread.join(5000);
+        if (acceptThread.isAlive()) {
+          LOG.warn("RoundRobinProxy accept thread still alive after join timeout");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (Thread t : pipeThreads) {
+        try {
+          t.join(5000);
+          if (t.isAlive()) {
+            LOG.warn("RoundRobinProxy pipe thread {} still alive after join timeout", t.getName());
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      pipeThreads.clear();
+    }
+  }
+
+  private static void closeQuietly(Closeable c) {
+    try {
+      if (c != null) c.close();
+    } catch (IOException ignored) {
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/TcpProxy.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/TcpProxy.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2025 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+package com.datastax.oss.driver.core.clientroutes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple TCP proxy that forwards connections from a local port to a remote target. Each accepted
+ * connection spawns two threads to pipe data in both directions.
+ */
+public class TcpProxy implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(TcpProxy.class);
+  private static final int BUFFER_SIZE = 8192;
+
+  private final ServerSocket serverSocket;
+  private final InetSocketAddress target;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final CopyOnWriteArrayList<Socket> activeSockets = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<Thread> pipeThreads = new CopyOnWriteArrayList<>();
+  private final Thread acceptThread;
+
+  /**
+   * Creates and starts a TCP proxy.
+   *
+   * @param bindAddress the local address to bind on
+   * @param listenPort the local port to listen on (0 for any available port)
+   * @param target the remote address to forward connections to
+   */
+  public TcpProxy(String bindAddress, int listenPort, InetSocketAddress target) throws IOException {
+    this.target = target;
+    this.serverSocket = new ServerSocket();
+    this.serverSocket.setReuseAddress(true);
+    this.serverSocket.bind(new InetSocketAddress(bindAddress, listenPort));
+    this.acceptThread =
+        new Thread(this::acceptLoop, "tcp-proxy-accept-" + serverSocket.getLocalPort());
+    this.acceptThread.setDaemon(true);
+    this.acceptThread.start();
+    LOG.debug("TcpProxy listening on {} -> {}", serverSocket.getLocalPort(), target);
+  }
+
+  /** Returns the local port this proxy is listening on. */
+  public int getLocalPort() {
+    return serverSocket.getLocalPort();
+  }
+
+  private void acceptLoop() {
+    while (!closed.get()) {
+      try {
+        Socket client = serverSocket.accept();
+        if (closed.get()) {
+          client.close();
+          break;
+        }
+        activeSockets.add(client);
+        Socket remote = new Socket();
+        activeSockets.add(remote);
+        try {
+          remote.connect(target, 5000);
+        } catch (IOException e) {
+          closeQuietly(client);
+          closeQuietly(remote);
+          if (!closed.get()) {
+            LOG.warn("TcpProxy connect to target failed", e);
+          }
+          continue;
+        }
+
+        Thread c2r =
+            new Thread(
+                () -> pipe(client, remote),
+                "tcp-proxy-c2r-" + serverSocket.getLocalPort() + "-" + client.getPort());
+        Thread r2c =
+            new Thread(
+                () -> pipe(remote, client),
+                "tcp-proxy-r2c-" + serverSocket.getLocalPort() + "-" + client.getPort());
+        c2r.setDaemon(true);
+        r2c.setDaemon(true);
+        pipeThreads.add(c2r);
+        pipeThreads.add(r2c);
+        c2r.start();
+        r2c.start();
+      } catch (SocketException e) {
+        if (!closed.get()) {
+          LOG.warn("TcpProxy accept error", e);
+        }
+      } catch (IOException e) {
+        if (!closed.get()) {
+          LOG.warn("TcpProxy accept error", e);
+        }
+      }
+    }
+  }
+
+  private void pipe(Socket from, Socket to) {
+    byte[] buf = new byte[BUFFER_SIZE];
+    try {
+      InputStream in = from.getInputStream();
+      OutputStream out = to.getOutputStream();
+      int n;
+      while ((n = in.read(buf)) >= 0) {
+        out.write(buf, 0, n);
+        out.flush();
+      }
+    } catch (IOException e) {
+      // expected when sockets close
+    } finally {
+      closeQuietly(from);
+      closeQuietly(to);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      closeQuietly(serverSocket);
+      for (Socket s : activeSockets) {
+        closeQuietly(s);
+      }
+      activeSockets.clear();
+      try {
+        acceptThread.join(5000);
+        if (acceptThread.isAlive()) {
+          LOG.warn("TcpProxy accept thread still alive after join timeout");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (Thread t : pipeThreads) {
+        try {
+          t.join(5000);
+          if (t.isAlive()) {
+            LOG.warn("TcpProxy pipe thread {} still alive after join timeout", t.getName());
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      pipeThreads.clear();
+      LOG.debug("TcpProxy on port {} closed", serverSocket.getLocalPort());
+    }
+  }
+
+  private static void closeQuietly(Closeable c) {
+    try {
+      if (c != null) c.close();
+    } catch (IOException ignored) {
+    }
+  }
+}

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -118,6 +118,93 @@ datastax-java-driver.advanced.address-translator.class = com.mycompany.MyAddress
 Note: the contact points provided while creating the `CqlSession` are not translated, only addresses
 retrieved from or sent by Cassandra nodes are.
 
+### Client Routes (cloud private endpoint deployments)
+
+For cloud deployments using private endpoint services (such as AWS PrivateLink, Azure Private Link,
+or GCP Private Service Connect) or similar technologies (e.g., ScyllaDB Cloud), nodes are accessed
+through private DNS endpoints rather than direct IP addresses. The driver
+provides a built-in client routes feature that handles address translation automatically.
+
+Client routes can be configured either **programmatically** or via **HOCON configuration files**.
+Note that `OptionsMap`-based configuration does not support client routes — use the programmatic
+API (`SessionBuilder.withClientRoutesConfig()`) instead, which can be combined with `OptionsMap`
+for all other driver options.
+
+Client routes are **mutually exclusive** with:
+- A custom `AddressTranslator` (if both are provided, an `IllegalStateException` is thrown)
+- Cloud secure connect bundles (if both are provided, an `IllegalStateException` is thrown)
+
+#### Quick start (programmatic)
+
+```java
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import java.net.InetSocketAddress;
+
+ClientRoutesConfig config = ClientRoutesConfig.builder()
+    .addEndpoint(new ClientRouteProxy(
+        "12345678-1234-1234-1234-123456789012",
+        "my-cluster-endpoint.example.com"))
+    .build();
+
+CqlSession session = CqlSession.builder()
+    .addContactPoint(new InetSocketAddress("my-cluster-endpoint.example.com", 9042))
+    .withClientRoutesConfig(config)
+    .withLocalDatacenter("datacenter1")
+    .build();
+```
+
+#### Quick start (HOCON configuration file)
+
+```
+datastax-java-driver {
+  advanced.client-routes {
+    endpoints = [
+      { connection-id = "12345678-1234-1234-1234-123456789012",
+        connection-addr = "my-cluster-endpoint.example.com" }
+    ]
+  }
+}
+```
+
+#### How it works
+
+1. **Startup** — after the control connection is established, the driver queries
+   `system.client_routes` (filtered to the configured `connection_id` values) and builds an
+   in-memory map of `host_id → (hostname, port, tls_port)`.
+2. **Translation** — every time the driver opens a connection to a peer node, it looks up the
+   node's `host_id` in the route map and resolves the associated DNS hostname. Contact points bypass
+   translation so the initial seed addresses are used as-is.
+3. **Event-driven updates** — the driver registers for `CLIENT_ROUTES_CHANGE` server events. When
+   one arrives, it re-queries the table and atomically swaps the route map.
+4. **Reconnect** — if the control connection is recreated the driver performs a full re-read of the
+   route table before refreshing node metadata.
+
+#### DNS resolution
+
+DNS is resolved at connection time (not at route discovery time). The driver delegates to
+`InetAddress.getByName()`, which is a blocking call that uses the JVM's built-in DNS cache
+(30 s default TTL in Java 8+). Because this runs on Netty I/O threads, slow or unresponsive
+DNS can block connection establishment and impact driver throughput. To mitigate this, configure
+the JVM DNS cache TTL via the `networkaddress.cache.ttl` security property (e.g. in
+`$JAVA_HOME/conf/security/java.security` or programmatically with
+`java.security.Security.setProperty("networkaddress.cache.ttl", "60")`).
+
+- **Route-map refresh** — the driver re-queries `system.client_routes` and atomically swaps the
+  in-memory route map in two situations:
+  - a `CLIENT_ROUTES_CHANGE` server event is received, or
+  - the control connection reconnects after a failure.
+
+  A route-map refresh does **not** flush the DNS cache. New hostnames are resolved on first use.
+
+#### Limitations
+
+- Requires ScyllaDB Enterprise ≥ 2026.1 with `system.client_routes` support
+  (scylladb/scylladb#27323). Not yet available on ScyllaDB OSS.
+- Not supported on Apache Cassandra.
+- Mutually exclusive with custom `AddressTranslator` and with cloud secure connect bundles.
+
 ### EC2 multi-region
 
 If you deploy both Cassandra and client applications on Amazon EC2, and your cluster spans multiple regions, you'll have

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
       <dependency>
         <groupId>com.scylladb</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.2.1</version>
+        <version>1.5.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -630,6 +630,15 @@ public class CcmBridge implements AutoCloseable {
     return f;
   }
 
+  /** Returns the total number of nodes across all data centers. */
+  public int getNodeCount() {
+    int total = 0;
+    for (int n : nodes) {
+      total += n;
+    }
+    return total;
+  }
+
   public String getNodeIpAddress(int nodeId) {
     return ipPrefix + nodeId;
   }

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -19,6 +19,59 @@ under the License.
 
 ## Upgrade guide
 
+### 4.19.0.7
+
+#### Cloud private-endpoint support via client routes
+
+The driver now supports automatic address translation for cloud private-endpoint deployments
+(e.g. AWS PrivateLink, Azure Private Link, GCP Private Service Connect)
+through the new client routes feature. When enabled, the driver reads endpoint mappings from the
+`system.client_routes` system table and translates peer addresses transparently at connection time,
+with automatic refresh on `CLIENT_ROUTES_CHANGE` events.
+
+Configure it programmatically on the session builder:
+
+```java
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
+import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
+import java.net.InetSocketAddress;
+
+ClientRoutesConfig config = ClientRoutesConfig.builder()
+    .addEndpoint(new ClientRouteProxy(
+        "<connection-id>",
+        "my-cluster.region.provider.scylladb.com"))
+    .build();
+
+CqlSession session = CqlSession.builder()
+    .addContactPoint(new InetSocketAddress("my-cluster.region.provider.scylladb.com", 9042))
+    .withClientRoutesConfig(config)
+    .withLocalDatacenter("datacenter1")
+    .build();
+```
+
+Or via HOCON configuration file:
+
+```
+datastax-java-driver {
+  advanced.client-routes {
+    endpoints = [
+      { connection-id = "<connection-id>",
+        connection-addr = "my-cluster.region.provider.scylladb.com" }
+    ]
+  }
+}
+```
+
+Key points:
+
+- **Mutually exclusive** with a custom `AddressTranslator` and with cloud secure connect bundles —
+  providing both throws `IllegalStateException` at session build time.
+- **Requires ScyllaDB Enterprise ≥ 2026.1** (scylladb/scylladb#27323). The feature is not
+  available on ScyllaDB OSS or Apache Cassandra.
+
+See [Address resolution — Client Routes](../manual/core/address_resolution/) for full details.
+
 ### 4.18.1
 
 #### Keystore reloading in DefaultSslEngineFactory


### PR DESCRIPTION
# 4.x: PrivateLink Support Phase 3: Query Implementation, DNS Resolution & Tests 🔌

### Previous phases:
- #803 
- #804 

## Overview

Completes the runtime implementation of PrivateLink/client-routes support for ScyllaDB Cloud. The
driver can now query `system.client_routes` at startup and on control-connection reconnect, resolve
node hostnames to `InetSocketAddress` via a TTL-aware caching DNS resolver, and dynamically
translate addresses used for every CQL connection.

Server-side feature requires [scylladb/scylladb#27323](https://github.com/scylladb/scylladb/pull/27323).

---

## Changes

### Event Negotiation Fix — `ProtocolInitHandler` (SCYLLADB-850)

- Introduced a mutable `registerEventTypes` list (copy of `options.eventTypes`) so the REGISTER
  step can be retried with a narrowed event set without mutating the original channel options.
- When the REGISTER step receives a `PROTOCOL_ERROR` whose message contains
  `CLIENT_ROUTES_CHANGE`, the driver logs a warning, removes that event type, and retries REGISTER
  with the remaining types (`SCHEMA_CHANGE`, `STATUS_CHANGE`, `TOPOLOGY_CHANGE`).
- If no event types remain after stripping, the handler calls `setConnectSuccess()` directly,
  skipping REGISTER altogether.
- This makes the driver backward-compatible with ScyllaDB Enterprise < 2026.1: client-routes table
  queries may still work on those versions, but live push-updates via the event are disabled.

### DNS Resolution — `CachingDnsResolver` (new)

- TTL-based in-memory cache backed by `ConcurrentHashMap<String, CacheEntry>` with per-hostname
  `Semaphore(1)` to prevent concurrent re-resolution storms.
- Fast-path unlocked read; double-checked locking only when the entry is absent or stale.
- Last-known-good fallback: on `UnknownHostException`, the previous successful resolution is
  returned and a warning is logged.
- `clearCache()` preserves last-known-good entries so a full session re-init survives transient DNS
  failures.

### Client Routes Query — `ClientRoutesHandler`

- `queryAndResolveRoutes()` implemented: executes
  `SELECT connection_id, host_id, address, port, tls_port FROM %s WHERE connection_id IN :connectionIds ALLOW FILTERING`
  via `AdminRequestHandler`.
- `CachingDnsResolver` wired in, replacing the Phase 2 no-op stub.
- Route map atomically swapped via `AtomicReference.set()` so in-flight translations see a
  consistent snapshot.

### Session Lifecycle — `DefaultSession`

- `initClientRoutes()` inserted between `topologyMonitor.init()` and
  `metadataManager.refreshNodes()` in the startup chain.
- Failure is non-fatal: if the client-routes query fails at startup, the session still opens and
  falls back to direct addressing.

### Reconnect Integration — `ControlConnection`

- On a successful reconnect, `clientRoutesHandler.refresh()` is awaited before `refreshNodes()`,
  so translated addresses are current before nodes are re-evaluated.

---

## Tests

### Unit Tests — 22 new tests across 3 suites

| Suite | # | Coverage |
|---|---|---|
| `CachingDnsResolverTest` | 7 | Cache hit/miss, TTL expiry, concurrency, last-known-good fallback, `clearCache()` |
| `ClientRoutesHandlerTest` | 8 | Query construction, route-map population, translate with/without SSL, refresh no-op when disabled |
| `ClientRoutesAddressTranslatorTest` | 7 | Address translation pipeline, null pass-through, SSL port selection |

### Integration Tests — 6 new tests across 2 suites

| Suite | Requirement | # | Coverage |
|---|---|---|---|
| `ClientRoutesIT` | ScyllaDB Enterprise ≥ 2026.1 | 5 | Routes loaded on init; `refresh()` picks up new rows; session opens with empty table; TLS port selection; auto-refresh on control-connection reconnect |
| `ClientRoutesUnsupportedVersionIT` | ScyllaDB Enterprise < 2026.1 | 1 | Session opens and handler returns `null` when `system.client_routes` is absent (graceful degradation) |

Both integration test suites are `@Category(IsolatedTests.class)` and `@ScyllaOnly`. Positive tests
use a user-space mirror table (`test_client_routes.client_routes`) to avoid requiring privileged
write access to `system`.

## Additional notes
This PR also uses workaround for  [SCYLLADB-850](https://scylladb.atlassian.net/browse/SCYLLADB-850): older ScyllaDB Enterprise versions (< 2026.1) reject the `CLIENT_ROUTES_CHANGE` REGISTER event with a `PROTOCOL_ERROR`, which previously caused connection initialisation to fail. The driver now gracefully handles this by stripping the unsupported event and retrying REGISTER with the remaining types, so sessions succeed on any server version.

---

Related to DRIVER-86, DRIVER-88, [SCYLLADB-850](https://scylladb.atlassian.net/browse/SCYLLADB-850)


[SCYLLADB-850]: https://scylladb.atlassian.net/browse/SCYLLADB-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ