### PR TITLE
Merge upstream changes from 4.19.0 to 4.19.1

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -7383,6 +7383,11 @@
         "old": "method <T extends java.lang.Number> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(java.lang.Class<T>)",
         "new": "method <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(java.lang.Class<T>)",
         "justification": "JAVA-3143: Extend driver vector support to arbitrary subtypes and fix handling of variable length types (OSS C* 5.0)"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Optional<com.datastax.oss.driver.api.core.tracker.RequestIdGenerator> com.datastax.oss.driver.api.core.context.DriverContext::getRequestIdGenerator()",
+        "justification": "CASSJAVA-97: Let users inject an ID for each request and write to the custom payload"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1075,6 +1075,12 @@ public enum DefaultDriverOption implements DriverOption {
   LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD(
       "advanced.load-balancing-policy.default-lwt-request-routing-method"),
   /**
+   * The class of session-wide component that generates request IDs.
+   *
+   * <p>Value-type: {@link String}
+   */
+  REQUEST_ID_GENERATOR_CLASS("advanced.request-id.generator.class"),
+  /**
    * An address to always translate all node addresses to that same proxy hostname no matter what IP
    * address a node has, but still using its native transport port.
    *

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1065,7 +1065,6 @@ public enum DefaultDriverOption implements DriverOption {
   LOAD_BALANCING_DC_FAILOVER_PREFERRED_REMOTE_DCS(
       "advanced.load-balancing-policy.dc-failover.preferred-remote-dcs"),
 
-
   /**
    * The default routing method to use for LWT (Lightweight Transaction) requests. REGULAR uses the
    * standard load balancing algorithm with slow replica avoidance and shuffling.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1073,7 +1073,48 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: string
    */
   LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD(
-      "advanced.load-balancing-policy.default-lwt-request-routing-method");
+      "advanced.load-balancing-policy.default-lwt-request-routing-method"),
+  /**
+   * An address to always translate all node addresses to that same proxy hostname no matter what IP
+   * address a node has, but still using its native transport port.
+   *
+   * <p>Value-Type: {@link String}
+   */
+  ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME("advanced.address-translator.advertised-hostname"),
+  /**
+   * A map of Cassandra node subnets (CIDR notations) to target addresses, for example (note quoted
+   * keys):
+   *
+   * <pre>
+   * advanced.address-translator.subnet-addresses {
+   *   "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+   *   "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+   *   # IPv6 example:
+   *   # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+   *   # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+   * }
+   * </pre>
+   *
+   * Note: subnets must be represented as prefix blocks, see {@link
+   * inet.ipaddr.Address#isPrefixBlock()}.
+   *
+   * <p>Value type: {@link java.util.Map Map}&#60;{@link String},{@link String}&#62;
+   */
+  ADDRESS_TRANSLATOR_SUBNET_ADDRESSES("advanced.address-translator.subnet-addresses"),
+  /**
+   * A default address to fallback to if Cassandra node IP isn't contained in any of the configured
+   * subnets.
+   *
+   * <p>Value-Type: {@link String}
+   */
+  ADDRESS_TRANSLATOR_DEFAULT_ADDRESS("advanced.address-translator.default-address"),
+  /**
+   * Whether to resolve the addresses on initialization (if true) or on each node (re-)connection
+   * (if false). Defaults to false.
+   *
+   * <p>Value-Type: boolean
+   */
+  ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES("advanced.address-translator.resolve-addresses");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1101,8 +1101,8 @@ public enum DefaultDriverOption implements DriverOption {
    * }
    * </pre>
    *
-   * Note: subnets must be represented as prefix blocks, see {@link
-   * inet.ipaddr.Address#isPrefixBlock()}.
+   * Note: subnets must be represented as prefix blocks, see
+   * {@code inet.ipaddr.Address#isPrefixBlock()}.
    *
    * <p>Value type: {@link java.util.Map Map}&#60;{@link String},{@link String}&#62;
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1101,8 +1101,8 @@ public enum DefaultDriverOption implements DriverOption {
    * }
    * </pre>
    *
-   * Note: subnets must be represented as prefix blocks, see
-   * {@code inet.ipaddr.Address#isPrefixBlock()}.
+   * Note: subnets must be represented as prefix blocks, see {@code
+   * inet.ipaddr.Address#isPrefixBlock()}.
    *
    * <p>Value type: {@link java.util.Map Map}&#60;{@link String},{@link String}&#62;
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -1065,6 +1065,7 @@ public enum DefaultDriverOption implements DriverOption {
   LOAD_BALANCING_DC_FAILOVER_PREFERRED_REMOTE_DCS(
       "advanced.load-balancing-policy.dc-failover.preferred-remote-dcs"),
 
+
   /**
    * The default routing method to use for LWT (Lightweight Transaction) requests. REGULAR uses the
    * standard load balancing algorithm with slow replica avoidance and shuffling.
@@ -1120,7 +1121,13 @@ public enum DefaultDriverOption implements DriverOption {
    *
    * <p>Value-Type: boolean
    */
-  ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES("advanced.address-translator.resolve-addresses");
+  ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES("advanced.address-translator.resolve-addresses"),
+  /**
+   * Whether or not to do a DNS reverse-lookup of provided server addresses for SAN addresses.
+   *
+   * <p>Value-type: boolean
+   */
+  SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN("advanced.ssl-engine-factory.allow-dns-reverse-lookup-san");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -923,6 +923,20 @@ public class TypedDriverOption<ValueT> {
               DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS,
               GenericType.BOOLEAN);
 
+  public static final TypedDriverOption<String> ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME, GenericType.STRING);
+  public static final TypedDriverOption<Map<String, String>> ADDRESS_TRANSLATOR_SUBNET_ADDRESSES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES,
+          GenericType.mapOf(GenericType.STRING, GenericType.STRING));
+  public static final TypedDriverOption<String> ADDRESS_TRANSLATOR_DEFAULT_ADDRESS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, GenericType.STRING);
+  public static final TypedDriverOption<Boolean> ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES, GenericType.BOOLEAN);
+
   /**
    * Ordered preference list of remote dcs optionally supplied for automatic failover and included
    * in query plan. This feature is enabled only when max-nodes-per-remote-dc is greater than 0.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -296,6 +296,10 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DefaultDriverOption.REQUEST_TRACKER_CLASSES, GenericType.listOf(String.class));
 
+  /** The class of a session-wide component that generates request IDs. */
+  public static final TypedDriverOption<String> REQUEST_ID_GENERATOR_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_ID_GENERATOR_CLASS, GenericType.STRING);
+
   /** Whether to log successful requests. */
   public static final TypedDriverOption<Boolean> REQUEST_LOGGER_SUCCESS_ENABLED =
       new TypedDriverOption<>(

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -248,6 +248,10 @@ public class TypedDriverOption<ValueT> {
    */
   public static final TypedDriverOption<Boolean> SSL_HOSTNAME_VALIDATION =
       new TypedDriverOption<>(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, GenericType.BOOLEAN);
+
+  public static final TypedDriverOption<Boolean> SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN =
+      new TypedDriverOption<>(
+          DefaultDriverOption.SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN, GenericType.BOOLEAN);
   /** The location of the keystore file. */
   public static final TypedDriverOption<String> SSL_KEYSTORE_PATH =
       new TypedDriverOption<>(DefaultDriverOption.SSL_KEYSTORE_PATH, GenericType.STRING);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.api.core.time.TimestampGenerator;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
@@ -138,6 +139,10 @@ public interface DriverContext extends AttachmentPoint {
   /** @return The driver's request tracker; never {@code null}. */
   @NonNull
   RequestTracker getRequestTracker();
+
+  /** @return The driver's request ID generator; never {@code null}. */
+  @NonNull
+  Optional<RequestIdGenerator> getRequestIdGenerator();
 
   /** @return The driver's request throttler; never {@code null}. */
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/api/core/loadbalancing/LoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/loadbalancing/LoadBalancingPolicy.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -75,6 +76,12 @@ public interface LoadBalancingPolicy extends AutoCloseable {
    *     change distances dynamically over time).
    */
   void init(@NonNull Map<UUID, Node> nodes, @NonNull DistanceReporter distanceReporter);
+
+  /** Returns map containing details that impact C* node connectivity. */
+  @NonNull
+  default Map<String, ?> getStartupConfiguration() {
+    return Collections.emptyMap();
+  }
 
   /**
    * Returns the coordinators to use for a new query.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
@@ -59,6 +60,7 @@ public class ProgrammaticArguments {
   private final NodeStateListener nodeStateListener;
   private final SchemaChangeListener schemaChangeListener;
   private final RequestTracker requestTracker;
+  private final RequestIdGenerator requestIdGenerator;
   private final Map<String, String> localDatacenters;
   private final Map<String, Predicate<Node>> nodeFilters;
   private final Map<String, NodeDistanceEvaluator> nodeDistanceEvaluators;
@@ -77,6 +79,7 @@ public class ProgrammaticArguments {
       @Nullable NodeStateListener nodeStateListener,
       @Nullable SchemaChangeListener schemaChangeListener,
       @Nullable RequestTracker requestTracker,
+      @Nullable RequestIdGenerator requestIdGenerator,
       @NonNull Map<String, String> localDatacenters,
       @NonNull Map<String, Predicate<Node>> nodeFilters,
       @NonNull Map<String, NodeDistanceEvaluator> nodeDistanceEvaluators,
@@ -94,6 +97,7 @@ public class ProgrammaticArguments {
     this.nodeStateListener = nodeStateListener;
     this.schemaChangeListener = schemaChangeListener;
     this.requestTracker = requestTracker;
+    this.requestIdGenerator = requestIdGenerator;
     this.localDatacenters = localDatacenters;
     this.nodeFilters = nodeFilters;
     this.nodeDistanceEvaluators = nodeDistanceEvaluators;
@@ -126,6 +130,11 @@ public class ProgrammaticArguments {
   @Nullable
   public RequestTracker getRequestTracker() {
     return requestTracker;
+  }
+
+  @Nullable
+  public RequestIdGenerator getRequestIdGenerator() {
+    return requestIdGenerator;
   }
 
   @NonNull
@@ -196,6 +205,7 @@ public class ProgrammaticArguments {
     private NodeStateListener nodeStateListener;
     private SchemaChangeListener schemaChangeListener;
     private RequestTracker requestTracker;
+    private RequestIdGenerator requestIdGenerator;
     private ImmutableMap.Builder<String, String> localDatacentersBuilder = ImmutableMap.builder();
     private final ImmutableMap.Builder<String, Predicate<Node>> nodeFiltersBuilder =
         ImmutableMap.builder();
@@ -291,6 +301,12 @@ public class ProgrammaticArguments {
           this.requestTracker = multiplexingRequestTracker;
         }
       }
+      return this;
+    }
+
+    @NonNull
+    public Builder withRequestIdGenerator(@Nullable RequestIdGenerator requestIdGenerator) {
+      this.requestIdGenerator = requestIdGenerator;
       return this;
     }
 
@@ -417,6 +433,7 @@ public class ProgrammaticArguments {
           nodeStateListener,
           schemaChangeListener,
           requestTracker,
+          requestIdGenerator,
           localDatacentersBuilder.build(),
           nodeFiltersBuilder.build(),
           nodeDistanceEvaluatorsBuilder.build(),

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -41,6 +41,7 @@ import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.ssl.ProgrammaticSslEngineFactory;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
@@ -53,6 +54,7 @@ import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
+import com.datastax.oss.driver.internal.core.tracker.W3CContextRequestIdGenerator;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -88,6 +90,8 @@ import org.slf4j.LoggerFactory;
  */
 @NotThreadSafe
 public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
+
+  public static final String ASTRA_PAYLOAD_KEY = "traceparent";
 
   private static final Logger LOG = LoggerFactory.getLogger(SessionBuilder.class);
 
@@ -321,6 +325,17 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   @NonNull
   public SelfT addRequestTracker(@NonNull RequestTracker requestTracker) {
     programmaticArgumentsBuilder.addRequestTracker(requestTracker);
+    return self;
+  }
+
+  /**
+   * Registers a request ID generator. The driver will use the generated ID in the logs and
+   * optionally add to the custom payload so that users can correlate logs about the same request
+   * from the Cassandra side.
+   */
+  @NonNull
+  public SelfT withRequestIdGenerator(@NonNull RequestIdGenerator requestIdGenerator) {
+    this.programmaticArgumentsBuilder.withRequestIdGenerator(requestIdGenerator);
     return self;
   }
 
@@ -868,6 +883,13 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
       List<String> configContactPoints =
           defaultConfig.getStringList(DefaultDriverOption.CONTACT_POINTS, Collections.emptyList());
       if (cloudConfigInputStream != null) {
+        // override request id generator, unless user has already set it
+        if (programmaticArguments.getRequestIdGenerator() == null) {
+          programmaticArgumentsBuilder.withRequestIdGenerator(
+              new W3CContextRequestIdGenerator(ASTRA_PAYLOAD_KEY));
+          LOG.debug(
+              "A secure connect bundle is provided, using W3CContextRequestIdGenerator as request ID generator.");
+        }
         if (!programmaticContactPoints.isEmpty() || !configContactPoints.isEmpty()) {
           LOG.info(
               "Both a secure connect bundle and contact points were provided. These are mutually exclusive. The contact points from the secure bundle will have priority.");

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/throttling/RequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/throttling/RequestThrottler.java
@@ -23,10 +23,10 @@ import java.io.Closeable;
 /**
  * Limits the number of concurrent requests executed by the driver.
  *
- * <p>Usage in non-blocking applications: beware that all built-in implementations of this interface
- * use locks for internal coordination, and do not qualify as lock-free, with the obvious exception
- * of {@code PassThroughRequestThrottler}. If your application enforces strict lock-freedom, then
- * request throttling should not be enabled.
+ * <p>Usage in non-blocking applications: beware that some implementations of this interface use
+ * locks for internal coordination, and do not qualify as lock-free. If your application enforces
+ * strict lock-freedom, then you should use the {@code PassThroughRequestThrottler} or the {@code
+ * ConcurrencyLimitingRequestThrottler}.
  */
 public interface RequestThrottler extends Closeable {
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestIdGenerator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.tracker;
+
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Interface responsible for generating request IDs.
+ *
+ * <p>Note that all request IDs have a parent/child relationship. A "parent ID" can loosely be
+ * thought of as encompassing a sequence of a request + any attendant retries, speculative
+ * executions etc. It's scope is identical to that of a {@link
+ * com.datastax.oss.driver.internal.core.cql.CqlRequestHandler}. A "request ID" represents a single
+ * request within this larger scope. Note that a request corresponding to a request ID may be
+ * retried; in that case the retry count will be appended to the corresponding identifier in the
+ * logs.
+ */
+public interface RequestIdGenerator {
+
+  String DEFAULT_PAYLOAD_KEY = "request-id";
+
+  /**
+   * Generates a unique identifier for the session request. This will be the identifier for the
+   * entire `session.execute()` call. This identifier will be added to logs, and propagated to
+   * request trackers.
+   *
+   * @return a unique identifier for the session request
+   */
+  String getSessionRequestId();
+
+  /**
+   * Generates a unique identifier for the node request. This will be the identifier for the CQL
+   * request against a particular node. There can be one or more node requests for a single session
+   * request, due to retries or speculative executions. This identifier will be added to logs, and
+   * propagated to request trackers.
+   *
+   * @param statement the statement to be executed
+   * @param parentId the session request identifier
+   * @return a unique identifier for the node request
+   */
+  String getNodeRequestId(@NonNull Request statement, @NonNull String parentId);
+
+  default String getCustomPayloadKey() {
+    return DEFAULT_PAYLOAD_KEY;
+  }
+
+  default Statement<?> getDecoratedStatement(
+      @NonNull Statement<?> statement, @NonNull String requestId) {
+    Map<String, ByteBuffer> customPayload =
+        NullAllowingImmutableMap.<String, ByteBuffer>builder()
+            .putAll(statement.getCustomPayload())
+            .put(getCustomPayloadKey(), ByteBuffer.wrap(requestId.getBytes(StandardCharsets.UTF_8)))
+            .build();
+    return statement.setCustomPayload(customPayload);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestTracker.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestTracker.java
@@ -47,21 +47,22 @@ public interface RequestTracker extends AutoCloseable {
       @NonNull Node node) {}
 
   /**
-   * Invoked each time a request succeeds.
+   * Invoked each time a session request succeeds. A session request is a `session.execute()` call
    *
    * @param latencyNanos the overall execution time (from the {@link Session#execute(Request,
    *     GenericType) session.execute} call until the result is made available to the client).
    * @param executionProfile the execution profile of this request.
    * @param node the node that returned the successful response.
-   * @param requestLogPrefix the dedicated log prefix for this request
+   * @param sessionRequestLogPrefix the dedicated log prefix for this request
    */
   default void onSuccess(
       @NonNull Request request,
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestLogPrefix) {
-    // If client doesn't override onSuccess with requestLogPrefix delegate call to the old method
+      @NonNull String sessionRequestLogPrefix) {
+    // If client doesn't override onSuccess with sessionRequestLogPrefix delegate call to the old
+    // method
     onSuccess(request, latencyNanos, executionProfile, node);
   }
 
@@ -78,13 +79,13 @@ public interface RequestTracker extends AutoCloseable {
       @Nullable Node node) {}
 
   /**
-   * Invoked each time a request fails.
+   * Invoked each time a session request fails. A session request is a `session.execute()` call
    *
    * @param latencyNanos the overall execution time (from the {@link Session#execute(Request,
    *     GenericType) session.execute} call until the error is propagated to the client).
    * @param executionProfile the execution profile of this request.
    * @param node the node that returned the error response, or {@code null} if the error occurred
-   * @param requestLogPrefix the dedicated log prefix for this request
+   * @param sessionRequestLogPrefix the dedicated log prefix for this request
    */
   default void onError(
       @NonNull Request request,
@@ -92,8 +93,9 @@ public interface RequestTracker extends AutoCloseable {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @Nullable Node node,
-      @NonNull String requestLogPrefix) {
-    // If client doesn't override onError with requestLogPrefix delegate call to the old method
+      @NonNull String sessionRequestLogPrefix) {
+    // If client doesn't override onError with sessionRequestLogPrefix delegate call to the old
+    // method
     onError(request, error, latencyNanos, executionProfile, node);
   }
 
@@ -110,14 +112,15 @@ public interface RequestTracker extends AutoCloseable {
       @NonNull Node node) {}
 
   /**
-   * Invoked each time a request fails at the node level. Similar to {@link #onError(Request,
-   * Throwable, long, DriverExecutionProfile, Node, String)} but at a per node level.
+   * Invoked each time a node request fails. A node request is a CQL request sent to a particular
+   * node. There can be one or more node requests for a single session request, due to retries or
+   * speculative executions.
    *
    * @param latencyNanos the overall execution time (from the {@link Session#execute(Request,
    *     GenericType) session.execute} call until the error is propagated to the client).
    * @param executionProfile the execution profile of this request.
    * @param node the node that returned the error response.
-   * @param requestLogPrefix the dedicated log prefix for this request
+   * @param nodeRequestLogPrefix the dedicated log prefix for this request
    */
   default void onNodeError(
       @NonNull Request request,
@@ -125,8 +128,9 @@ public interface RequestTracker extends AutoCloseable {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestLogPrefix) {
-    // If client doesn't override onNodeError with requestLogPrefix delegate call to the old method
+      @NonNull String nodeRequestLogPrefix) {
+    // If client doesn't override onNodeError with nodeRequestLogPrefix delegate call to the old
+    // method
     onNodeError(request, error, latencyNanos, executionProfile, node);
   }
 
@@ -142,22 +146,23 @@ public interface RequestTracker extends AutoCloseable {
       @NonNull Node node) {}
 
   /**
-   * Invoked each time a request succeeds at the node level. Similar to {@link #onSuccess(Request,
-   * long, DriverExecutionProfile, Node, String)} but at per node level.
+   * Invoked each time a node request succeeds. A node request is a CQL request sent to a particular
+   * node. There can be one or more node requests for a single session request, due to retries or
+   * speculative executions.
    *
    * @param latencyNanos the overall execution time (from the {@link Session#execute(Request,
    *     GenericType) session.execute} call until the result is made available to the client).
    * @param executionProfile the execution profile of this request.
    * @param node the node that returned the successful response.
-   * @param requestLogPrefix the dedicated log prefix for this request
+   * @param nodeRequestLogPrefix the dedicated log prefix for this request
    */
   default void onNodeSuccess(
       @NonNull Request request,
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestLogPrefix) {
-    // If client doesn't override onNodeSuccess with requestLogPrefix delegate call to the old
+      @NonNull String nodeRequestLogPrefix) {
+    // If client doesn't override onNodeSuccess with nodeRequestLogPrefix delegate call to the old
     // method
     onNodeSuccess(request, latencyNanos, executionProfile, node);
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
@@ -19,14 +19,11 @@ package com.datastax.oss.driver.internal.core;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.util.AddressUtils;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -41,7 +38,22 @@ public class ContactPoints {
 
     Set<EndPoint> result = Sets.newHashSet(programmaticContactPoints);
     for (String spec : configContactPoints) {
-      for (InetSocketAddress address : extract(spec, resolve)) {
+
+      Set<InetSocketAddress> addresses = Collections.emptySet();
+      try {
+        addresses = AddressUtils.extract(spec, resolve);
+      } catch (RuntimeException e) {
+        LOG.warn("Ignoring invalid contact point {} ({})", spec, e.getMessage(), e);
+      }
+
+      if (addresses.size() > 1) {
+        LOG.info(
+            "Contact point {} resolves to multiple addresses, will use them all ({})",
+            spec,
+            addresses);
+      }
+
+      for (InetSocketAddress address : addresses) {
         DefaultEndPoint endPoint = new DefaultEndPoint(address);
         boolean wasNew = result.add(endPoint);
         if (!wasNew) {
@@ -50,44 +62,5 @@ public class ContactPoints {
       }
     }
     return ImmutableSet.copyOf(result);
-  }
-
-  private static Set<InetSocketAddress> extract(String spec, boolean resolve) {
-    int separator = spec.lastIndexOf(':');
-    if (separator < 0) {
-      LOG.warn("Ignoring invalid contact point {} (expecting host:port)", spec);
-      return Collections.emptySet();
-    }
-
-    String host = spec.substring(0, separator);
-    String portSpec = spec.substring(separator + 1);
-    int port;
-    try {
-      port = Integer.parseInt(portSpec);
-    } catch (NumberFormatException e) {
-      LOG.warn("Ignoring invalid contact point {} (expecting a number, got {})", spec, portSpec);
-      return Collections.emptySet();
-    }
-    if (!resolve) {
-      return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
-    } else {
-      try {
-        InetAddress[] inetAddresses = InetAddress.getAllByName(host);
-        if (inetAddresses.length > 1) {
-          LOG.info(
-              "Contact point {} resolves to multiple addresses, will use them all ({})",
-              spec,
-              Arrays.deepToString(inetAddresses));
-        }
-        Set<InetSocketAddress> result = new HashSet<>();
-        for (InetAddress inetAddress : inetAddresses) {
-          result.add(new InetSocketAddress(inetAddress, port));
-        }
-        return result;
-      } catch (UnknownHostException e) {
-        LOG.warn("Ignoring invalid contact point {} (unknown host {})", spec, host);
-        return Collections.emptySet();
-      }
-    }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
@@ -17,8 +17,9 @@
  */
 package com.datastax.oss.driver.internal.core.addresstranslation;
 
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
+
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
-import com.datastax.oss.driver.api.core.config.DriverOption;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetSocketAddress;
@@ -37,28 +38,13 @@ public class FixedHostNameAddressTranslator implements AddressTranslator {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixedHostNameAddressTranslator.class);
 
-  public static final String ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME =
-      "advanced.address-translator.advertised-hostname";
-
-  public static DriverOption ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION =
-      new DriverOption() {
-        @NonNull
-        @Override
-        public String getPath() {
-          return ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
-        }
-      };
-
   private final String advertisedHostname;
   private final String logPrefix;
 
   public FixedHostNameAddressTranslator(@NonNull DriverContext context) {
     logPrefix = context.getSessionName();
     advertisedHostname =
-        context
-            .getConfig()
-            .getDefaultProfile()
-            .getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION);
+        context.getConfig().getDefaultProfile().getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME);
   }
 
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Subnet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Subnet.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+class Subnet {
+  private final byte[] subnet;
+  private final byte[] networkMask;
+  private final byte[] upper;
+  private final byte[] lower;
+
+  private Subnet(byte[] subnet, byte[] networkMask) {
+    this.subnet = subnet;
+    this.networkMask = networkMask;
+
+    byte[] upper = new byte[subnet.length];
+    byte[] lower = new byte[subnet.length];
+    for (int i = 0; i < subnet.length; i++) {
+      upper[i] = (byte) (subnet[i] | ~networkMask[i]);
+      lower[i] = (byte) (subnet[i] & networkMask[i]);
+    }
+    this.upper = upper;
+    this.lower = lower;
+  }
+
+  static Subnet parse(String subnetCIDR) throws UnknownHostException {
+    List<String> parts = Splitter.on("/").splitToList(subnetCIDR);
+    if (parts.size() != 2) {
+      throw new IllegalArgumentException("Invalid subnet: " + subnetCIDR);
+    }
+
+    boolean isIPv6 = parts.get(0).contains(":");
+    byte[] subnet = InetAddress.getByName(parts.get(0)).getAddress();
+    if (isIPv4(subnet) && isIPv6) {
+      subnet = toIPv6(subnet);
+    }
+    int prefixLength = Integer.parseInt(parts.get(1));
+    validatePrefixLength(subnet, prefixLength);
+
+    byte[] networkMask = toNetworkMask(subnet, prefixLength);
+    validateSubnetIsPrefixBlock(subnet, networkMask, subnetCIDR);
+    return new Subnet(subnet, networkMask);
+  }
+
+  private static byte[] toNetworkMask(byte[] subnet, int prefixLength) {
+    int fullBytes = prefixLength / 8;
+    int remainingBits = prefixLength % 8;
+    byte[] mask = new byte[subnet.length];
+    Arrays.fill(mask, 0, fullBytes, (byte) 0xFF);
+    if (remainingBits > 0) {
+      mask[fullBytes] = (byte) (0xFF << (8 - remainingBits));
+    }
+    return mask;
+  }
+
+  private static void validatePrefixLength(byte[] subnet, int prefixLength) {
+    int max_prefix_length = subnet.length * 8;
+    if (prefixLength < 0 || max_prefix_length < prefixLength) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Prefix length %s must be within [0; %s]", prefixLength, max_prefix_length));
+    }
+  }
+
+  private static void validateSubnetIsPrefixBlock(
+      byte[] subnet, byte[] networkMask, String subnetCIDR) {
+    byte[] prefixBlock = toPrefixBlock(subnet, networkMask);
+    if (!Arrays.equals(subnet, prefixBlock)) {
+      throw new IllegalArgumentException(
+          String.format("Subnet %s must be represented as a network prefix block", subnetCIDR));
+    }
+  }
+
+  private static byte[] toPrefixBlock(byte[] subnet, byte[] networkMask) {
+    byte[] prefixBlock = new byte[subnet.length];
+    for (int i = 0; i < subnet.length; i++) {
+      prefixBlock[i] = (byte) (subnet[i] & networkMask[i]);
+    }
+    return prefixBlock;
+  }
+
+  @VisibleForTesting
+  byte[] getSubnet() {
+    return Arrays.copyOf(subnet, subnet.length);
+  }
+
+  @VisibleForTesting
+  byte[] getNetworkMask() {
+    return Arrays.copyOf(networkMask, networkMask.length);
+  }
+
+  byte[] getUpper() {
+    return Arrays.copyOf(upper, upper.length);
+  }
+
+  byte[] getLower() {
+    return Arrays.copyOf(lower, lower.length);
+  }
+
+  boolean isIPv4() {
+    return isIPv4(subnet);
+  }
+
+  boolean isIPv6() {
+    return isIPv6(subnet);
+  }
+
+  boolean contains(byte[] ip) {
+    if (isIPv4() && !isIPv4(ip)) {
+      return false;
+    }
+    if (isIPv6() && isIPv4(ip)) {
+      ip = toIPv6(ip);
+    }
+    if (subnet.length != ip.length) {
+      throw new IllegalArgumentException(
+          "IP version is unknown: " + Arrays.toString(toZeroBasedByteArray(ip)));
+    }
+    for (int i = 0; i < subnet.length; i++) {
+      if (subnet[i] != (byte) (ip[i] & networkMask[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isIPv4(byte[] ip) {
+    return ip.length == 4;
+  }
+
+  private static boolean isIPv6(byte[] ip) {
+    return ip.length == 16;
+  }
+
+  private static byte[] toIPv6(byte[] ipv4) {
+    byte[] ipv6 = new byte[16];
+    ipv6[10] = (byte) 0xFF;
+    ipv6[11] = (byte) 0xFF;
+    System.arraycopy(ipv4, 0, ipv6, 12, 4);
+    return ipv6;
+  }
+
+  @Override
+  public String toString() {
+    return Arrays.toString(toZeroBasedByteArray(subnet));
+  }
+
+  private static int[] toZeroBasedByteArray(byte[] bytes) {
+    int[] res = new int[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      res[i] = bytes[i] & 0xFF;
+    }
+    return res;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddress.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddress.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+class SubnetAddress {
+  private final Subnet subnet;
+  private final InetSocketAddress address;
+
+  SubnetAddress(String subnetCIDR, InetSocketAddress address) {
+    try {
+      this.subnet = Subnet.parse(subnetCIDR);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+    this.address = address;
+  }
+
+  InetSocketAddress getAddress() {
+    return this.address;
+  }
+
+  boolean isOverlapping(SubnetAddress other) {
+    Subnet thisSubnet = this.subnet;
+    Subnet otherSubnet = other.subnet;
+    return thisSubnet.contains(otherSubnet.getLower())
+        || thisSubnet.contains(otherSubnet.getUpper())
+        || otherSubnet.contains(thisSubnet.getLower())
+        || otherSubnet.contains(thisSubnet.getUpper());
+  }
+
+  boolean contains(InetSocketAddress address) {
+    return subnet.contains(address.getAddress().getAddress());
+  }
+
+  boolean isIPv4() {
+    return subnet.isIPv4();
+  }
+
+  boolean isIPv6() {
+    return subnet.isIPv6();
+  }
+
+  @Override
+  public String toString() {
+    return "SubnetAddress[subnet=" + subnet + ", address=" + address + "]";
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES;
+
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.util.AddressUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This translator returns the proxy address of the private subnet containing the Cassandra node IP,
+ * or default address if no matching subnets, or passes through the original node address if no
+ * default configured.
+ *
+ * <p>The translator can be used for scenarios when all nodes are behind some kind of proxy, and
+ * that proxy is different for nodes located in different subnets (eg. when Cassandra is deployed in
+ * multiple datacenters/regions). One can use this, for example, for Cassandra on Kubernetes with
+ * different Cassandra datacenters deployed to different Kubernetes clusters.
+ */
+public class SubnetAddressTranslator implements AddressTranslator {
+  private static final Logger LOG = LoggerFactory.getLogger(SubnetAddressTranslator.class);
+
+  private final List<SubnetAddress> subnetAddresses;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private final Optional<InetSocketAddress> defaultAddress;
+
+  private final String logPrefix;
+
+  public SubnetAddressTranslator(@NonNull DriverContext context) {
+    logPrefix = context.getSessionName();
+    boolean resolveAddresses =
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES, false);
+    this.subnetAddresses =
+        context.getConfig().getDefaultProfile().getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)
+            .entrySet().stream()
+            .map(
+                e -> {
+                  // Quoted and/or containing forward slashes map keys in reference.conf are read to
+                  // strings with additional quotes, eg. 100.64.0.0/15 -> '100.64.0."0/15"' or
+                  // "100.64.0.0/15" -> '"100.64.0.0/15"'
+                  String subnetCIDR = e.getKey().replaceAll("\"", "");
+                  String address = e.getValue();
+                  return new SubnetAddress(subnetCIDR, parseAddress(address, resolveAddresses));
+                })
+            .collect(Collectors.toList());
+    this.defaultAddress =
+        Optional.ofNullable(
+                context
+                    .getConfig()
+                    .getDefaultProfile()
+                    .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+            .map(address -> parseAddress(address, resolveAddresses));
+
+    validateSubnetsAreOfSameProtocol(this.subnetAddresses);
+    validateSubnetsAreNotOverlapping(this.subnetAddresses);
+  }
+
+  private static void validateSubnetsAreOfSameProtocol(List<SubnetAddress> subnets) {
+    for (int i = 0; i < subnets.size() - 1; i++) {
+      for (int j = i + 1; j < subnets.size(); j++) {
+        SubnetAddress subnet1 = subnets.get(i);
+        SubnetAddress subnet2 = subnets.get(j);
+        if (subnet1.isIPv4() != subnet2.isIPv4() && subnet1.isIPv6() != subnet2.isIPv6()) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Configured subnets are of the different protocols: %s, %s", subnet1, subnet2));
+        }
+      }
+    }
+  }
+
+  private static void validateSubnetsAreNotOverlapping(List<SubnetAddress> subnets) {
+    for (int i = 0; i < subnets.size() - 1; i++) {
+      for (int j = i + 1; j < subnets.size(); j++) {
+        SubnetAddress subnet1 = subnets.get(i);
+        SubnetAddress subnet2 = subnets.get(j);
+        if (subnet1.isOverlapping(subnet2)) {
+          throw new IllegalArgumentException(
+              String.format("Configured subnets are overlapping: %s, %s", subnet1, subnet2));
+        }
+      }
+    }
+  }
+
+  @NonNull
+  @Override
+  public InetSocketAddress translate(@NonNull InetSocketAddress address) {
+    InetSocketAddress translatedAddress = null;
+    for (SubnetAddress subnetAddress : subnetAddresses) {
+      if (subnetAddress.contains(address)) {
+        translatedAddress = subnetAddress.getAddress();
+      }
+    }
+    if (translatedAddress == null && defaultAddress.isPresent()) {
+      translatedAddress = defaultAddress.get();
+    }
+    if (translatedAddress == null) {
+      translatedAddress = address;
+    }
+    LOG.debug("[{}] Translated {} to {}", logPrefix, address, translatedAddress);
+    return translatedAddress;
+  }
+
+  @Override
+  public void close() {}
+
+  @Nullable
+  private InetSocketAddress parseAddress(String address, boolean resolve) {
+    try {
+      InetSocketAddress parsedAddress = AddressUtils.extract(address, resolve).iterator().next();
+      LOG.debug("[{}] Parsed {} to {}", logPrefix, address, parsedAddress);
+      return parsedAddress;
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid address %s (%s)", address, e.getMessage()), e);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -217,8 +217,8 @@ public class DefaultDriverContext implements InternalDriverContext {
       new LazyReference<>("metricIdGenerator", this::buildMetricIdGenerator, cycleDetector);
   private final LazyReference<RequestThrottler> requestThrottlerRef =
       new LazyReference<>("requestThrottler", this::buildRequestThrottler, cycleDetector);
-  private final LazyReference<Map<String, String>> startupOptionsRef =
-      new LazyReference<>("startupOptions", this::buildStartupOptions, cycleDetector);
+  private final LazyReference<StartupOptionsBuilder> startupOptionsRef =
+      new LazyReference<>("startupOptionsFactory", this::buildStartupOptionsFactory, cycleDetector);
   private final LazyReference<NodeStateListener> nodeStateListenerRef;
   private final LazyReference<SchemaChangeListener> schemaChangeListenerRef;
   private final LazyReference<RequestTracker> requestTrackerRef;
@@ -336,16 +336,15 @@ public class DefaultDriverContext implements InternalDriverContext {
   }
 
   /**
-   * Builds a map of options to send in a Startup message.
+   * Returns builder of options to send in a Startup message.
    *
    * @see #getStartupOptions()
    */
-  protected Map<String, String> buildStartupOptions() {
+  protected StartupOptionsBuilder buildStartupOptionsFactory() {
     return new StartupOptionsBuilder(this)
         .withClientId(startupClientId)
         .withApplicationName(startupApplicationName)
-        .withApplicationVersion(startupApplicationVersion)
-        .build();
+        .withApplicationVersion(startupApplicationVersion);
   }
 
   protected Map<String, LoadBalancingPolicy> buildLoadBalancingPolicies() {
@@ -1017,7 +1016,8 @@ public class DefaultDriverContext implements InternalDriverContext {
   @NonNull
   @Override
   public Map<String, String> getStartupOptions() {
-    return startupOptionsRef.get();
+    // startup options are calculated dynamically and may vary per connection
+    return startupOptionsRef.get().build();
   }
 
   protected RequestLogFormatter buildRequestLogFormatter() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -44,6 +44,7 @@ import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.api.core.time.TimestampGenerator;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
@@ -222,6 +223,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   private final LazyReference<NodeStateListener> nodeStateListenerRef;
   private final LazyReference<SchemaChangeListener> schemaChangeListenerRef;
   private final LazyReference<RequestTracker> requestTrackerRef;
+  private final LazyReference<Optional<RequestIdGenerator>> requestIdGeneratorRef;
   private final LazyReference<Optional<AuthProvider>> authProviderRef;
   private final LazyReference<List<LifecycleListener>> lifecycleListenersRef =
       new LazyReference<>("lifecycleListeners", this::buildLifecycleListeners, cycleDetector);
@@ -283,6 +285,11 @@ public class DefaultDriverContext implements InternalDriverContext {
     this.requestTrackerRef =
         new LazyReference<>(
             "requestTracker", () -> buildRequestTracker(requestTrackerFromBuilder), cycleDetector);
+    this.requestIdGeneratorRef =
+        new LazyReference<>(
+            "requestIdGenerator",
+            () -> buildRequestIdGenerator(programmaticArguments.getRequestIdGenerator()),
+            cycleDetector);
     this.sslEngineFactoryRef =
         new LazyReference<>(
             "sslEngineFactory",
@@ -712,6 +719,17 @@ public class DefaultDriverContext implements InternalDriverContext {
     }
   }
 
+  protected Optional<RequestIdGenerator> buildRequestIdGenerator(
+      RequestIdGenerator requestIdGenerator) {
+    return (requestIdGenerator != null)
+        ? Optional.of(requestIdGenerator)
+        : Reflection.buildFromConfig(
+            this,
+            DefaultDriverOption.REQUEST_ID_GENERATOR_CLASS,
+            RequestIdGenerator.class,
+            "com.datastax.oss.driver.internal.core.tracker");
+  }
+
   protected Optional<AuthProvider> buildAuthProvider(AuthProvider authProviderFromBuilder) {
     return (authProviderFromBuilder != null)
         ? Optional.of(authProviderFromBuilder)
@@ -974,6 +992,12 @@ public class DefaultDriverContext implements InternalDriverContext {
   @Override
   public RequestTracker getRequestTracker() {
     return requestTrackerRef.get();
+  }
+
+  @NonNull
+  @Override
+  public Optional<RequestIdGenerator> getRequestIdGenerator() {
+    return requestIdGeneratorRef.get();
   }
 
   @Nullable

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
@@ -200,7 +200,7 @@ public class DefaultNettyOptions implements NettyOptions {
   }
 
   @Override
-  public synchronized Timer getTimer() {
+  public Timer getTimer() {
     return timer;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilder.java
@@ -19,23 +19,33 @@ package com.datastax.oss.driver.internal.core.context;
 
 import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.protocol.internal.request.Startup;
 import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import net.jcip.annotations.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Immutable
 public class StartupOptionsBuilder {
 
   public static final String DRIVER_NAME_KEY = "DRIVER_NAME";
   public static final String DRIVER_VERSION_KEY = "DRIVER_VERSION";
+  public static final String DRIVER_BAGGAGE = "DRIVER_BAGGAGE";
   public static final String APPLICATION_NAME_KEY = "APPLICATION_NAME";
   public static final String APPLICATION_VERSION_KEY = "APPLICATION_VERSION";
   public static final String CLIENT_ID_KEY = "CLIENT_ID";
+
+  private static final Logger LOG = LoggerFactory.getLogger(StartupOptionsBuilder.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   protected final InternalDriverContext context;
   private UUID clientId;
@@ -119,6 +129,7 @@ public class StartupOptionsBuilder {
     if (applicationVersion != null) {
       builder.put(APPLICATION_VERSION_KEY, applicationVersion);
     }
+    driverBaggage().ifPresent(s -> builder.put(DRIVER_BAGGAGE, s));
 
     return builder.build();
   }
@@ -141,5 +152,22 @@ public class StartupOptionsBuilder {
    */
   protected String getDriverVersion() {
     return Session.OSS_DRIVER_COORDINATES.getVersion().toString();
+  }
+
+  private Optional<String> driverBaggage() {
+    ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+    for (Map.Entry<String, LoadBalancingPolicy> entry :
+        context.getLoadBalancingPolicies().entrySet()) {
+      Map<String, ?> config = entry.getValue().getStartupConfiguration();
+      if (!config.isEmpty()) {
+        builder.put(entry.getKey(), config);
+      }
+    }
+    try {
+      return Optional.of(mapper.writeValueAsString(builder.build()));
+    } catch (Exception e) {
+      LOG.warn("Failed to construct startup driver baggage", e);
+      return Optional.empty();
+    }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -55,6 +55,7 @@ import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
 import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.session.throttling.Throttled;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.internal.core.adminrequest.ThrottledAdminRequestHandler;
 import com.datastax.oss.driver.internal.core.adminrequest.UnexpectedResponseException;
@@ -73,6 +74,7 @@ import com.datastax.oss.driver.internal.core.tracker.NoopRequestTracker;
 import com.datastax.oss.driver.internal.core.tracker.RequestLogger;
 import com.datastax.oss.driver.internal.core.util.Loggers;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
+import com.datastax.oss.driver.shaded.guava.common.base.Joiner;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
@@ -96,6 +98,7 @@ import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -114,7 +117,7 @@ public class CqlRequestHandler implements Throttled {
   private static final long NANOTIME_NOT_MEASURED_YET = -1;
 
   private final long startTimeNanos;
-  private final String logPrefix;
+  private final String handlerLogPrefix;
   private final Statement<?> initialStatement;
   private final DefaultSession session;
   private final CqlIdentifier keyspace;
@@ -139,6 +142,7 @@ public class CqlRequestHandler implements Throttled {
   private final List<NodeResponseCallback> inFlightCallbacks;
   private final RequestThrottler throttler;
   private final RequestTracker requestTracker;
+  private final Optional<RequestIdGenerator> requestIdGenerator;
   private final SessionMetricUpdater sessionMetricUpdater;
   private final DriverExecutionProfile executionProfile;
 
@@ -146,15 +150,25 @@ public class CqlRequestHandler implements Throttled {
   // We don't use a map because nodes can appear multiple times.
   private volatile List<Map.Entry<Node, Throwable>> errors;
 
+  private final Joiner logPrefixJoiner = Joiner.on('|');
+  private final String sessionName;
+  private final String sessionRequestId;
+
   protected CqlRequestHandler(
       Statement<?> statement,
       DefaultSession session,
       InternalDriverContext context,
-      String sessionLogPrefix) {
+      String sessionName) {
 
     this.startTimeNanos = System.nanoTime();
-    this.logPrefix = sessionLogPrefix + "|" + this.hashCode();
-    LOG.trace("[{}] Creating new handler for request {}", logPrefix, statement);
+    this.requestIdGenerator = context.getRequestIdGenerator();
+    this.sessionName = sessionName;
+    this.sessionRequestId =
+        this.requestIdGenerator
+            .map(RequestIdGenerator::getSessionRequestId)
+            .orElse(Integer.toString(this.hashCode()));
+    this.handlerLogPrefix = logPrefixJoiner.join(sessionName, sessionRequestId);
+    LOG.trace("[{}] Creating new handler for request {}", handlerLogPrefix, statement);
 
     this.initialStatement = statement;
     this.session = session;
@@ -169,7 +183,7 @@ public class CqlRequestHandler implements Throttled {
               context.getRequestThrottler().signalCancel(this);
             }
           } catch (Throwable t2) {
-            Loggers.warnWithException(LOG, "[{}] Uncaught exception", logPrefix, t2);
+            Loggers.warnWithException(LOG, "[{}] Uncaught exception", handlerLogPrefix, t2);
           }
           return null;
         });
@@ -366,6 +380,16 @@ public class CqlRequestHandler implements Throttled {
         setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
       }
     } else {
+      Statement finalStatement = statement;
+      String nodeRequestId =
+          this.requestIdGenerator
+              .map((g) -> g.getNodeRequestId(finalStatement, sessionRequestId))
+              .orElse(Integer.toString(this.hashCode()));
+      statement =
+          this.requestIdGenerator
+              .map((g) -> g.getDecoratedStatement(finalStatement, nodeRequestId))
+              .orElse(finalStatement);
+
       NodeResponseCallback nodeResponseCallback =
           new NodeResponseCallback(
               statement,
@@ -375,7 +399,7 @@ public class CqlRequestHandler implements Throttled {
               currentExecutionIndex,
               retryCount,
               scheduleNextExecution,
-              logPrefix);
+              logPrefixJoiner.join(this.sessionName, nodeRequestId, currentExecutionIndex));
       Message message = Conversions.toMessage(statement, executionProfile, context);
       channel
           .write(message, statement.isTracing(), statement.getCustomPayload(), nodeResponseCallback)
@@ -434,9 +458,17 @@ public class CqlRequestHandler implements Throttled {
           totalLatencyNanos = completionTimeNanos - startTimeNanos;
           long nodeLatencyNanos = completionTimeNanos - callback.nodeStartTimeNanos;
           requestTracker.onNodeSuccess(
-              callback.statement, nodeLatencyNanos, executionProfile, callback.node, logPrefix);
+              callback.statement,
+              nodeLatencyNanos,
+              executionProfile,
+              callback.node,
+              handlerLogPrefix);
           requestTracker.onSuccess(
-              callback.statement, totalLatencyNanos, executionProfile, callback.node, logPrefix);
+              callback.statement,
+              totalLatencyNanos,
+              executionProfile,
+              callback.node,
+              handlerLogPrefix);
         }
         if (sessionMetricUpdater.isEnabled(
             DefaultSessionMetric.CQL_REQUESTS, executionProfile.getName())) {
@@ -560,7 +592,8 @@ public class CqlRequestHandler implements Throttled {
       cancelScheduledTasks();
       if (!(requestTracker instanceof NoopRequestTracker)) {
         long latencyNanos = System.nanoTime() - startTimeNanos;
-        requestTracker.onError(statement, error, latencyNanos, executionProfile, node, logPrefix);
+        requestTracker.onError(
+            statement, error, latencyNanos, executionProfile, node, handlerLogPrefix);
       }
       if (error instanceof DriverTimeoutException) {
         throttler.signalTimeout(this);
@@ -610,7 +643,7 @@ public class CqlRequestHandler implements Throttled {
       this.execution = execution;
       this.retryCount = retryCount;
       this.scheduleNextExecution = scheduleNextExecution;
-      this.logPrefix = logPrefix + "|" + execution;
+      this.logPrefix = logPrefix;
     }
 
     // this gets invoked once the write completes.
@@ -688,7 +721,7 @@ public class CqlRequestHandler implements Throttled {
                   if (!result.isDone()) {
                     LOG.trace(
                         "[{}] Starting speculative execution {}",
-                        CqlRequestHandler.this.logPrefix,
+                        CqlRequestHandler.this.handlerLogPrefix,
                         index);
                     activeExecutionsCount.incrementAndGet();
                     startedSpeculativeExecutionsCount.incrementAndGet();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -355,7 +355,7 @@ public class CqlRequestHandler implements Throttled {
         || (channel =
                 session.getChannel(
                     node,
-                    logPrefix,
+                    handlerLogPrefix,
                     getRoutingToken(statement),
                     getShardFromTabletMap(statement, node, getRoutingToken(statement))))
             == null) {
@@ -363,7 +363,7 @@ public class CqlRequestHandler implements Throttled {
         channel =
             session.getChannel(
                 node,
-                logPrefix,
+                handlerLogPrefix,
                 getRoutingToken(statement),
                 getShardFromTabletMap(statement, node, getRoutingToken(statement)));
         if (channel != null) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -58,6 +58,7 @@ import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.driver.shaded.guava.common.base.Predicates;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -168,13 +169,41 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
    * Before initialization, this method always returns null.
    */
   @Nullable
-  protected String getLocalDatacenter() {
+  public String getLocalDatacenter() {
     return localDc;
   }
 
   @Nullable
   protected String getLocalRack() {
     return localRack;
+  }
+
+  @NonNull
+  @Override
+  public Map<String, ?> getStartupConfiguration() {
+    ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+    if (localDc != null) {
+      builder.put("localDc", localDc);
+    } else {
+      // Local data center may not be discovered prior to connection pool initialization.
+      // In such scenario, return configured local data center name.
+      // Note that when using DC inferring load balancing policy, startup configuration
+      // may not show local DC name, because it will be discovered only once control connection
+      // is established and datacenter of contact points known.
+      Optional<String> configuredDc =
+          new OptionalLocalDcHelper(context, profile, logPrefix).configuredLocalDc();
+      configuredDc.ifPresent(d -> builder.put("localDc", d));
+    }
+    if (!preferredRemoteDcs.isEmpty()) {
+      builder.put("preferredRemoteDcs", preferredRemoteDcs);
+    }
+    if (allowDcFailoverForLocalCl) {
+      builder.put("allowDcFailoverForLocalCl", allowDcFailoverForLocalCl);
+    }
+    if (maxNodesPerRemoteDc > 0) {
+      builder.put("maxNodesPerRemoteDc", maxNodesPerRemoteDc);
+    }
+    return ImmutableMap.of(BasicLoadBalancingPolicy.class.getSimpleName(), builder.build());
   }
 
   /** @return The nodes currently considered as live. */

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -351,7 +351,7 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     updateResponseTimes(node);
   }
 
@@ -362,7 +362,7 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     updateResponseTimes(node);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.internal.core.util.ArrayUtils;
 import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.MapMaker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -453,5 +454,14 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
       long threshold = now - RESPONSE_COUNT_RESET_INTERVAL_NANOS;
       return this.oldest - threshold >= 0;
     }
+  }
+
+  @NonNull
+  @Override
+  public Map<String, ?> getStartupConfiguration() {
+    Map<String, ?> parent = super.getStartupConfiguration();
+    return ImmutableMap.of(
+        DefaultLoadBalancingPolicy.class.getSimpleName(),
+        parent.get(BasicLoadBalancingPolicy.class.getSimpleName()));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
@@ -65,20 +65,14 @@ public class OptionalLocalDcHelper implements LocalDcHelper {
   @Override
   @NonNull
   public Optional<String> discoverLocalDc(@NonNull Map<UUID, Node> nodes) {
-    String localDc = context.getLocalDatacenter(profile.getName());
-    if (localDc != null) {
-      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDc);
-      checkLocalDatacenterCompatibility(localDc, context.getMetadataManager().getContactPoints());
-      return Optional.of(localDc);
-    } else if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)) {
-      localDc = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
-      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDc);
-      checkLocalDatacenterCompatibility(localDc, context.getMetadataManager().getContactPoints());
-      return Optional.of(localDc);
+    Optional<String> localDc = configuredLocalDc();
+    if (localDc.isPresent()) {
+      checkLocalDatacenterCompatibility(
+          localDc.get(), context.getMetadataManager().getContactPoints());
     } else {
       LOG.debug("[{}] Local DC not set, DC awareness will be disabled", logPrefix);
-      return Optional.empty();
     }
+    return localDc;
   }
 
   /**
@@ -137,5 +131,20 @@ public class OptionalLocalDcHelper implements LocalDcHelper {
       }
     }
     return String.join(", ", new TreeSet<>(l));
+  }
+
+  /** @return Local data center set programmatically or from configuration file. */
+  @NonNull
+  public Optional<String> configuredLocalDc() {
+    String localDc = context.getLocalDatacenter(profile.getName());
+    if (localDc != null) {
+      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDc);
+      return Optional.of(localDc);
+    } else if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)) {
+      localDc = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
+      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDc);
+      return Optional.of(localDc);
+    }
+    return Optional.empty();
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
@@ -26,10 +26,10 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SniEndPoint implements EndPoint {
-  private static final AtomicLong OFFSET = new AtomicLong();
+  private static final AtomicInteger OFFSET = new AtomicInteger();
 
   private final InetSocketAddress proxyAddress;
   private final String serverName;
@@ -64,7 +64,10 @@ public class SniEndPoint implements EndPoint {
       // The order of the returned address is unspecified. Sort by IP to make sure we get a true
       // round-robin
       Arrays.sort(aRecords, IP_COMPARATOR);
-      int index = (aRecords.length == 1) ? 0 : (int) OFFSET.getAndIncrement() % aRecords.length;
+      int index =
+          (aRecords.length == 1)
+              ? 0
+              : OFFSET.getAndUpdate(x -> x == Integer.MAX_VALUE ? 0 : x + 1) % aRecords.length;
       return new InetSocketAddress(aRecords[index], proxyAddress.getPort());
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottler.java
@@ -26,10 +26,9 @@ import com.datastax.oss.driver.api.core.session.throttling.Throttled;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.locks.ReentrantLock;
-import net.jcip.annotations.GuardedBy;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,17 +60,12 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
   private final String logPrefix;
   private final int maxConcurrentRequests;
   private final int maxQueueSize;
-
-  private final ReentrantLock lock = new ReentrantLock();
-
-  @GuardedBy("lock")
-  private int concurrentRequests;
-
-  @GuardedBy("lock")
-  private final Deque<Throttled> queue = new ArrayDeque<>();
-
-  @GuardedBy("lock")
-  private boolean closed;
+  private final AtomicInteger concurrentRequests = new AtomicInteger(0);
+  // CLQ is not O(1) for size(), as it forces a full iteration of the queue. So, we track
+  // the size of the queue explicitly.
+  private final Deque<Throttled> queue = new ConcurrentLinkedDeque<>();
+  private final AtomicInteger queueSize = new AtomicInteger(0);
+  private volatile boolean closed = false;
 
   public ConcurrencyLimitingRequestThrottler(DriverContext context) {
     this.logPrefix = context.getSessionName();
@@ -88,50 +82,62 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
 
   @Override
   public void register(@NonNull Throttled request) {
-    boolean notifyReadyRequired = false;
-
-    lock.lock();
-    try {
-      if (closed) {
-        LOG.trace("[{}] Rejecting request after shutdown", logPrefix);
-        fail(request, "The session is shutting down");
-      } else if (queue.isEmpty() && concurrentRequests < maxConcurrentRequests) {
-        // We have capacity for one more concurrent request
-        LOG.trace("[{}] Starting newly registered request", logPrefix);
-        concurrentRequests += 1;
-        notifyReadyRequired = true;
-      } else if (queue.size() < maxQueueSize) {
-        LOG.trace("[{}] Enqueuing request", logPrefix);
-        queue.add(request);
-      } else {
-        LOG.trace("[{}] Rejecting request because of full queue", logPrefix);
-        fail(
-            request,
-            String.format(
-                "The session has reached its maximum capacity "
-                    + "(concurrent requests: %d, queue size: %d)",
-                maxConcurrentRequests, maxQueueSize));
-      }
-    } finally {
-      lock.unlock();
+    if (closed) {
+      LOG.trace("[{}] Rejecting request after shutdown", logPrefix);
+      fail(request, "The session is shutting down");
+      return;
     }
 
-    // no need to hold the lock while allowing the task to progress
-    if (notifyReadyRequired) {
-      request.onThrottleReady(false);
+    // Implementation note: Technically the "concurrent requests" or "queue size"
+    // could read transiently over the limit, but the queue itself will never grow
+    // beyond the limit since we always check for that condition and revert if
+    // over-limit. We do this instead of a CAS-loop to avoid the potential loop.
+
+    // If no backlog exists AND we get capacity, we can execute immediately
+    if (queueSize.get() == 0) {
+      // Take a claim first, and then check if we are OK to proceed
+      int newConcurrent = concurrentRequests.incrementAndGet();
+      if (newConcurrent <= maxConcurrentRequests) {
+        LOG.trace("[{}] Starting newly registered request", logPrefix);
+        request.onThrottleReady(false);
+        return;
+      } else {
+        // We exceeded the limit, decrement the count and fall through to the queuing logic
+        concurrentRequests.decrementAndGet();
+      }
+    }
+
+    // If we have a backlog, or we failed to claim capacity, try to enqueue
+    int newQueueSize = queueSize.incrementAndGet();
+    if (newQueueSize <= maxQueueSize) {
+      LOG.trace("[{}] Enqueuing request", logPrefix);
+      queue.offer(request);
+
+      // Double-check that we were still supposed to be enqueued; it is possible
+      // that the session was closed while we were enqueuing, it's also possible
+      // that it is right now removing the request, so we need to check both
+      if (closed) {
+        if (queue.remove(request)) {
+          queueSize.decrementAndGet();
+          LOG.trace("[{}] Rejecting late request after shutdown", logPrefix);
+          fail(request, "The session is shutting down");
+        }
+      }
+    } else {
+      LOG.trace("[{}] Rejecting request because of full queue", logPrefix);
+      queueSize.decrementAndGet();
+      fail(
+          request,
+          String.format(
+              "The session has reached its maximum capacity "
+                  + "(concurrent requests: %d, queue size: %d)",
+              maxConcurrentRequests, maxQueueSize));
     }
   }
 
   @Override
   public void signalSuccess(@NonNull Throttled request) {
-    Throttled nextRequest = null;
-    lock.lock();
-    try {
-      nextRequest = onRequestDoneAndDequeNext();
-    } finally {
-      lock.unlock();
-    }
-
+    Throttled nextRequest = onRequestDoneAndDequeNext();
     if (nextRequest != null) {
       nextRequest.onThrottleReady(true);
     }
@@ -145,17 +151,13 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
   @Override
   public void signalTimeout(@NonNull Throttled request) {
     Throttled nextRequest = null;
-    lock.lock();
-    try {
-      if (!closed) {
-        if (queue.remove(request)) { // The request timed out before it was active
-          LOG.trace("[{}] Removing timed out request from the queue", logPrefix);
-        } else {
-          nextRequest = onRequestDoneAndDequeNext();
-        }
+    if (!closed) {
+      if (queue.remove(request)) { // The request timed out before it was active
+        queueSize.decrementAndGet();
+        LOG.trace("[{}] Removing timed out request from the queue", logPrefix);
+      } else {
+        nextRequest = onRequestDoneAndDequeNext();
       }
-    } finally {
-      lock.unlock();
     }
 
     if (nextRequest != null) {
@@ -166,17 +168,13 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
   @Override
   public void signalCancel(@NonNull Throttled request) {
     Throttled nextRequest = null;
-    lock.lock();
-    try {
-      if (!closed) {
-        if (queue.remove(request)) { // The request has been cancelled before it was active
-          LOG.trace("[{}] Removing cancelled request from the queue", logPrefix);
-        } else {
-          nextRequest = onRequestDoneAndDequeNext();
-        }
+    if (!closed) {
+      if (queue.remove(request)) { // The request has been cancelled before it was active
+        queueSize.decrementAndGet();
+        LOG.trace("[{}] Removing cancelled request from the queue", logPrefix);
+      } else {
+        nextRequest = onRequestDoneAndDequeNext();
       }
-    } finally {
-      lock.unlock();
     }
 
     if (nextRequest != null) {
@@ -184,17 +182,16 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
     }
   }
 
-  @SuppressWarnings("GuardedBy") // this method is only called with the lock held
   @Nullable
   private Throttled onRequestDoneAndDequeNext() {
-    assert lock.isHeldByCurrentThread();
     if (!closed) {
-      if (queue.isEmpty()) {
-        concurrentRequests -= 1;
+      Throttled nextRequest = queue.poll();
+      if (nextRequest == null) {
+        concurrentRequests.decrementAndGet();
       } else {
+        queueSize.decrementAndGet();
         LOG.trace("[{}] Starting dequeued request", logPrefix);
-        // don't touch concurrentRequests since we finished one but started another
-        return queue.poll();
+        return nextRequest;
       }
     }
 
@@ -204,45 +201,28 @@ public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
 
   @Override
   public void close() {
-    lock.lock();
-    try {
-      closed = true;
-      LOG.debug("[{}] Rejecting {} queued requests after shutdown", logPrefix, queue.size());
-      for (Throttled request : queue) {
-        fail(request, "The session is shutting down");
-      }
-    } finally {
-      lock.unlock();
+    closed = true;
+
+    LOG.debug("[{}] Rejecting {} queued requests after shutdown", logPrefix, queueSize.get());
+    Throttled request;
+    while ((request = queue.poll()) != null) {
+      queueSize.decrementAndGet();
+      fail(request, "The session is shutting down");
     }
   }
 
   public int getQueueSize() {
-    lock.lock();
-    try {
-      return queue.size();
-    } finally {
-      lock.unlock();
-    }
+    return queueSize.get();
   }
 
   @VisibleForTesting
   int getConcurrentRequests() {
-    lock.lock();
-    try {
-      return concurrentRequests;
-    } finally {
-      lock.unlock();
-    }
+    return concurrentRequests.get();
   }
 
   @VisibleForTesting
   Deque<Throttled> getQueue() {
-    lock.lock();
-    try {
-      return queue;
-    } finally {
-      lock.unlock();
-    }
+    return queue;
   }
 
   private static void fail(Throttled request, String message) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/MultiplexingRequestTracker.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/MultiplexingRequestTracker.java
@@ -82,10 +82,12 @@ public class MultiplexingRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
     invokeTrackers(
-        tracker -> tracker.onSuccess(request, latencyNanos, executionProfile, node, logPrefix),
-        logPrefix,
+        tracker ->
+            tracker.onSuccess(
+                request, latencyNanos, executionProfile, node, sessionRequestLogPrefix),
+        sessionRequestLogPrefix,
         "onSuccess");
   }
 
@@ -96,10 +98,12 @@ public class MultiplexingRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @Nullable Node node,
-      @NonNull String logPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
     invokeTrackers(
-        tracker -> tracker.onError(request, error, latencyNanos, executionProfile, node, logPrefix),
-        logPrefix,
+        tracker ->
+            tracker.onError(
+                request, error, latencyNanos, executionProfile, node, sessionRequestLogPrefix),
+        sessionRequestLogPrefix,
         "onError");
   }
 
@@ -109,10 +113,12 @@ public class MultiplexingRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     invokeTrackers(
-        tracker -> tracker.onNodeSuccess(request, latencyNanos, executionProfile, node, logPrefix),
-        logPrefix,
+        tracker ->
+            tracker.onNodeSuccess(
+                request, latencyNanos, executionProfile, node, nodeRequestLogPrefix),
+        nodeRequestLogPrefix,
         "onNodeSuccess");
   }
 
@@ -123,11 +129,12 @@ public class MultiplexingRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     invokeTrackers(
         tracker ->
-            tracker.onNodeError(request, error, latencyNanos, executionProfile, node, logPrefix),
-        logPrefix,
+            tracker.onNodeError(
+                request, error, latencyNanos, executionProfile, node, nodeRequestLogPrefix),
+        nodeRequestLogPrefix,
         "onNodeError");
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/NoopRequestTracker.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/NoopRequestTracker.java
@@ -42,7 +42,7 @@ public class NoopRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
     // nothing to do
   }
 
@@ -53,7 +53,7 @@ public class NoopRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       Node node,
-      @NonNull String requestPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
     // nothing to do
   }
 
@@ -64,7 +64,7 @@ public class NoopRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     // nothing to do
   }
 
@@ -74,7 +74,7 @@ public class NoopRequestTracker implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String requestPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     // nothing to do
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/RequestLogger.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/RequestLogger.java
@@ -86,7 +86,7 @@ public class RequestLogger implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
 
     boolean successEnabled =
         executionProfile.getBoolean(DefaultDriverOption.REQUEST_LOGGER_SUCCESS_ENABLED, false);
@@ -129,7 +129,7 @@ public class RequestLogger implements RequestTracker {
         showValues,
         maxValues,
         maxValueLength,
-        logPrefix);
+        sessionRequestLogPrefix);
   }
 
   @Override
@@ -139,7 +139,7 @@ public class RequestLogger implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       Node node,
-      @NonNull String logPrefix) {
+      @NonNull String sessionRequestLogPrefix) {
 
     if (!executionProfile.getBoolean(DefaultDriverOption.REQUEST_LOGGER_ERROR_ENABLED, false)) {
       return;
@@ -173,7 +173,7 @@ public class RequestLogger implements RequestTracker {
         maxValues,
         maxValueLength,
         showStackTraces,
-        logPrefix);
+        sessionRequestLogPrefix);
   }
 
   @Override
@@ -183,7 +183,7 @@ public class RequestLogger implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     // Nothing to do
   }
 
@@ -193,7 +193,7 @@ public class RequestLogger implements RequestTracker {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     // Nothing to do
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/UuidRequestIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/UuidRequestIdGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.tracker;
+
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class UuidRequestIdGenerator implements RequestIdGenerator {
+  public UuidRequestIdGenerator(DriverContext context) {}
+
+  /** Generates a random v4 UUID. */
+  @Override
+  public String getSessionRequestId() {
+    return Uuids.random().toString();
+  }
+
+  /**
+   * {session-request-id}-{random-uuid} All node requests for a session request will have the same
+   * session request id
+   */
+  @Override
+  public String getNodeRequestId(@NonNull Request statement, @NonNull String parentId) {
+    return parentId + "-" + Uuids.random();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/W3CContextRequestIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/tracker/W3CContextRequestIdGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.tracker;
+
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
+import com.datastax.oss.driver.shaded.guava.common.io.BaseEncoding;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.SecureRandom;
+import java.util.Random;
+
+public class W3CContextRequestIdGenerator implements RequestIdGenerator {
+
+  private final Random random = new SecureRandom();
+  private final BaseEncoding baseEncoding = BaseEncoding.base16().lowerCase();
+  private final String payloadKey;
+
+  public W3CContextRequestIdGenerator(DriverContext context) {
+    payloadKey = RequestIdGenerator.super.getCustomPayloadKey();
+  }
+
+  public W3CContextRequestIdGenerator(String payloadKey) {
+    this.payloadKey = payloadKey;
+  }
+
+  /** Random 16 bytes, e.g. "4bf92f3577b34da6a3ce929d0e0e4736" */
+  @Override
+  public String getSessionRequestId() {
+    byte[] bytes = new byte[16];
+    random.nextBytes(bytes);
+    return baseEncoding.encode(bytes);
+  }
+
+  /**
+   * Following the format of W3C "traceparent" spec,
+   * https://www.w3.org/TR/trace-context/#traceparent-header-field-values e.g.
+   * "00-4bf92f3577b34da6a3ce929d0e0e4736-a3ce929d0e0e4736-01" All node requests in the same session
+   * request share the same "trace-id" field value
+   */
+  @Override
+  public String getNodeRequestId(@NonNull Request statement, @NonNull String parentId) {
+    byte[] bytes = new byte[8];
+    random.nextBytes(bytes);
+    return String.format("00-%s-%s-00", parentId, baseEncoding.encode(bytes));
+  }
+
+  @Override
+  public String getCustomPayloadKey() {
+    return this.payloadKey;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
@@ -159,7 +159,10 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
 
     @Override
     public int hashCode() {
-      return Objects.hash(cqlType, javaType, isJavaCovariant);
+      // NOTE: inlined Objects.hash for performance reasons (avoid Object[] allocation
+      // seen in profiler allocation traces)
+      return ((31 + Objects.hashCode(cqlType)) * 31 + Objects.hashCode(javaType)) * 31
+              + Boolean.hashCode(isJavaCovariant);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
@@ -162,7 +162,7 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
       // NOTE: inlined Objects.hash for performance reasons (avoid Object[] allocation
       // seen in profiler allocation traces)
       return ((31 + Objects.hashCode(cqlType)) * 31 + Objects.hashCode(javaType)) * 31
-              + Boolean.hashCode(isJavaCovariant);
+          + Boolean.hashCode(isJavaCovariant);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/AddressUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/AddressUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AddressUtils {
+
+  public static Set<InetSocketAddress> extract(String address, boolean resolve) {
+    int separator = address.lastIndexOf(':');
+    if (separator < 0) {
+      throw new IllegalArgumentException("expecting format host:port");
+    }
+
+    String host = address.substring(0, separator);
+    String portString = address.substring(separator + 1);
+    int port;
+    try {
+      port = Integer.parseInt(portString);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("expecting port to be a number, got " + portString, e);
+    }
+    if (!resolve) {
+      return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
+    } else {
+      InetAddress[] inetAddresses;
+      try {
+        inetAddresses = InetAddress.getAllByName(host);
+      } catch (UnknownHostException e) {
+        throw new RuntimeException(e);
+      }
+      Set<InetSocketAddress> result = new HashSet<>();
+      for (InetAddress inetAddress : inetAddresses) {
+        result.add(new InetSocketAddress(inetAddress, port));
+      }
+      return result;
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.internal.core.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ArrayUtils {
@@ -77,7 +78,7 @@ public class ArrayUtils {
    *     Fisher-Yates shuffle</a>
    */
   public static <ElementT> void shuffleHead(
-      @NonNull ElementT[] elements, int n, @NonNull ThreadLocalRandom random) {
+      @NonNull ElementT[] elements, int n, @NonNull Random random) {
     if (n > elements.length) {
       throw new ArrayIndexOutOfBoundsException(
           String.format(

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1097,8 +1097,9 @@ datastax-java-driver {
     # the package com.datastax.oss.driver.internal.core.addresstranslation.
     #
     # The driver provides the following implementations out of the box:
-    # - PassThroughAddressTranslator: returns all addresses unchanged
+    # - PassThroughAddressTranslator: returns all addresses unchanged.
     # - FixedHostNameAddressTranslator: translates all addresses to a specific hostname.
+    # - SubnetAddressTranslator: translates addresses to hostname based on the subnet match.
     # - Ec2MultiRegionAddressTranslator: suitable for an Amazon multi-region EC2 deployment where
     #   clients are also deployed in EC2. It optimizes network costs by favoring private IPs over
     #   public ones whenever possible.
@@ -1106,8 +1107,23 @@ datastax-java-driver {
     # You can also specify a custom class that implements AddressTranslator and has a public
     # constructor with a DriverContext argument.
     class = PassThroughAddressTranslator
+    #
     # This property has to be set only in case you use FixedHostNameAddressTranslator.
     # advertised-hostname = mycustomhostname
+    #
+    # These properties are only applicable in case you use SubnetAddressTranslator.
+    # subnet-addresses {
+    #   "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+    #   "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+    #   # IPv6 example:
+    #   # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+    #   # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+    # }
+    # Optional. When configured, addresses not matching the configured subnets are translated to this address.
+    # default-address = "cassandra.datacenter1.com:9042"
+    # Whether to resolve the addresses once on initialization (if true) or on each node (re-)connection (if false).
+    # If not configured, defaults to false.
+    # resolve-addresses = false
   }
 
   # Whether to resolve the addresses passed to `basic.contact-points`.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -989,6 +989,13 @@ datastax-java-driver {
     }
   }
 
+  advanced.request-id {
+    generator {
+      # The component that generates a unique identifier for each CQL request, and possibly write the id to the custom payload  .
+      // class = W3CContextRequestIdGenerator
+    }
+  }
+
   # A session-wide component that controls the rate at which requests are executed.
   #
   # Implementations vary, but throttlers generally track a metric that represents the level of

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -866,6 +866,12 @@ datastax-java-driver {
     # name matches the hostname of the server being connected to. If not set, defaults to true.
     // hostname-validation = true
 
+    # Whether or not to allow a DNS reverse-lookup of provided server addresses for SAN addresses,
+    # if cluster endpoints are specified as literal IPs.
+    # This is left as true for compatibility, but in most environments a DNS reverse-lookup should
+    # not be necessary to get an address that matches the server certificate SANs.
+    // allow-dns-reverse-lookup-san = true
+
     # The locations and passwords used to access truststore and keystore contents.
     # These properties are optional. If either truststore-path or keystore-path are specified,
     # the driver builds an SSLContext from these files.  If neither option is specified, the

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
@@ -121,7 +121,7 @@ public class ContactPointsTest {
         ContactPoints.merge(Collections.emptySet(), ImmutableList.of("foobar"), true);
 
     assertThat(endPoints).isEmpty();
-    assertLog(Level.WARN, "Ignoring invalid contact point foobar (expecting host:port)");
+    assertLog(Level.WARN, "Ignoring invalid contact point foobar (expecting format host:port)");
   }
 
   @Test
@@ -132,7 +132,7 @@ public class ContactPointsTest {
     assertThat(endPoints).isEmpty();
     assertLog(
         Level.WARN,
-        "Ignoring invalid contact point 127.0.0.1:foobar (expecting a number, got foobar)");
+        "Ignoring invalid contact point 127.0.0.1:foobar (expecting port to be a number, got foobar)");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
@@ -17,6 +17,7 @@
  */
 package com.datastax.oss.driver.internal.core.addresstranslation;
 
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,9 +34,7 @@ public class FixedHostNameAddressTranslatorTest {
   @Test
   public void should_translate_address() {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
-    when(defaultProfile.getString(
-            FixedHostNameAddressTranslator.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION))
-        .thenReturn("myaddress");
+    when(defaultProfile.getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME)).thenReturn("myaddress");
     DefaultDriverContext defaultDriverContext =
         MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
@@ -26,7 +26,6 @@ import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.context.MockedDriverContextFactory;
 import java.net.InetSocketAddress;
-import java.util.Optional;
 import org.junit.Test;
 
 public class FixedHostNameAddressTranslatorTest {
@@ -36,7 +35,7 @@ public class FixedHostNameAddressTranslatorTest {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
     when(defaultProfile.getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME)).thenReturn("myaddress");
     DefaultDriverContext defaultDriverContext =
-        MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
+        MockedDriverContextFactory.defaultDriverContext(defaultProfile);
 
     FixedHostNameAddressTranslator translator =
         new FixedHostNameAddressTranslator(defaultDriverContext);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class SubnetAddressTest {
+  @Test
+  public void should_return_return_true_on_overlapping_with_another_subnet_address() {
+    SubnetAddress subnetAddress1 =
+        new SubnetAddress("100.64.0.0/15", mock(InetSocketAddress.class));
+    SubnetAddress subnetAddress2 =
+        new SubnetAddress("100.65.0.0/16", mock(InetSocketAddress.class));
+    assertThat(subnetAddress1.isOverlapping(subnetAddress2)).isTrue();
+  }
+
+  @Test
+  public void should_return_return_false_on_not_overlapping_with_another_subnet_address() {
+    SubnetAddress subnetAddress1 =
+        new SubnetAddress("100.64.0.0/15", mock(InetSocketAddress.class));
+    SubnetAddress subnetAddress2 =
+        new SubnetAddress("100.66.0.0/15", mock(InetSocketAddress.class));
+    assertThat(subnetAddress1.isOverlapping(subnetAddress2)).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.context.MockedDriverContextFactory;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+
+@SuppressWarnings("resource")
+public class SubnetAddressTranslatorTest {
+
+  @Test
+  public void should_translate_to_correct_subnet_address_ipv4() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"100.64.0.0/15\"", "cassandra.datacenter1.com:19042",
+            "100.66.0.\"0/15\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.64.0.1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042));
+  }
+
+  @Test
+  public void should_translate_to_correct_subnet_address_ipv6() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"::ffff:6440:0/111\"", "cassandra.datacenter1.com:19042",
+            "\"::ffff:6442:0/111\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("::ffff:6440:1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042));
+  }
+
+  @Test
+  public void should_translate_to_default_address() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    when(context
+            .getConfig()
+            .getDefaultProfile()
+            .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+        .thenReturn("cassandra.com:19042");
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.68.0.1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.com", 19042));
+  }
+
+  @Test
+  public void should_pass_through_not_matched_address() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.68.0.1", 9042);
+    assertThat(translator.translate(address)).isEqualTo(address);
+  }
+
+  @Test
+  public void should_fail_on_intersecting_subnets_ipv4() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"100.64.0.0/15\"", "cassandra.datacenter1.com:19042",
+            "100.65.0.\"0/16\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage(
+            "Configured subnets are overlapping: "
+                + String.format(
+                    "SubnetAddress[subnet=[100, 64, 0, 0], address=%s], ",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042))
+                + String.format(
+                    "SubnetAddress[subnet=[100, 65, 0, 0], address=%s]",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter2.com", 19042)));
+  }
+
+  @Test
+  public void should_fail_on_intersecting_subnets_ipv6() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"::ffff:6440:0/111\"", "cassandra.datacenter1.com:19042",
+            "\"::ffff:6441:0/112\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage(
+            "Configured subnets are overlapping: "
+                + String.format(
+                    "SubnetAddress[subnet=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0], address=%s], ",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042))
+                + String.format(
+                    "SubnetAddress[subnet=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 65, 0, 0], address=%s]",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter2.com", 19042)));
+  }
+
+  @Test
+  public void should_fail_on_subnet_address_without_port() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of("\"100.64.0.0/15\"", "cassandra.datacenter1.com");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage("Invalid address cassandra.datacenter1.com (expecting format host:port)");
+  }
+
+  @Test
+  public void should_fail_on_default_address_without_port() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    when(context
+            .getConfig()
+            .getDefaultProfile()
+            .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+        .thenReturn("cassandra.com");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage("Invalid address cassandra.com (expecting format host:port)");
+  }
+
+  private static DefaultDriverContext context(Map<String, String> subnetAddresses) {
+    DriverExecutionProfile profile = mock(DriverExecutionProfile.class);
+    when(profile.getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)).thenReturn(subnetAddresses);
+    return MockedDriverContextFactory.defaultDriverContext(Optional.of(profile));
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
@@ -30,7 +30,6 @@ import com.datastax.oss.driver.internal.core.context.MockedDriverContextFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.Test;
 
 @SuppressWarnings("resource")
@@ -148,6 +147,6 @@ public class SubnetAddressTranslatorTest {
   private static DefaultDriverContext context(Map<String, String> subnetAddresses) {
     DriverExecutionProfile profile = mock(DriverExecutionProfile.class);
     when(profile.getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)).thenReturn(subnetAddresses);
-    return MockedDriverContextFactory.defaultDriverContext(Optional.of(profile));
+    return MockedDriverContextFactory.defaultDriverContext(profile);
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.net.UnknownHostException;
+import org.junit.Test;
+
+public class SubnetTest {
+  @Test
+  public void should_parse_to_correct_ipv4_subnet() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.getSubnet()).containsExactly(100, 64, 0, 0);
+    assertThat(subnet.getNetworkMask()).containsExactly(255, 254, 0, 0);
+    assertThat(subnet.getUpper()).containsExactly(100, 65, 255, 255);
+    assertThat(subnet.getLower()).containsExactly(100, 64, 0, 0);
+  }
+
+  @Test
+  public void should_parse_to_correct_ipv6_subnet() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("2001:db8:85a3::8a2e:370:0/111");
+    assertThat(subnet.getSubnet())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 0, 0);
+    assertThat(subnet.getNetworkMask())
+        .containsExactly(
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 0, 0);
+    assertThat(subnet.getUpper())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 113, 255, 255);
+    assertThat(subnet.getLower())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 0, 0);
+  }
+
+  @Test
+  public void should_parse_to_correct_ipv6_subnet_ipv4_convertible() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("::ffff:6440:0/111");
+    assertThat(subnet.getSubnet())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0);
+    assertThat(subnet.getNetworkMask())
+        .containsExactly(
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 0, 0);
+    assertThat(subnet.getUpper())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 65, 255, 255);
+    assertThat(subnet.getLower())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0);
+  }
+
+  @Test
+  public void should_fail_on_invalid_cidr_format() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("invalid"))
+        .withMessage("Invalid subnet: invalid");
+  }
+
+  @Test
+  public void should_parse_bounding_prefix_lengths_correctly() {
+    assertThatNoException().isThrownBy(() -> Subnet.parse("0.0.0.0/0"));
+    assertThatNoException().isThrownBy(() -> Subnet.parse("100.64.0.0/32"));
+  }
+
+  @Test
+  public void should_fail_on_invalid_prefix_length() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.64.0.0/-1"))
+        .withMessage("Prefix length -1 must be within [0; 32]");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.64.0.0/33"))
+        .withMessage("Prefix length 33 must be within [0; 32]");
+  }
+
+  @Test
+  public void should_fail_on_not_prefix_block_subnet_ipv4() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.65.0.0/15"))
+        .withMessage("Subnet 100.65.0.0/15 must be represented as a network prefix block");
+  }
+
+  @Test
+  public void should_fail_on_not_prefix_block_subnet_ipv6() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("::ffff:6441:0/111"))
+        .withMessage("Subnet ::ffff:6441:0/111 must be represented as a network prefix block");
+  }
+
+  @Test
+  public void should_return_true_on_containing_address() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.contains(new byte[] {100, 64, 0, 0})).isTrue();
+    assertThat(subnet.contains(new byte[] {100, 65, (byte) 255, (byte) 255})).isTrue();
+    assertThat(subnet.contains(new byte[] {100, 65, 100, 100})).isTrue();
+  }
+
+  @Test
+  public void should_return_false_on_not_containing_address() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.contains(new byte[] {100, 63, (byte) 255, (byte) 255})).isFalse();
+    assertThat(subnet.contains(new byte[] {100, 66, 0, 0})).isFalse();
+    // IPv6 cannot be contained by IPv4 subnet.
+    assertThat(subnet.contains(new byte[16])).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
@@ -24,6 +24,7 @@ public enum MockOptions implements DriverOption {
   INT1("int1"),
   INT2("int2"),
   AUTH_PROVIDER("auth_provider"),
+  SUBNET_ADDRESSES("subnet_addresses"),
   ;
 
   private final String path;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
@@ -101,12 +101,24 @@ public class TypesafeDriverConfigTest {
         parse(
             "int1 = 42 \n auth_provider { auth_thing_one= one \n auth_thing_two = two \n auth_thing_three = three}");
     DriverExecutionProfile base = config.getDefaultProfile();
-    base.getStringMap(MockOptions.AUTH_PROVIDER);
     Map<String, String> map = base.getStringMap(MockOptions.AUTH_PROVIDER);
     assertThat(map.entrySet().size()).isEqualTo(3);
     assertThat(map.get("auth_thing_one")).isEqualTo("one");
     assertThat(map.get("auth_thing_two")).isEqualTo("two");
     assertThat(map.get("auth_thing_three")).isEqualTo("three");
+  }
+
+  @Test
+  public void should_fetch_string_map_with_forward_slash_in_keys() {
+    TypesafeDriverConfig config =
+        parse(
+            "subnet_addresses { 100.64.0.0/15 = \"cassandra.datacenter1.com:9042\" \n \"100.66.0.0/15\" = \"cassandra.datacenter2.com\" \n \"::ffff:6440:0/111\" = \"cassandra.datacenter3.com:19042\" }");
+    DriverExecutionProfile base = config.getDefaultProfile();
+    Map<String, String> map = base.getStringMap(MockOptions.SUBNET_ADDRESSES);
+    assertThat(map.entrySet().size()).isEqualTo(3);
+    assertThat(map.get("100.64.0.\"0/15\"")).isEqualTo("cassandra.datacenter1.com:9042");
+    assertThat(map.get("\"100.66.0.0/15\"")).isEqualTo("cassandra.datacenter2.com");
+    assertThat(map.get("\"::ffff:6440:0/111\"")).isEqualTo("cassandra.datacenter3.com:19042");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContextTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContextTest.java
@@ -42,7 +42,7 @@ public class DefaultDriverContextTest {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
     when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
         .thenReturn(compressionOption.orElse("none"));
-    return MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
+    return MockedDriverContextFactory.defaultDriverContext(defaultProfile);
   }
 
   private void doCreateCompressorTest(Optional<String> configVal, Class<?> expectedClz) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
@@ -119,6 +119,9 @@ public class MockedDriverContextFactory {
         .thenReturn("DefaultMetricsFactory");
     when(defaultProfile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
         .thenReturn(localDc);
+    when(defaultProfile.getString(
+            DefaultDriverOption.LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD))
+        .thenReturn("REGULAR");
     return defaultProfile;
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
@@ -24,44 +24,45 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
+import com.datastax.oss.driver.api.core.loadbalancing.NodeDistanceEvaluator;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
+import com.datastax.oss.driver.internal.core.ConsistencyLevelRegistry;
+import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public class MockedDriverContextFactory {
 
   public static DefaultDriverContext defaultDriverContext() {
-    return defaultDriverContext(Optional.empty());
+    return defaultDriverContext(MockedDriverContextFactory.defaultProfile("datacenter1"));
   }
 
   public static DefaultDriverContext defaultDriverContext(
-      Optional<DriverExecutionProfile> profileOption) {
-
-    /* If the caller provided a profile use that, otherwise make a new one */
-    final DriverExecutionProfile profile =
-        profileOption.orElseGet(
-            () -> {
-              DriverExecutionProfile blankProfile = mock(DriverExecutionProfile.class);
-              when(blankProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
-                  .thenReturn("none");
-              when(blankProfile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
-                  .thenReturn(Duration.ofMinutes(5));
-              when(blankProfile.isDefined(DefaultDriverOption.METRICS_FACTORY_CLASS))
-                  .thenReturn(true);
-              when(blankProfile.getString(DefaultDriverOption.METRICS_FACTORY_CLASS))
-                  .thenReturn("DefaultMetricsFactory");
-              return blankProfile;
-            });
+      DriverExecutionProfile defaultProfile, DriverExecutionProfile... profiles) {
 
     /* Setup machinery to connect the input DriverExecutionProfile to the config loader */
     final DriverConfig driverConfig = mock(DriverConfig.class);
     final DriverConfigLoader configLoader = mock(DriverConfigLoader.class);
     when(configLoader.getInitialConfig()).thenReturn(driverConfig);
-    when(driverConfig.getDefaultProfile()).thenReturn(profile);
+    when(driverConfig.getDefaultProfile()).thenReturn(defaultProfile);
+    when(driverConfig.getProfile(defaultProfile.getName())).thenReturn(defaultProfile);
+
+    for (DriverExecutionProfile profile : profiles) {
+      when(driverConfig.getProfile(profile.getName())).thenReturn(profile);
+    }
 
     ProgrammaticArguments args =
         ProgrammaticArguments.builder()
@@ -71,6 +72,89 @@ public class MockedDriverContextFactory {
             .withLocalDatacenters(Maps.newHashMap())
             .withNodeDistanceEvaluators(Maps.newHashMap())
             .build();
-    return new DefaultDriverContext(configLoader, args);
+
+    return new DefaultDriverContext(configLoader, args) {
+      @NonNull
+      @Override
+      public Map<String, LoadBalancingPolicy> getLoadBalancingPolicies() {
+        ImmutableMap.Builder<String, LoadBalancingPolicy> map = ImmutableMap.builder();
+        map.put(
+            defaultProfile.getName(),
+            mockLoadBalancingPolicy(
+                this,
+                defaultProfile.getName(),
+                defaultProfile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)));
+        for (DriverExecutionProfile profile : profiles) {
+          map.put(
+              profile.getName(),
+              mockLoadBalancingPolicy(
+                  this,
+                  profile.getName(),
+                  profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)));
+        }
+        return map.build();
+      }
+
+      @NonNull
+      @Override
+      public ConsistencyLevelRegistry getConsistencyLevelRegistry() {
+        return mock(ConsistencyLevelRegistry.class);
+      }
+    };
+  }
+
+  public static DriverExecutionProfile defaultProfile(String localDc) {
+    return createProfile(DriverExecutionProfile.DEFAULT_NAME, localDc);
+  }
+
+  public static DriverExecutionProfile createProfile(String name, String localDc) {
+    DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
+    when(defaultProfile.getName()).thenReturn(name);
+    when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
+        .thenReturn("none");
+    when(defaultProfile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
+        .thenReturn(Duration.ofMinutes(5));
+    when(defaultProfile.isDefined(DefaultDriverOption.METRICS_FACTORY_CLASS)).thenReturn(true);
+    when(defaultProfile.getString(DefaultDriverOption.METRICS_FACTORY_CLASS))
+        .thenReturn("DefaultMetricsFactory");
+    when(defaultProfile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(localDc);
+    return defaultProfile;
+  }
+
+  public static void allowRemoteDcConnectivity(
+      DriverExecutionProfile profile,
+      int maxNodesPerRemoteDc,
+      boolean allowRemoteSatisfyLocalDc,
+      List<String> preferredRemoteDcs) {
+    when(profile.getInt(DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC))
+        .thenReturn(maxNodesPerRemoteDc);
+    when(profile.getBoolean(
+            DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS))
+        .thenReturn(allowRemoteSatisfyLocalDc);
+    when(profile.getStringList(DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_PREFERRED_REMOTE_DCS))
+        .thenReturn(preferredRemoteDcs);
+  }
+
+  private static LoadBalancingPolicy mockLoadBalancingPolicy(
+      DefaultDriverContext driverContext, String profile, String localDc) {
+    LoadBalancingPolicy loadBalancingPolicy =
+        new DefaultLoadBalancingPolicy(driverContext, profile) {
+          @NonNull
+          @Override
+          protected Optional<String> discoverLocalDc(@NonNull Map<UUID, Node> nodes) {
+            return Optional.ofNullable(localDc);
+          }
+
+          @NonNull
+          @Override
+          protected NodeDistanceEvaluator createNodeDistanceEvaluator(
+              @Nullable String localDc, @NonNull Map<UUID, Node> nodes) {
+            return mock(NodeDistanceEvaluator.class);
+          }
+        };
+    loadBalancingPolicy.init(
+        Collections.emptyMap(), mock(LoadBalancingPolicy.DistanceReporter.class));
+    return loadBalancingPolicy;
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilderTest.java
@@ -26,10 +26,10 @@ import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.request.Startup;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,7 +41,8 @@ public class StartupOptionsBuilderTest {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
     when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
         .thenReturn(compression);
-    return MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
+    when(defaultProfile.getName()).thenReturn(DriverExecutionProfile.DEFAULT_NAME);
+    return MockedDriverContextFactory.defaultDriverContext(defaultProfile);
   }
 
   private void assertDefaultStartupOptions(Startup startup) {
@@ -93,5 +94,45 @@ public class StartupOptionsBuilderTest {
               DefaultDriverContext ctx = buildMockedContext("foobar");
               new Startup(ctx.getStartupOptions());
             });
+  }
+
+  @Test
+  public void should_include_all_local_dcs_in_startup_message() {
+
+    DefaultDriverContext ctx =
+        MockedDriverContextFactory.defaultDriverContext(
+            MockedDriverContextFactory.defaultProfile("us-west-2"),
+            MockedDriverContextFactory.createProfile("oltp", "us-east-2"),
+            MockedDriverContextFactory.createProfile("olap", "eu-central-1"));
+    Startup startup = new Startup(ctx.getStartupOptions());
+    assertThat(startup.options)
+        .containsEntry(
+            StartupOptionsBuilder.DRIVER_BAGGAGE,
+            "{\"default\":{\"DefaultLoadBalancingPolicy\":{\"localDc\":\"us-west-2\"}},"
+                + "\"oltp\":{\"DefaultLoadBalancingPolicy\":{\"localDc\":\"us-east-2\"}},"
+                + "\"olap\":{\"DefaultLoadBalancingPolicy\":{\"localDc\":\"eu-central-1\"}}}");
+  }
+
+  @Test
+  public void should_include_all_lbp_details_in_startup_message() {
+
+    DriverExecutionProfile defaultProfile = MockedDriverContextFactory.defaultProfile("dc1");
+    DriverExecutionProfile oltpProfile = MockedDriverContextFactory.createProfile("oltp", "dc1");
+    MockedDriverContextFactory.allowRemoteDcConnectivity(
+        oltpProfile, 2, true, ImmutableList.of("dc2", "dc3"));
+    DefaultDriverContext ctx =
+        MockedDriverContextFactory.defaultDriverContext(defaultProfile, oltpProfile);
+
+    Startup startup = new Startup(ctx.getStartupOptions());
+
+    assertThat(startup.options)
+        .containsEntry(
+            StartupOptionsBuilder.DRIVER_BAGGAGE,
+            "{\"default\":{\"DefaultLoadBalancingPolicy\":{\"localDc\":\"dc1\"}},"
+                + "\"oltp\":{\"DefaultLoadBalancingPolicy\":{"
+                + "\"localDc\":\"dc1\","
+                + "\"preferredRemoteDcs\":[\"dc2\",\"dc3\"],"
+                + "\"allowDcFailoverForLocalCl\":true,"
+                + "\"maxNodesPerRemoteDc\":2}}}");
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/StartupOptionsBuilderTest.java
@@ -42,6 +42,9 @@ public class StartupOptionsBuilderTest {
     when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
         .thenReturn(compression);
     when(defaultProfile.getName()).thenReturn(DriverExecutionProfile.DEFAULT_NAME);
+    when(defaultProfile.getString(
+            DefaultDriverOption.LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD))
+        .thenReturn("REGULAR");
     return MockedDriverContextFactory.defaultDriverContext(defaultProfile);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
@@ -79,7 +79,7 @@ public class QueryTraceFetcherTest {
   @Mock private NettyOptions nettyOptions;
   @Mock private EventExecutorGroup adminEventExecutorGroup;
   @Mock private EventExecutor eventExecutor;
-  @Mock private InetAddress address;
+  private InetAddress address = InetAddress.getLoopbackAddress();
 
   @Captor private ArgumentCaptor<SimpleStatement> statementCaptor;
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -194,6 +195,8 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     when(context.getRequestThrottler()).thenReturn(new PassThroughRequestThrottler(context));
 
     when(context.getRequestTracker()).thenReturn(new NoopRequestTracker(context));
+
+    when(context.getRequestIdGenerator()).thenReturn(Optional.empty());
   }
 
   public DefaultSession getSession() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/tracker/RequestIdGeneratorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/tracker/RequestIdGeneratorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.tracker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Strict.class)
+public class RequestIdGeneratorTest {
+  @Mock private InternalDriverContext context;
+  @Mock private Statement<?> statement;
+
+  @Test
+  public void uuid_generator_should_generate() {
+    // given
+    UuidRequestIdGenerator generator = new UuidRequestIdGenerator(context);
+    // when
+    String parentId = generator.getSessionRequestId();
+    String requestId = generator.getNodeRequestId(statement, parentId);
+    // then
+    // e.g. "550e8400-e29b-41d4-a716-446655440000", which is 36 characters long
+    assertThat(parentId.length()).isEqualTo(36);
+    // e.g. "550e8400-e29b-41d4-a716-446655440000-550e8400-e29b-41d4-a716-446655440000", which is 73
+    // characters long
+    assertThat(requestId.length()).isEqualTo(73);
+  }
+
+  @Test
+  public void w3c_generator_should_generate() {
+    // given
+    W3CContextRequestIdGenerator generator = new W3CContextRequestIdGenerator(context);
+    // when
+    String parentId = generator.getSessionRequestId();
+    String requestId = generator.getNodeRequestId(statement, parentId);
+    // then
+    // e.g. "4bf92f3577b34da6a3ce929d0e0e4736", which is 32 characters long
+    assertThat(parentId.length()).isEqualTo(32);
+    // According to W3C "traceparent" spec,
+    // https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+    // e.g. "00-4bf92f3577b34da6a3ce929d0e0e4736-a3ce929d0e0e4736-01", which 55 characters long
+    assertThat(requestId.length()).isEqualTo(55);
+  }
+
+  @Test
+  public void w3c_generator_default_payloadkey() {
+    W3CContextRequestIdGenerator w3cGenerator = new W3CContextRequestIdGenerator(context);
+    assertThat(w3cGenerator.getCustomPayloadKey())
+        .isEqualTo(RequestIdGenerator.DEFAULT_PAYLOAD_KEY);
+  }
+
+  @Test
+  public void w3c_generator_provided_payloadkey() {
+    String someString = RandomStringUtils.random(12);
+    W3CContextRequestIdGenerator w3cGenerator = new W3CContextRequestIdGenerator(someString);
+    assertThat(w3cGenerator.getCustomPayloadKey()).isEqualTo(someString);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ArrayUtilsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ArrayUtilsTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 import org.junit.Test;
 
 public class ArrayUtilsTest {
@@ -86,7 +86,7 @@ public class ArrayUtilsTest {
   @Test
   public void should_shuffle_head() {
     String[] array = {"a", "b", "c", "d", "e"};
-    ThreadLocalRandom random = mock(ThreadLocalRandom.class);
+    Random random = mock(Random.class);
     when(random.nextInt(anyInt()))
         .thenAnswer(
             (invocation) -> {

--- a/guava-shaded/pom.xml
+++ b/guava-shaded/pom.xml
@@ -46,6 +46,7 @@
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>
       </exclusions>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.graalvm.nativeimage</groupId>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
@@ -27,10 +27,13 @@ import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.assertions.Assertions;
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory;
+import java.net.InetSocketAddress;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -92,6 +95,69 @@ public class DefaultSslEngineFactoryIT {
   public void should_not_connect_if_not_using_ssl() {
     try (CqlSession session = SessionUtils.newSession(CCM_RULE)) {
       session.execute("select * from system.local where key='local'");
+    }
+  }
+
+  public static class InstrumentedSslEngineFactory extends DefaultSslEngineFactory {
+    int countReverseLookups = 0;
+    int countNoLookups = 0;
+
+    public InstrumentedSslEngineFactory(DriverContext driverContext) {
+      super(driverContext);
+    }
+
+    @Override
+    protected String hostMaybeFromDnsReverseLookup(InetSocketAddress addr) {
+      countReverseLookups++;
+      return super.hostMaybeFromDnsReverseLookup(addr);
+    }
+
+    @Override
+    protected String hostNoLookup(InetSocketAddress addr) {
+      countNoLookups++;
+      return super.hostNoLookup(addr);
+    }
+  };
+
+  @Test
+  public void should_respect_config_for_san_resolution() {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withClass(
+                DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, InstrumentedSslEngineFactory.class)
+            .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
+            .withString(
+                DefaultDriverOption.SSL_TRUSTSTORE_PATH,
+                CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath())
+            .withString(
+                DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD,
+                CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
+            .build();
+    try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
+      InstrumentedSslEngineFactory ssl =
+          (InstrumentedSslEngineFactory) session.getContext().getSslEngineFactory().get();
+      Assertions.assertThat(ssl.countReverseLookups).isGreaterThan(0);
+      Assertions.assertThat(ssl.countNoLookups).isEqualTo(0);
+    }
+
+    loader =
+        SessionUtils.configLoaderBuilder()
+            .withClass(
+                DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, InstrumentedSslEngineFactory.class)
+            .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false)
+            .withString(
+                DefaultDriverOption.SSL_TRUSTSTORE_PATH,
+                CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath())
+            .withString(
+                DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD,
+                CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD)
+            .withBoolean(DefaultDriverOption.SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN, false)
+            .build();
+    try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
+      InstrumentedSslEngineFactory ssl =
+          (InstrumentedSslEngineFactory) session.getContext().getSslEngineFactory().get();
+      Assertions.assertThat(ssl.countReverseLookups).isEqualTo(0);
+      Assertions.assertThat(ssl.countNoLookups).isGreaterThan(0);
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestIdGeneratorIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestIdGeneratorIT.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
+import com.datastax.oss.driver.api.testinfra.ScyllaSkip;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -41,6 +42,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
+@ScyllaSkip(description = "Scylla does not support custom payload in requests")
 public class RequestIdGeneratorIT {
   private CcmRule ccmRule = CcmRule.getInstance();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestIdGeneratorIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestIdGeneratorIT.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.tracker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class RequestIdGeneratorIT {
+  private CcmRule ccmRule = CcmRule.getInstance();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule);
+
+  @Test
+  public void should_write_uuid_to_custom_payload_with_key() {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(DefaultDriverOption.REQUEST_ID_GENERATOR_CLASS, "UuidRequestIdGenerator")
+            .build();
+    try (CqlSession session = SessionUtils.newSession(ccmRule, loader)) {
+      String query = "SELECT * FROM system.local";
+      ResultSet rs = session.execute(query);
+      ByteBuffer id = rs.getExecutionInfo().getRequest().getCustomPayload().get("request-id");
+      assertThat(id.remaining()).isEqualTo(73);
+    }
+  }
+
+  @Test
+  public void should_write_default_request_id_to_custom_payload_with_key() {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(
+                DefaultDriverOption.REQUEST_ID_GENERATOR_CLASS, "W3CContextRequestIdGenerator")
+            .build();
+    try (CqlSession session = SessionUtils.newSession(ccmRule, loader)) {
+      String query = "SELECT * FROM system.local";
+      ResultSet rs = session.execute(query);
+      ByteBuffer id = rs.getExecutionInfo().getRequest().getCustomPayload().get("request-id");
+      assertThat(id.remaining()).isEqualTo(55);
+    }
+  }
+
+  @Test
+  public void should_use_customized_request_id_generator() {
+    RequestIdGenerator myRequestIdGenerator =
+        new RequestIdGenerator() {
+          @Override
+          public String getSessionRequestId() {
+            return "123";
+          }
+
+          @Override
+          public String getNodeRequestId(@NonNull Request statement, @NonNull String parentId) {
+            return "456";
+          }
+
+          @Override
+          public Statement<?> getDecoratedStatement(
+              @NonNull Statement<?> statement, @NonNull String requestId) {
+            Map<String, ByteBuffer> customPayload =
+                NullAllowingImmutableMap.<String, ByteBuffer>builder()
+                    .putAll(statement.getCustomPayload())
+                    .put("trace_key", ByteBuffer.wrap(requestId.getBytes(StandardCharsets.UTF_8)))
+                    .build();
+            return statement.setCustomPayload(customPayload);
+          }
+        };
+    try (CqlSession session =
+        (CqlSession)
+            SessionUtils.baseBuilder()
+                .addContactEndPoints(ccmRule.getContactPoints())
+                .withRequestIdGenerator(myRequestIdGenerator)
+                .build()) {
+      String query = "SELECT * FROM system.local";
+      ResultSet rs = session.execute(query);
+      ByteBuffer id = rs.getExecutionInfo().getRequest().getCustomPayload().get("trace_key");
+      assertThat(id).isEqualTo(ByteBuffer.wrap("456".getBytes(StandardCharsets.UTF_8)));
+    }
+  }
+
+  @Test
+  public void should_not_write_id_to_custom_payload_when_key_is_not_set() {
+    DriverConfigLoader loader = SessionUtils.configLoaderBuilder().build();
+    try (CqlSession session = SessionUtils.newSession(ccmRule, loader)) {
+      String query = "SELECT * FROM system.local";
+      ResultSet rs = session.execute(query);
+      assertThat(rs.getExecutionInfo().getRequest().getCustomPayload().get("trace_key")).isNull();
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestNodeLoggerExample.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestNodeLoggerExample.java
@@ -39,7 +39,7 @@ public class RequestNodeLoggerExample extends RequestLogger {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     if (!executionProfile.getBoolean(DefaultDriverOption.REQUEST_LOGGER_ERROR_ENABLED)) {
       return;
     }
@@ -66,7 +66,7 @@ public class RequestNodeLoggerExample extends RequestLogger {
         maxValues,
         maxValueLength,
         showStackTraces,
-        logPrefix);
+        nodeRequestLogPrefix);
   }
 
   @Override
@@ -75,7 +75,7 @@ public class RequestNodeLoggerExample extends RequestLogger {
       long latencyNanos,
       @NonNull DriverExecutionProfile executionProfile,
       @NonNull Node node,
-      @NonNull String logPrefix) {
+      @NonNull String nodeRequestLogPrefix) {
     boolean successEnabled =
         executionProfile.getBoolean(DefaultDriverOption.REQUEST_LOGGER_SUCCESS_ENABLED);
     boolean slowEnabled =
@@ -114,6 +114,6 @@ public class RequestNodeLoggerExample extends RequestLogger {
         showValues,
         maxValues,
         maxValueLength,
-        logPrefix);
+        nodeRequestLogPrefix);
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/RelationOptionsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/RelationOptionsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.querybuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class RelationOptionsIT {
+
+  private CcmRule ccmRule = CcmRule.getInstance();
+
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+
+  @Rule public TestName name = new TestName();
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "3.0",
+      description = "CRC check chance was moved to top level table in Cassandra 3.0")
+  public void should_create_table_with_crc_check_chance() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withCRCCheckChance(0.8)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("crc_check_chance = 0.8");
+  }
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "5.0",
+      description = "chunk_length_kb was renamed to chunk_length_in_kb in Cassandra 5.0")
+  public void should_create_table_with_chunk_length_in_kb() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withLZ4Compression(4096)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("'class':'org.apache.cassandra.io.compress.LZ4Compressor'");
+    assertThat(describeOutput).contains("'chunk_length_in_kb':'4096'");
+  }
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "3.0",
+      maxExclusive = "5.0",
+      description =
+          "Deprecated compression options should still work with Cassandra >= 3.0 & < 5.0")
+  public void should_create_table_with_deprecated_options() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withLZ4Compression(4096, 0.8)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("'class':'org.apache.cassandra.io.compress.LZ4Compressor'");
+    assertThat(describeOutput).contains("'chunk_length_in_kb':'4096'");
+    assertThat(describeOutput).contains("crc_check_chance = 0.8");
+  }
+}

--- a/manual/core/README.md
+++ b/manual/core/README.md
@@ -380,6 +380,7 @@ for (ColumnDefinitions.Definition definition : row.getColumnDefinitions()) {
    query_timestamps/*
    reactive/*
    reconnection/*
+   request_id/*
    request_tracker/*
    retries/*
    shaded_jar/*

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -118,6 +118,55 @@ datastax-java-driver.advanced.address-translator.class = com.mycompany.MyAddress
 Note: the contact points provided while creating the `CqlSession` are not translated, only addresses
 retrieved from or sent by Cassandra nodes are.
 
+### Fixed proxy hostname
+
+If your client applications access Cassandra through some kind of proxy (eg. with AWS PrivateLink when all Cassandra
+nodes are exposed via one hostname pointing to AWS Endpoint), you can configure driver with
+`FixedHostNameAddressTranslator` to always translate all node addresses to that same proxy hostname, no matter what IP
+address a node has but still using its native transport port.
+
+To use it, specify the following in the [configuration](../configuration):
+
+```
+datastax-java-driver.advanced.address-translator.class = FixedHostNameAddressTranslator
+advertised-hostname = proxyhostname
+```
+
+### Fixed proxy hostname per subnet
+
+When running Cassandra in a private network and accessing it from outside of that private network via some kind of
+proxy, we have an option to use `FixedHostNameAddressTranslator`. But for multi-datacenter Cassandra deployments, we
+want to have more control over routing queries to a specific datacenter (eg. for optimizing latencies), which requires
+setting up a separate proxy per datacenter.
+
+Normally, each Cassandra datacenter nodes are deployed to a different subnet to support internode communications in the
+cluster and avoid IP address collisions. So when Cassandra broadcasts its nodes IP addresses, we can determine which
+datacenter that node belongs to by checking its IP address against the given datacenter subnet.
+
+For such scenarios you can use `SubnetAddressTranslator` to translate node IPs to the datacenter proxy address
+associated with it. 
+
+To use it, specify the following in the [configuration](../configuration):
+```
+datastax-java-driver.advanced.address-translator {
+  class = SubnetAddressTranslator
+  subnet-addresses {
+    "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+    "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+    # IPv6 example:
+    # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+    # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+  }
+  # Optional. When configured, addresses not matching the configured subnets are translated to this address.
+  default-address = "cassandra.datacenter1.com:9042"
+  # Whether to resolve the addresses once on initialization (if true) or on each node (re-)connection (if false).
+  # If not configured, defaults to false.
+  resolve-addresses = false
+}
+```
+
+Such setup is common for running Cassandra on Kubernetes with [k8ssandra](https://docs.k8ssandra.io/).
+
 ### EC2 multi-region
 
 If you deploy both Cassandra and client applications on Amazon EC2, and your cluster spans multiple regions, you'll have

--- a/manual/core/non_blocking/README.md
+++ b/manual/core/non_blocking/README.md
@@ -152,15 +152,13 @@ should not be used if strict lock-freedom is enforced.
 
 [`SafeInitNodeStateListener`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListener.html
 
-The same is valid for both built-in [request throttlers]:
+The `RateLimitingRequestThrottler` is currently blocking. The `ConcurrencyLimitingRequestThrottler`
+is lock-free.
 
-* `ConcurrencyLimitingRequestThrottler`
-* `RateLimitingRequestThrottler`
-
-See the section about [throttling](../throttling) for details about these components. Again, they 
-use locks internally, and depending on how many requests are being executed in parallel, the thread
-contention on these locks can be high: in short, if your application enforces strict lock-freedom, 
-then these components should not be used.
+See the section about [throttling](../throttling) for details about these components. Depending on
+how many requests are being executed in parallel, the thread contention on these locks can be high:
+in short, if your application enforces strict lock-freedom, then you should not use the
+`RateLimitingRequestThrottler`.
 
 [request throttlers]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/session/throttling/RequestThrottler.html
 

--- a/manual/core/request_id/README.md
+++ b/manual/core/request_id/README.md
@@ -1,0 +1,48 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Request Id
+
+### Quick overview
+
+Users can inject an identifier for each individual CQL request, and such ID can be written in to the [custom payload](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v5.spec) to 
+correlate a request across the driver and the Apache Cassandra server.
+
+A request ID generator needs to generate both:
+- Session request ID: an identifier for an entire session.execute() call
+- Node request ID: an identifier for the execution of a CQL statement against a particular node. There can be one or more node requests for a single session request, due to retries or speculative executions.
+
+Usage:
+* Inject ID generator: set the desired `RequestIdGenerator` in `advanced.request-id.generator.class`.
+* Add ID to custom payload: the default behavior of a `RequestIdGenerator` is to add the request ID into the custom payload with the key `request-id`. Override `RequestIdGenerator.getDecoratedStatement` to customize the behavior.
+
+### Request Id Generator Configuration
+
+Request ID generator can be declared in the [configuration](../configuration/) as follows:
+
+```
+datastax-java-driver.advanced.request-id.generator {
+  class = com.example.app.MyGenerator
+}
+```
+
+To register your own request ID generator, specify the name of the class
+that implements `RequestIdGenerator`.
+
+The generated ID will be added to the log message of `CqlRequestHandler`, and propagated to other classes, e.g. the request trackers.

--- a/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/schema/RelationOptions.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/schema/RelationOptions.java
@@ -59,6 +59,18 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
+   * Defines the crc check chance.
+   *
+   * <p>Note that using this option with a version of Apache Cassandra less than 3.0 will raise a
+   * syntax error.
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withCRCCheckChance(double crcCheckChance) {
+    return withOption("crc_check_chance", crcCheckChance);
+  }
+
+  /**
    * Defines the caching criteria.
    *
    * <p>If no call is made to this method, the default value is determined by the global caching
@@ -97,11 +109,10 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the LZ4 algorithm with the given chunk length and crc check
-   * chance.
-   *
-   * @see #withCompression(String, int, double)
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later. Use {@link #withLZ4Compression(int)} instead.
    */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withLZ4Compression(int chunkLengthKB, double crcCheckChance) {
@@ -109,10 +120,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the LZ4 algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the LZ4 algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withLZ4Compression(int chunkLengthKB) {
+    return withCompression("LZ4Compressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the LZ4 algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -121,11 +143,35 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Snappy algorithm with the given chunk length and crc check
-   * chance.
+   * Configures compression using the Zstd algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
    */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withZstdCompression(int chunkLengthKB) {
+    return withCompression("ZstdCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Zstd algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withZstdCompression() {
+    return withCompression("ZstdCompressor");
+  }
+
+  /**
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withSnappyCompression(int)} instead.
+   */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withSnappyCompression(int chunkLengthKB, double crcCheckChance) {
@@ -133,10 +179,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Snappy algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the Snappy algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withSnappyCompression(int chunkLengthKB) {
+    return withCompression("SnappyCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Snappy algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -145,11 +202,12 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Deflate algorithm with the given chunk length and crc check
-   * chance.
-   *
-   * @see #withCompression(String, int, double)
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withDeflateCompression(int)} instead.
    */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withDeflateCompression(int chunkLengthKB, double crcCheckChance) {
@@ -157,10 +215,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Deflate algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the Deflate algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withDeflateCompression(int chunkLengthKB) {
+    return withCompression("DeflateCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Deflate algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -170,13 +239,13 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
 
   /**
    * Configures compression using the given algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * chunk_length).
    *
    * <p>Unless specifying a custom compression algorithm implementation, it is recommended to use
    * {@link #withLZ4Compression()}, {@link #withSnappyCompression()}, or {@link
    * #withDeflateCompression()}.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -185,7 +254,7 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the given algorithm, chunk length and crc check chance.
+   * Configures compression using the given algorithm, chunk length.
    *
    * <p>Unless specifying a custom compression algorithm implementation, it is recommended to use
    * {@link #withLZ4Compression()}, {@link #withSnappyCompression()}, or {@link
@@ -193,11 +262,24 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
    *
    * @param compressionAlgorithmName The class name of the compression algorithm.
    * @param chunkLengthKB The chunk length in KB of compression blocks. Defaults to 64.
-   * @param crcCheckChance The probability (0.0 to 1.0) that checksum will be checked on each read.
-   *     Defaults to 1.0.
    */
   @NonNull
   @CheckReturnValue
+  default SelfT withCompression(@NonNull String compressionAlgorithmName, int chunkLengthKB) {
+    return withOption(
+        "compression",
+        ImmutableMap.of("class", compressionAlgorithmName, "chunk_length_in_kb", chunkLengthKB));
+  }
+
+  /**
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withCompression(String, int)} instead.
+   */
+  @NonNull
+  @CheckReturnValue
+  @Deprecated
   default SelfT withCompression(
       @NonNull String compressionAlgorithmName, int chunkLengthKB, double crcCheckChance) {
     return withOption(

--- a/query-builder/src/test/java/com/datastax/dse/driver/api/querybuilder/schema/CreateDseTableTest.java
+++ b/query-builder/src/test/java/com/datastax/dse/driver/api/querybuilder/schema/CreateDseTableTest.java
@@ -199,9 +199,42 @@ public class CreateDseTableTest {
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
                 .withColumn("v", DataTypes.TEXT)
+                .withLZ4Compression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_in_kb':1024}");
+  }
+
+  @Test
+  public void should_generate_create_table_lz4_compression_options_crc() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
                 .withLZ4Compression(1024, .5))
         .hasCql(
             "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_kb':1024,'crc_check_chance':0.5}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression())
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor'}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor','chunk_length_in_kb':1024}");
   }
 
   @Test
@@ -217,6 +250,17 @@ public class CreateDseTableTest {
 
   @Test
   public void should_generate_create_table_snappy_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withSnappyCompression(2048))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'SnappyCompressor','chunk_length_in_kb':2048}");
+  }
+
+  @Test
+  public void should_generate_create_table_snappy_compression_options_crc() {
     assertThat(
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -239,6 +283,17 @@ public class CreateDseTableTest {
 
   @Test
   public void should_generate_create_table_deflate_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withDeflateCompression(4096))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'DeflateCompressor','chunk_length_in_kb':4096}");
+  }
+
+  @Test
+  public void should_generate_create_table_deflate_compression_options_crc() {
     assertThat(
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -388,5 +443,15 @@ public class CreateDseTableTest {
                 + "AND EDGE LABEL contrib "
                 + "FROM person(contributor) "
                 + "TO soft((company_name,software_name),software_version)");
+  }
+
+  @Test
+  public void should_generate_create_table_crc_check_chance() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withCRCCheckChance(0.8))
+        .hasCql("CREATE TABLE bar (k int PRIMARY KEY,v text) WITH crc_check_chance=0.8");
   }
 }

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
@@ -203,9 +203,42 @@ public class CreateTableTest {
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
                 .withColumn("v", DataTypes.TEXT)
+                .withLZ4Compression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_in_kb':1024}");
+  }
+
+  @Test
+  public void should_generate_create_table_lz4_compression_options_crc() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
                 .withLZ4Compression(1024, .5))
         .hasCql(
             "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_kb':1024,'crc_check_chance':0.5}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression())
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor'}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor','chunk_length_in_kb':1024}");
   }
 
   @Test
@@ -221,6 +254,17 @@ public class CreateTableTest {
 
   @Test
   public void should_generate_create_table_snappy_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withSnappyCompression(2048))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'SnappyCompressor','chunk_length_in_kb':2048}");
+  }
+
+  @Test
+  public void should_generate_create_table_snappy_compression_options_crc() {
     assertThat(
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -243,6 +287,17 @@ public class CreateTableTest {
 
   @Test
   public void should_generate_create_table_deflate_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withDeflateCompression(4096))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'DeflateCompressor','chunk_length_in_kb':4096}");
+  }
+
+  @Test
+  public void should_generate_create_table_deflate_compression_options_crc() {
     assertThat(
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -72,7 +72,13 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
   @Override
   public Statement apply(Statement base, Description description) {
     // Scylla-specific annotations
+    // Check both method-level and class-level annotations.
+    // When used as @Rule (not @ClassRule), description.getAnnotation() only finds
+    // method-level annotations, so we also check the test class directly.
     ScyllaSkip scyllaSkip = description.getAnnotation(ScyllaSkip.class);
+    if (scyllaSkip == null && description.getTestClass() != null) {
+      scyllaSkip = description.getTestClass().getAnnotation(ScyllaSkip.class);
+    }
     if (scyllaSkip != null) {
       if (CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
         return new Statement() {
@@ -88,6 +94,9 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     }
 
     ScyllaOnly scyllaOnly = description.getAnnotation(ScyllaOnly.class);
+    if (scyllaOnly == null && description.getTestClass() != null) {
+      scyllaOnly = description.getTestClass().getAnnotation(ScyllaOnly.class);
+    }
     if (scyllaOnly != null) {
       if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
         return new Statement() {


### PR DESCRIPTION
## Summary

Cherry-picks upstream Apache Cassandra Java Driver changes from 4.19.0 to 4.19.1 into scylla-4.x.

## Upstream PRs included

| Status | Upstream Commit(s) | PR | Description |
|--------|--------------------|----|-------------|
| ✅ Cherry-picked | `53bb5c8b65`, `c9facc3c36` | N/A | CASSJAVA-68: Improve DefaultCodecRegistry.CacheKey#hashCode() to eliminate Object[] allocation |
| ✅ Cherry-picked | `bb9bb11e57` | N/A | Add SubnetAddressTranslator for translating Cassandra node IPs based on subnet masks |
| ✅ Cherry-picked | `ddd6f03d71` | [#2028](https://github.com/apache/cassandra-java-driver/pull/2028) | Remove unnecessary locking in DefaultNettyOptions |
| ✅ Cherry-picked | `f32069bd8a` | [#2029](https://github.com/apache/cassandra-java-driver/pull/2029) | CASSJAVA-89: Support schema options changed in Cassandra 5.0 |
| ✅ Cherry-picked | `7e21eb2028` | [#2025](https://github.com/apache/cassandra-java-driver/pull/2025) | Eliminate lock in ConcurrencyLimitingRequestThrottler |
| ✅ Cherry-picked | `ff2d7f26c6` | [#2036](https://github.com/apache/cassandra-java-driver/pull/2036) | CASSJAVA-92: Local DC provided for nodetool clientstats |
| ✅ Cherry-picked | `e2c7ad4d11` | [#2037](https://github.com/apache/cassandra-java-driver/pull/2037) | CASSJAVA-97: Let users inject an ID for each request and write to the custom payload |
| ✅ Cherry-picked | `3bb5b18903`, `7982f413a9` | [#2018](https://github.com/apache/cassandra-java-driver/pull/2018) | CASSJAVA-80: Support configuration to disable DNS reverse-lookups for SAN validation |
| ✅ Cherry-picked | `0115cd67c1` | [#2035](https://github.com/apache/cassandra-java-driver/pull/2035) | Prevent long overflow in SNI address resolution |
| ✅ Cherry-picked | `d7e829775c` | N/A | Make guava an optional dependency of java-driver-guava-shaded |
| ✅ Cherry-picked | `204dd09329` (code only) | [#1999](https://github.com/apache/cassandra-java-driver/pull/1999) | CASSJAVA-40: Java 21 compatibility fixes for ArrayUtils and tests |

## Upstream commits skipped (not applicable to our fork)

| Upstream Commit | Reason |
|----------------|--------|
| `90612f6758` | maven-release-plugin: prepare for next dev iteration |
| `c0cae9bf76` | CASSJAVA-90: native-protocol version update (our fork already at 1.5.2.1, newer than upstream 1.5.2) |
| `529d56e174`, `7161d12fb2` | CASSJAVA-40: CI/Jenkinsfile changes only (not applicable to our CI) |
| `f42ab99ccc` | Netty upgrade to 4.1.119 (our fork already at 4.1.127) |
| `c43efd42cb` | revapi artifact ID fix (build tooling) |
| `eb54934d5d` | Jackson bump to 2.13.5 (our fork already at 2.21.1) |
| `29d3531202` | Fix revapi complaints about optional deps |
| `f49e19b8c7`, `17ebe6092e` | Jenkinsfile CI changes |
| `69eebb939c` | Change groupId in README (not applicable) |
| `05e6717253` | Manual codeblock directive fix (docs) |
| `104751c166`, `77b2baebeb` | Changelog and release prep |

## Additional fixes

- Fixed javadoc reference for `inet.ipaddr.Address#isPrefixBlock()` (changed `@link` to `@code`)
- Fixed `MockedDriverContextFactory` and `StartupOptionsBuilderTest` to mock `LOAD_BALANCING_DEFAULT_LWT_REQUEST_ROUTING_METHOD` option (pre-existing test issue exposed by CASSJAVA-92 changes)

## Test plan

- [x] Compilation passes (Java 8)
- [x] Unit tests pass
- [ ] CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)