### PR TITLE
fix: prevent schema refresh deadlock when newInstance() fails

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -446,6 +446,7 @@ public class MetadataManager implements AsyncAutoCloseable {
                 (schemaInAgreement, agreementError) -> {
                   if (agreementError != null) {
                     refreshFuture.completeExceptionally(agreementError);
+                    onSchemaRefreshComplete();
                   } else {
                     try {
                       schemaQueriesFactory
@@ -460,21 +461,12 @@ public class MetadataManager implements AsyncAutoCloseable {
                                   refreshFuture.complete(
                                       new RefreshSchemaResult(newMetadata, schemaInAgreement));
                                 }
-
-                                firstSchemaRefreshFuture.complete(null);
-
-                                currentSchemaRefresh = null;
-                                // If another refresh was enqueued during this one, run it now
-                                if (queuedSchemaRefresh != null) {
-                                  CompletableFuture<RefreshSchemaResult> tmp =
-                                      this.queuedSchemaRefresh;
-                                  this.queuedSchemaRefresh = null;
-                                  startSchemaRequest(tmp);
-                                }
+                                onSchemaRefreshComplete();
                               });
                     } catch (Throwable t) {
                       LOG.debug("[{}] Exception getting new metadata", logPrefix, t);
                       refreshFuture.completeExceptionally(t);
+                      onSchemaRefreshComplete();
                     }
                   }
                 });
@@ -483,6 +475,18 @@ public class MetadataManager implements AsyncAutoCloseable {
       } else {
         CompletableFutures.completeFrom(
             queuedSchemaRefresh, refreshFuture); // join the queued request
+      }
+    }
+
+    private void onSchemaRefreshComplete() {
+      assert adminExecutor.inEventLoop();
+      firstSchemaRefreshFuture.complete(null);
+      currentSchemaRefresh = null;
+      // If another refresh was enqueued during this one, run it now
+      if (queuedSchemaRefresh != null) {
+        CompletableFuture<RefreshSchemaResult> tmp = this.queuedSchemaRefresh;
+        this.queuedSchemaRefresh = null;
+        startSchemaRequest(tmp);
       }
     }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -38,6 +38,7 @@ import com.datastax.oss.driver.internal.core.control.ControlConnection;
 import com.datastax.oss.driver.internal.core.metadata.schema.parsing.SchemaParserFactory;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaQueriesFactory;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
+import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import io.netty.channel.DefaultEventLoopGroup;
@@ -311,6 +312,97 @@ public class MetadataManagerTest {
     // Then
     waitForPendingAdminTasks(() -> result.toCompletableFuture().isDone());
     assertThatStage(result).isFailed(t -> assertThat(t).isEqualTo(expectedException));
+  }
+
+  @Test
+  public void refreshSchema_should_recover_after_newInstance_failure() {
+    // Given
+    IllegalStateException expectedException = new IllegalStateException("Error we're testing");
+    when(schemaQueriesFactory.newInstance()).thenThrow(expectedException);
+    when(topologyMonitor.refreshNodeList())
+        .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mock(NodeInfo.class))));
+    when(topologyMonitor.checkSchemaAgreement())
+        .thenReturn(CompletableFuture.completedFuture(Boolean.TRUE));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    metadataManager.refreshNodes();
+    waitForPendingAdminTasks(() -> metadataManager.refreshes.size() == 1);
+
+    // First refresh fails
+    CompletionStage<MetadataManager.RefreshSchemaResult> result1 =
+        metadataManager.refreshSchema("foo", true, true);
+    waitForPendingAdminTasks(() -> result1.toCompletableFuture().isDone());
+    assertThatStage(result1).isFailed(t -> assertThat(t).isEqualTo(expectedException));
+
+    // When - second refresh should not be stuck (uses same throwing mock)
+    CompletionStage<MetadataManager.RefreshSchemaResult> result2 =
+        metadataManager.refreshSchema("bar", true, true);
+
+    // Then - should complete (not hang forever), proving currentSchemaRefresh was cleared
+    waitForPendingAdminTasks(() -> result2.toCompletableFuture().isDone());
+    assertThatStage(result2).isFailed(t -> assertThat(t).isEqualTo(expectedException));
+  }
+
+  @Test
+  public void refreshSchema_should_recover_after_agreement_error() {
+    // Given
+    RuntimeException agreementException = new RuntimeException("Agreement check failed");
+    when(topologyMonitor.refreshNodeList())
+        .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mock(NodeInfo.class))));
+    when(topologyMonitor.checkSchemaAgreement())
+        .thenReturn(CompletableFutures.failedFuture(agreementException));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    metadataManager.refreshNodes();
+    waitForPendingAdminTasks(() -> metadataManager.refreshes.size() == 1);
+
+    // First refresh fails due to agreement error
+    CompletionStage<MetadataManager.RefreshSchemaResult> result1 =
+        metadataManager.refreshSchema("foo", true, true);
+    waitForPendingAdminTasks(() -> result1.toCompletableFuture().isDone());
+    assertThatStage(result1).isFailed();
+
+    // When - second refresh should not be stuck (uses same failing mock)
+    CompletionStage<MetadataManager.RefreshSchemaResult> result2 =
+        metadataManager.refreshSchema("bar", true, true);
+
+    // Then - should complete (not hang forever), proving currentSchemaRefresh was cleared
+    waitForPendingAdminTasks(() -> result2.toCompletableFuture().isDone());
+    assertThatStage(result2).isFailed();
+  }
+
+  @Test
+  public void refreshSchema_should_drain_queued_refresh_after_newInstance_failure() {
+    // Given
+    IllegalStateException expectedException = new IllegalStateException("Error we're testing");
+    when(schemaQueriesFactory.newInstance()).thenThrow(expectedException);
+    when(topologyMonitor.refreshNodeList())
+        .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mock(NodeInfo.class))));
+    // Use a future we control to introduce a delay in schema agreement check
+    CompletableFuture<Boolean> agreementFuture = new CompletableFuture<>();
+    when(topologyMonitor.checkSchemaAgreement()).thenReturn(agreementFuture);
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    metadataManager.refreshNodes();
+    waitForPendingAdminTasks(() -> metadataManager.refreshes.size() == 1);
+
+    // Start first refresh (it will block on agreement check)
+    CompletionStage<MetadataManager.RefreshSchemaResult> result1 =
+        metadataManager.refreshSchema("foo", true, true);
+
+    // Queue a second refresh while the first is in progress
+    CompletionStage<MetadataManager.RefreshSchemaResult> result2 =
+        metadataManager.refreshSchema("bar", true, true);
+
+    // Now complete the agreement check - first refresh will fail at newInstance(),
+    // and onSchemaRefreshComplete should drain the queued second refresh
+    agreementFuture.complete(true);
+
+    // Then both requests should complete (not hang forever)
+    waitForPendingAdminTasks(
+        () -> result1.toCompletableFuture().isDone() && result2.toCompletableFuture().isDone());
+    assertThatStage(result1).isFailed(t -> assertThat(t).isEqualTo(expectedException));
+    assertThatStage(result2).isFailed(t -> assertThat(t).isEqualTo(expectedException));
   }
 
   private static class TestMetadataManager extends MetadataManager {


### PR DESCRIPTION
## Summary
- When `SchemaQueries.newInstance()` throws or schema agreement check fails in `startSchemaRequest()`, `currentSchemaRefresh` was never reset to `null`, permanently blocking all future schema refreshes for the session
- Extracted cleanup logic into `onSchemaRefreshComplete()` helper and call it from all three completion paths (agreement error, `newInstance()` exception, normal completion)
- Added tests verifying recovery after `newInstance()` failure, agreement error, and queued refresh draining

Fixes https://github.com/scylladb/java-driver/issues/841

## Test plan
- [x] `MetadataManagerTest.refreshSchema_should_recover_after_newInstance_failure` — second refresh completes after first fails
- [x] `MetadataManagerTest.refreshSchema_should_recover_after_agreement_error` — second refresh completes after agreement check failure
- [x] `MetadataManagerTest.refreshSchema_should_drain_queued_refresh_after_newInstance_failure` — queued refresh is drained when active refresh fails
- [x] All existing `MetadataManagerTest` tests pass