### PR TITLE
fix: xml formatting in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <skipUnitTests>${skipTests}</skipUnitTests>
     <release.autopublish>false</release.autopublish>
     <pushChanges>false</pushChanges>
-    <mockitoopens.argline />
+    <mockitoopens.argline/>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Fix xml-format-maven-plugin check failure caused by maven-release-plugin reformatting <mockitoopens.argline /> with a space in the self-closing tag.