### PR TITLE
Fix Scylla IT matrix version passing and tablets threshold

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -322,6 +322,8 @@ jobs:
 
       - name: Get scylla version
         id: scylla-version
+        env:
+          SCYLLA_VERSION: ${{ matrix.scylla-version }}
         run: make resolve-scylla-version
 
       - name: Pull CCM image from the cache

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ resolve-scylla-version: .prepare-get-version
 	elif [[ "${SCYLLA_VERSION}" == "LTS-PRIOR" ]]; then
 		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST-1.1.LAST" | tr -d '\"')
 		if [[ -z "$${SCYLLA_VERSION_RESOLVED}" ]]; then
-			SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla-enterprise -filters "^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1.1.LAST" | tr -d '\"')
+			SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla-enterprise -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST-1.1.LAST" | tr -d '\"')
 		fi
 	elif [[ "${SCYLLA_VERSION}" == "LATEST" ]]; then
 		SCYLLA_VERSION_RESOLVED=$$(get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$$.^[0-9]+$$.^[0-9]+$$ and LAST.LAST.LAST" | tr -d '\"')

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -93,7 +93,7 @@ public class DefaultLoadBalancingPolicyIT {
     CqlSession session = SESSION_RULE.session();
     if (CcmBridge.isDistributionOf(BackendType.SCYLLA)
         && ((CcmBridge.SCYLLA_ENTERPRISE
-                && CcmBridge.getDistributionVersion().compareTo(Version.parse("2023.1.0")) >= 0)
+                && CcmBridge.getDistributionVersion().compareTo(Version.parse("2024.2.0")) >= 0)
             || (!CcmBridge.SCYLLA_ENTERPRISE
                 && CcmBridge.getDistributionVersion().compareTo(Version.parse("6.1.0")) >= 0))) {
       session.execute(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingMultiDcIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingMultiDcIT.java
@@ -85,7 +85,7 @@ public class LWTLoadBalancingMultiDcIT {
     // Create multi-DC keyspace and table similarly to DefaultLoadBalancingPolicyIT.
     if (CcmBridge.isDistributionOf(BackendType.SCYLLA)
         && ((CcmBridge.SCYLLA_ENTERPRISE
-                && CcmBridge.getDistributionVersion().compareTo(Version.parse("2023.1.0")) >= 0)
+                && CcmBridge.getDistributionVersion().compareTo(Version.parse("2024.2.0")) >= 0)
             || (!CcmBridge.SCYLLA_ENTERPRISE
                 && CcmBridge.getDistributionVersion().compareTo(Version.parse("6.1.0")) >= 0))) {
       session.execute(


### PR DESCRIPTION
## Summary

- Pass `SCYLLA_VERSION` from the workflow matrix to the `resolve-scylla-version` make target. Without this, all three Scylla IT variants (LTS-LATEST, LTS-PRIOR, LATEST) resolve to the LATEST version due to the Makefile default.
- Fix enterprise tablets version threshold from `2023.1.0` to `2024.2.0` in `DefaultLoadBalancingPolicyIT` and `LWTLoadBalancingMultiDcIT`. Tablets were introduced in ScyllaDB Enterprise 2024.2.0, not 2023.1.0. This was hidden by the matrix bug since LTS-PRIOR never actually ran against an older version.

## Test plan

- CI should now run LTS-PRIOR against `2024.1.x` and the tablets-related tests should pass instead of failing with `SyntaxError: Unknown property 'tablets'`