### PR TITLE
integration cicd speedup: Make parallel test thread count configurable

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -38,7 +38,7 @@
     <skipParallelizableITs>${skipITs}</skipParallelizableITs>
     <skipSerialITs>${skipITs}</skipSerialITs>
     <skipIsolatedITs>${skipITs}</skipIsolatedITs>
-    <test.parallel.threads>8</test.parallel.threads>
+    <test.parallel.threads>16</test.parallel.threads>
   </properties>
   <dependencies>
     <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -38,6 +38,7 @@
     <skipParallelizableITs>${skipITs}</skipParallelizableITs>
     <skipSerialITs>${skipITs}</skipSerialITs>
     <skipIsolatedITs>${skipITs}</skipIsolatedITs>
+    <test.parallel.threads>8</test.parallel.threads>
   </properties>
   <dependencies>
     <dependency>
@@ -238,7 +239,7 @@
               <jvm>${testing.jvm}/bin/java</jvm>
               <groups>com.datastax.oss.driver.categories.ParallelizableTests</groups>
               <parallel>classes</parallel>
-              <threadCountClasses>8</threadCountClasses>
+              <threadCountClasses>${test.parallel.threads}</threadCountClasses>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
               <skipITs>${skipParallelizableITs}</skipITs>
               <argLine>${blockhound.argline}</argLine>


### PR DESCRIPTION
## Summary
- Extract hardcoded `threadCountClasses=8` into a configurable Maven property `test.parallel.threads`
- Increase default from 8 to 16 threads — most tests are I/O-bound (waiting on CCM/Scylla), so higher concurrency reduces total test time
- CI can override with `-Dtest.parallel.threads=N`

## Changes
- `integration-tests/pom.xml`: Add `test.parallel.threads` property (default 16) and reference it in failsafe config

## Usage
```bash
# Default (16 threads)
mvn verify -pl integration-tests

# Custom parallelism
mvn verify -pl integration-tests -Dtest.parallel.threads=8
```

## Test plan
- [x] Verify parallelizable tests pass with 16 threads: `mvn verify -pl integration-tests -DskipSerialITs=true -DskipIsolatedITs=true`
- [x] Verify override works: `mvn verify -pl integration-tests -Dtest.parallel.threads=4`