### PR TITLE
integration cicd speedup: Reclassify serial integration tests as parallelizable

### DIFF
--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/LineStringIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/LineStringIT.java
@@ -28,15 +28,18 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.util.Lists;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@Category(ParallelizableTests.class)
 @BackendRequirement(type = BackendType.DSE, minInclusive = "5.0")
 public class LineStringIT extends GeometryIT<LineString> {
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/PointIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/PointIT.java
@@ -22,12 +22,15 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.assertj.core.util.Lists;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@Category(ParallelizableTests.class)
 @BackendRequirement(type = BackendType.DSE, minInclusive = "5.0")
 public class PointIT extends GeometryIT<Point> {
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/PolygonIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/data/geometry/PolygonIT.java
@@ -28,14 +28,17 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.UUID;
 import org.assertj.core.util.Lists;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@Category(ParallelizableTests.class)
 @BackendRequirement(type = BackendType.DSE, minInclusive = "5.0")
 public class PolygonIT extends GeometryIT<Polygon> {
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadataIT.java
@@ -28,13 +28,16 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Objects;
 import java.util.Optional;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@Category(ParallelizableTests.class)
 @BackendRequirement(
     type = BackendType.DSE,
     minInclusive = "5.0",

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/DseFunctionMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/DseFunctionMetadataIT.java
@@ -30,13 +30,16 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Objects;
 import java.util.Optional;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+@Category(ParallelizableTests.class)
 @BackendRequirement(
     type = BackendType.DSE,
     minInclusive = "5.0",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileReloadIT.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
@@ -40,7 +41,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ParallelizableTests.class)
 public class DriverExecutionProfileReloadIT {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
@@ -55,7 +55,6 @@ import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.QueryCounter;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.stubbing.CloseType;
@@ -71,13 +70,11 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 
-@Category(ParallelizableTests.class)
 @RunWith(DataProviderRunner.class)
 public class DefaultRetryPolicyIT {
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
@@ -55,6 +55,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.QueryCounter;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.stubbing.CloseType;
@@ -70,11 +71,13 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 
+@Category(ParallelizableTests.class)
 @RunWith(DataProviderRunner.class)
 public class DefaultRetryPolicyIT {
   @ClassRule


### PR DESCRIPTION
## Summary
- Add `@Category(ParallelizableTests.class)` to 6 integration tests that are safe to run in parallel
- These tests use shared `CcmRule.getInstance()` or isolated `SimulacronRule` with their own keyspace, making them safe for parallel execution
- Tests reclassified: LineStringIT, PointIT, PolygonIT, DseAggregateMetadataIT, DseFunctionMetadataIT, DriverExecutionProfileReloadIT

## Audit summary
Remaining serial tests were audited and kept serial for these reasons:
- Graph tests: use `CustomCcmRule` with DSE graph workloads
- Auth/SSL tests: use `CustomCcmRule` with custom server configuration
- Token/metadata tests: use `CcmRule.builder()` with custom partitioners or manipulate nodes
- Session add/remove node tests: manipulate CCM nodes (stop/start)
- Metrics tests: explicitly marked as not parallelizable (shared mutable static state)
- HeartbeatDisabledIT: explicitly marked as not parallelizable
- DefaultRetryPolicyIT: uses shared Mockito log appender that gets contaminated in parallel runs

## Test plan
- [x] Run parallelizable tests only: `mvn verify -pl integration-tests -DskipSerialITs=true -DskipIsolatedITs=true`
- [x] Verify no test failures from parallel execution conflicts