### PR TITLE
fix: resolve control node endpoint for ClientRoutes contact point matching

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -69,7 +69,7 @@ public class DriverChannel {
   @SuppressWarnings("RedundantStringConstructorCall")
   static final Object FORCEFUL_CLOSE_MESSAGE = new String("FORCEFUL_CLOSE_MESSAGE");
 
-  private final EndPoint endPoint;
+  private volatile EndPoint endPoint;
   private final Channel channel;
   private final InFlightHandler inFlightHandler;
   private final WriteCoalescer writeCoalescer;
@@ -248,6 +248,11 @@ public class DriverChannel {
   /** The endpoint that was used to establish the connection. */
   public EndPoint getEndPoint() {
     return endPoint;
+  }
+
+  /** Updates the endpoint, e.g. after resolving the node's identity from system.local. */
+  public void setEndPoint(EndPoint endPoint) {
+    this.endPoint = endPoint;
   }
 
   public SocketAddress localAddress() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -463,7 +463,26 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                                   adminExecutor
                                       .submit(() -> onChannelClosed(channel, node))
                                       .addListener(UncaughtExceptions::log));
-                      onSuccess.run();
+                      resolveChannelNodeInfo(channel)
+                          .whenCompleteAsync(
+                              (ignored, fetchError) -> {
+                                if (fetchError != null) {
+                                  LOG.debug(
+                                      "[{}] Failed to fetch control node host_id from {}, "
+                                          + "trying next node",
+                                      logPrefix,
+                                      node,
+                                      fetchError);
+                                  channel.forceClose();
+                                  List<Entry<Node, Throwable>> newErrors =
+                                      (errors == null) ? new ArrayList<>() : errors;
+                                  newErrors.add(new SimpleEntry<>(node, fetchError));
+                                  connect(nodes, newErrors, onSuccess, onFailure);
+                                } else {
+                                  onSuccess.run();
+                                }
+                              },
+                              adminExecutor);
                     }
                   } catch (Exception e) {
                     Loggers.warnWithException(
@@ -475,6 +494,25 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                 },
                 adminExecutor);
       }
+    }
+
+    /**
+     * Resolves the identity of the node at the other end of the channel via the topology monitor,
+     * then updates the channel's endpoint. This allows {@link InitialNodeListRefresh} to identify
+     * the control node by endpoint equality when matching contact points (e.g., when a
+     * DefaultEndPoint contact point connects to a node that uses ClientRoutesEndPoint).
+     */
+    private CompletionStage<Void> resolveChannelNodeInfo(DriverChannel channel) {
+      return context
+          .getTopologyMonitor()
+          .getChannelNodeInfo(channel)
+          .thenAccept(
+              endPoint -> {
+                if (!endPoint.equals(channel.getEndPoint())) {
+                  channel.setEndPoint(endPoint);
+                  LOG.debug("[{}] Control channel endpoint upgraded to {}", logPrefix, endPoint);
+                }
+              });
     }
 
     private void onSuccessfulReconnect() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -165,6 +165,8 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
     // buildNodeEndPoint (called during the subsequent refreshNodes) can use ClientRoutesEndPoint.
     // If the server does not support CLIENT_ROUTES_CHANGE, the control connection will fail with
     // a ConnectionInitException and the error propagates naturally.
+    // Note: the control node's host_id is resolved by ControlConnection.connect() (via
+    // fetchControlNodeHostId) so that InitialNodeListRefresh can match the contact point.
     return super.init()
         .thenCompose(ignored -> queryClientRoutesAndCache(null, null))
         .whenComplete(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -165,6 +165,22 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   }
 
   @Override
+  public CompletionStage<EndPoint> getChannelNodeInfo(DriverChannel channel) {
+    if (closeFuture.isDone()) {
+      return CompletableFutures.failedFuture(new IllegalStateException("closed"));
+    }
+    EndPoint localEndPoint = channel.getEndPoint();
+    return query(channel, "SELECT * FROM system.local WHERE key='local'")
+        .thenApply(
+            result -> {
+              AdminRow localRow = result.iterator().next();
+              InetSocketAddress broadcastRpcAddress =
+                  getBroadcastRpcAddress(localRow, localEndPoint);
+              return buildNodeEndPoint(localRow, broadcastRpcAddress, localEndPoint);
+            });
+  }
+
+  @Override
   public CompletionStage<Iterable<NodeInfo>> refreshNodeList() {
     if (closeFuture.isDone()) {
       return CompletableFutures.failedFuture(new IllegalStateException("closed"));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
@@ -64,6 +65,17 @@ class InitialNodeListRefresh extends NodesRefresh {
     assert oldMetadata == DefaultMetadata.EMPTY;
     TokenFactory tokenFactory = null;
 
+    // After ControlConnection.connect() queries system.local, the control channel's endpoint is
+    // upgraded from DefaultEndPoint to ClientRoutesEndPoint. This lets us identify the control
+    // node by endpoint equality, so we can match it to its contact point.
+    EndPoint controlChannelEndPoint = null;
+    if (context.getControlConnection() != null) {
+      DriverChannel controlChannel = context.getControlConnection().channel();
+      if (controlChannel != null) {
+        controlChannelEndPoint = controlChannel.getEndPoint();
+      }
+    }
+
     Map<UUID, DefaultNode> newNodes = new HashMap<>();
     // Contact point nodes don't have host ID as well as other info yet, so we fill them with node
     // info found on first match by endpoint
@@ -82,6 +94,15 @@ class InitialNodeListRefresh extends NodesRefresh {
       } else {
         EndPoint endPoint = nodeInfo.getEndPoint();
         DefaultNode contactPointNode = findContactPointNode(endPoint);
+        // Fallback for ClientRoutes: the contact point has DefaultEndPoint (discovery proxy)
+        // while the NodeInfo has ClientRoutesEndPoint. If this NodeInfo's endpoint matches the
+        // control channel's (upgraded) endpoint, it's the control node — match it to the first
+        // available contact point.
+        if (contactPointNode == null
+            && controlChannelEndPoint != null
+            && endPoint.equals(controlChannelEndPoint)) {
+          contactPointNode = firstUnmatchedContactPoint(matchedContactPoints);
+        }
         DefaultNode node;
         if (contactPointNode == null || matchedContactPoints.contains(endPoint)) {
           node = new DefaultNode(endPoint, context);
@@ -119,6 +140,15 @@ class InitialNodeListRefresh extends NodesRefresh {
   private DefaultNode findContactPointNode(EndPoint endPoint) {
     for (DefaultNode node : contactPoints) {
       if (node.getEndPoint().equals(endPoint)) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  private DefaultNode firstUnmatchedContactPoint(Set<EndPoint> matchedContactPoints) {
+    for (DefaultNode node : contactPoints) {
+      if (!matchedContactPoints.contains(node.getEndPoint())) {
         return node;
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
@@ -19,8 +19,10 @@ package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import java.net.InetSocketAddress;
@@ -111,6 +113,16 @@ public interface TopologyMonitor extends AsyncAutoCloseable {
    *     always be returned in a single message (no paging).
    */
   CompletionStage<Iterable<NodeInfo>> refreshNodeList();
+
+  /**
+   * Resolves the endpoint for the node at the other end of the given channel by querying
+   * system.local. This is used by the control connection after establishing a channel to resolve
+   * the node's identity (e.g., host_id) and build the appropriate endpoint type.
+   *
+   * @param channel the channel to query system.local on.
+   * @return a future that completes with the resolved endpoint.
+   */
+  CompletionStage<EndPoint> getChannelNodeInfo(DriverChannel channel);
 
   /**
    * Checks whether the nodes in the cluster agree on a common schema version.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -41,6 +41,7 @@ import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.TestNodeFactory;
+import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
@@ -136,6 +137,15 @@ abstract class ControlConnectionTestBase {
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
     when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
         .thenReturn(false);
+
+    TopologyMonitor topologyMonitor = mock(TopologyMonitor.class);
+    when(topologyMonitor.getChannelNodeInfo(any(DriverChannel.class)))
+        .thenAnswer(
+            invocation -> {
+              DriverChannel ch = invocation.getArgument(0);
+              return CompletableFuture.completedFuture(ch.getEndPoint());
+            });
+    when(context.getTopologyMonitor()).thenReturn(topologyMonitor);
 
     controlConnection = new ControlConnection(context);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -482,7 +482,6 @@ public class ClientRoutesTopologyMonitorTest {
             .build();
     TestableClientRoutesTopologyMonitor h =
         new TestableClientRoutesTopologyMonitor(context, config) {
-          volatile boolean initDone = false;
           volatile boolean firstPostInitDone = false;
 
           @Override
@@ -492,12 +491,13 @@ public class ClientRoutesTopologyMonitorTest {
               @NonNull String queryString,
               @NonNull Duration timeout) {
             capturedQueries.add(queryString);
-            if (!initDone) {
-              initDone = true;
+            if (queryString.contains("system.client_routes") && !firstPostInitDone) {
+              // First client_routes query is during init — return immediately
+              firstPostInitDone = true;
               return CompletableFuture.completedFuture(emptyResult);
             }
-            if (!firstPostInitDone) {
-              firstPostInitDone = true;
+            if (queryString.contains("system.client_routes")) {
+              // Second client_routes query — block on delayedFuture
               return delayedFuture;
             }
             return CompletableFuture.completedFuture(emptyResult);


### PR DESCRIPTION
## Summary
- With ClientRoutes, contact points use `DefaultEndPoint` (discovery proxy) while discovered nodes use `ClientRoutesEndPoint` (keyed by host_id). These types never match via `equals()`, causing `InitialNodeListRefresh` to emit spurious remove+add events for the control node.
- Added `TopologyMonitor.getChannelNodeInfo(channel)` API that queries `system.local` and returns the proper endpoint for the connected node
- `ControlConnection.connect()` calls this after each successful connection and updates `DriverChannel.setEndPoint()` — for ClientRoutes this upgrades from `DefaultEndPoint` to `ClientRoutesEndPoint`
- `InitialNodeListRefresh` matches the control node by endpoint equality against the (now-upgraded) channel endpoint, falling back to the first unmatched contact point
- If the `system.local` query fails, the control connection retries the next node

## Test plan
- [x] All unit tests pass (MetadataManagerTest, InitialNodeListRefreshTest, ClientRoutesTopologyMonitorTest, ControlConnectionTest — 84 tests)
- [x] `ClientRoutesIT` integration test against ScyllaDB Enterprise 2026.1