### PR TITLE
chore: Bump Jackson version to 2.18.6 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <snappy.version>1.1.10.7</snappy.version>
         <lz4.version>1.10.1</lz4.version>
         <hdr.version>2.2.2</hdr.version>
-        <jackson.version>2.15.4</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <joda.version>2.12.7</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>


### PR DESCRIPTION
Bump  Jackson version to `2.18.6`, to fix **GHSA-72hv-8253-57qq** from `com.fasterxml.jackson.core:jackson-core`