### PR TITLE
integration cicd speedup: Enable Maven module parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CCM_SCYLLA_REPO ?= github.com/scylladb/scylla-ccm
 CCM_SCYLLA_VERSION ?= master
 
 SCYLLA_EXT_OPTS ?= --smp=2 --memory=4G
+MAVEN_PARALLEL_THREADS ?= 1C
 MVNCMD ?= mvn -B -X -ntp
 
 GET_VERSION_VERSION ?= 0.4.3
@@ -239,7 +240,7 @@ release-dry-run: .require-release-env
 	$(MVNCMD) release:perform > >(tee /tmp/java-driver-release-logs/stdout.log) 2> >(tee /tmp/java-driver-release-logs/stderr.log)
 
 compile-all: .install-guava-shaded
-	mvn -B compile test-compile -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	mvn -B -T $(MAVEN_PARALLEL_THREADS) install -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
 
 check:
 	$(MVNCMD) verify -DskipTests

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ release-dry-run: .require-release-env
 	$(MVNCMD) release:perform > >(tee /tmp/java-driver-release-logs/stdout.log) 2> >(tee /tmp/java-driver-release-logs/stderr.log)
 
 compile-all: .install-guava-shaded
-	mvn -B -T $(MAVEN_PARALLEL_THREADS) install -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	mvn -B -T $(MAVEN_PARALLEL_THREADS) install -pl '!examples' -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	mvn -B compile test-compile -pl examples -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
 
 check:
 	$(MVNCMD) verify -DskipTests


### PR DESCRIPTION
## Summary
- Add `MAVEN_PARALLEL_THREADS` variable (default: `1C` = 1 thread per CPU core) to the Makefile
- Modules without inter-dependencies (query-builder, mapper-processor, etc.) now compile and test in parallel
- Override with `make compile-all MAVEN_PARALLEL_THREADS=2` if needed

## Test plan
- [x] Verify `make compile-all` completes successfully with parallel builds
- [x] Verify `make test-unit` passes with parallel module execution
- [x] Verify `make check` passes