### PR TITLE
Fix flaky AdvancedShardAwarenessIT timeouts in CI

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
@@ -25,7 +25,11 @@ import com.google.common.collect.ImmutableSet;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,8 +43,11 @@ import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +71,19 @@ public class AdvancedShardAwarenessIT {
       Pattern.compile(".*r configuration of shard aware port.*");
   private final Pattern generalReconnectionPattern =
       Pattern.compile(".*Scheduling next reconnection in.*");
+
+  private static final org.slf4j.Logger LOG =
+      LoggerFactory.getLogger(AdvancedShardAwarenessIT.class);
+
+  @Rule
+  public TestWatcher logDumper =
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          dumpDriverLogs(description.getMethodName());
+          dumpScyllaLogs(description.getMethodName());
+        }
+      };
 
   @DataProvider
   public static Object[][] reuseAddressOption() {
@@ -357,5 +377,57 @@ public class AdvancedShardAwarenessIT {
         }
       }
     }
+  }
+
+  private void dumpDriverLogs(String testName) {
+    LOG.error("=== BEGIN DRIVER LOGS for {} ===", testName);
+    if (appender != null && appender.list != null) {
+      for (ILoggingEvent event : appender.list) {
+        LOG.error(
+            "[{}] {} {}", event.getLevel(), event.getLoggerName(), event.getFormattedMessage());
+      }
+    }
+    LOG.error(
+        "=== END DRIVER LOGS for {} ({} entries) ===",
+        testName,
+        appender != null && appender.list != null ? appender.list.size() : 0);
+  }
+
+  private void dumpScyllaLogs(String testName) {
+    Path configDir = CCM_RULE.getCcmBridge().getConfigDirectory();
+    LOG.error("=== BEGIN SCYLLA LOGS for {} (ccm dir: {}) ===", testName, configDir);
+    try (DirectoryStream<Path> clusters = Files.newDirectoryStream(configDir)) {
+      for (Path cluster : clusters) {
+        if (!Files.isDirectory(cluster)) continue;
+        try (DirectoryStream<Path> nodes = Files.newDirectoryStream(cluster, "node*")) {
+          for (Path node : nodes) {
+            Path logsDir = node.resolve("logs");
+            if (!Files.isDirectory(logsDir)) continue;
+            try (DirectoryStream<Path> logFiles = Files.newDirectoryStream(logsDir)) {
+              for (Path logFile : logFiles) {
+                if (!Files.isRegularFile(logFile)) continue;
+                LOG.error("--- {} ---", logFile);
+                try {
+                  List<String> lines = Files.readAllLines(logFile);
+                  // Print last 200 lines to avoid flooding
+                  int start = Math.max(0, lines.size() - 200);
+                  if (start > 0) {
+                    LOG.error("... ({} lines skipped, showing last 200) ...", start);
+                  }
+                  for (int i = start; i < lines.size(); i++) {
+                    LOG.error("{}", lines.get(i));
+                  }
+                } catch (IOException readEx) {
+                  LOG.error("Failed to read log file {}: {}", logFile, readEx.getMessage());
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch (IOException ex) {
+      LOG.error("Failed to read CCM logs from {}: {}", configDir, ex.getMessage());
+    }
+    LOG.error("=== END SCYLLA LOGS for {} ===", testName);
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
@@ -156,6 +156,7 @@ public class AdvancedShardAwarenessIT {
             .withInt(DefaultDriverOption.ADVANCED_SHARD_AWARENESS_PORT_LOW, 10000)
             .withInt(DefaultDriverOption.ADVANCED_SHARD_AWARENESS_PORT_HIGH, 60000)
             .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, 66)
+            .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(30))
             .build();
     try (CqlSession session =
         CqlSession.builder()
@@ -165,7 +166,7 @@ public class AdvancedShardAwarenessIT {
             .build()) {
       List<CqlSession> allSessions = Collections.singletonList(session);
       Awaitility.await()
-          .atMost(20, TimeUnit.SECONDS)
+          .atMost(60, TimeUnit.SECONDS)
           .pollInterval(500, TimeUnit.MILLISECONDS)
           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
       List<ILoggingEvent> logsCopy = ImmutableList.copyOf(appender.list);
@@ -217,6 +218,7 @@ public class AdvancedShardAwarenessIT {
             .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, expectedChannelsPerNode)
             .withDuration(DefaultDriverOption.RECONNECTION_BASE_DELAY, Duration.ofMillis(10))
             .withDuration(DefaultDriverOption.RECONNECTION_MAX_DELAY, Duration.ofMillis(20))
+            .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(30))
             .build();
     CqlSessionBuilder builder =
         CqlSession.builder()
@@ -234,7 +236,7 @@ public class AdvancedShardAwarenessIT {
         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
       Awaitility.await()
-          .atMost(20, TimeUnit.SECONDS)
+          .atMost(60, TimeUnit.SECONDS)
           .pollInterval(500, TimeUnit.MILLISECONDS)
           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
       int tolerance = 2; // Sometimes socket ends up already in use

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -312,6 +312,10 @@ public class CcmBridge implements AutoCloseable {
     return VERSION;
   }
 
+  public Path getConfigDirectory() {
+    return configDirectory;
+  }
+
   public static Version getCassandraVersion() {
     if (isDistributionOf(BackendType.CASSANDRA)) {
       return VERSION;


### PR DESCRIPTION
## Summary
- Increase Awaitility timeout from 20s to 60s for `should_not_struggle_to_fill_pools` and `should_see_mismatched_shard`
- Raise connection init query timeout from 5s (default) to 30s for tests that open 66 channels per node

These tests open hundreds of concurrent connections (4 sessions x 66 channels x 2 nodes = 528 channels). On CI runners the protocol OPTIONS handshakes time out at the default 5s, channels fail to initialize, and pools never reach full capacity within 20s.

## Test plan
- [ ] Verify `AdvancedShardAwarenessIT` passes in CI isolated test group
- [ ] Confirm no regressions in other shard awareness tests

Fixes #820