### PR TITLE
fix: resolve control node endpoint after connect via TopologyMonitor API

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -69,7 +69,7 @@ public class DriverChannel {
   @SuppressWarnings("RedundantStringConstructorCall")
   static final Object FORCEFUL_CLOSE_MESSAGE = new String("FORCEFUL_CLOSE_MESSAGE");
 
-  private final EndPoint endPoint;
+  private volatile EndPoint endPoint;
   private final Channel channel;
   private final InFlightHandler inFlightHandler;
   private final WriteCoalescer writeCoalescer;
@@ -248,6 +248,11 @@ public class DriverChannel {
   /** The endpoint that was used to establish the connection. */
   public EndPoint getEndPoint() {
     return endPoint;
+  }
+
+  /** Updates the endpoint, e.g. after resolving the node's identity from system.local. */
+  public void setEndPoint(EndPoint endPoint) {
+    this.endPoint = endPoint;
   }
 
   public SocketAddress localAddress() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -455,15 +455,34 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                             previousChannel);
                         previousChannel.forceClose();
                       }
-                      context.getEventBus().fire(ChannelEvent.channelOpened(node));
-                      channel
-                          .closeFuture()
-                          .addListener(
-                              f ->
-                                  adminExecutor
-                                      .submit(() -> onChannelClosed(channel, node))
-                                      .addListener(UncaughtExceptions::log));
-                      onSuccess.run();
+                      resolveChannelNodeInfo(channel)
+                          .whenCompleteAsync(
+                              (ignored, fetchError) -> {
+                                if (fetchError != null) {
+                                  LOG.debug(
+                                      "[{}] Failed to resolve control node endpoint from {}, "
+                                          + "trying next node",
+                                      logPrefix,
+                                      node,
+                                      fetchError);
+                                  channel.forceClose();
+                                  List<Entry<Node, Throwable>> newErrors =
+                                      (errors == null) ? new ArrayList<>() : errors;
+                                  newErrors.add(new SimpleEntry<>(node, fetchError));
+                                  connect(nodes, newErrors, onSuccess, onFailure);
+                                } else {
+                                  context.getEventBus().fire(ChannelEvent.channelOpened(node));
+                                  channel
+                                      .closeFuture()
+                                      .addListener(
+                                          f ->
+                                              adminExecutor
+                                                  .submit(() -> onChannelClosed(channel, node))
+                                                  .addListener(UncaughtExceptions::log));
+                                  onSuccess.run();
+                                }
+                              },
+                              adminExecutor);
                     }
                   } catch (Exception e) {
                     Loggers.warnWithException(
@@ -475,6 +494,23 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                 },
                 adminExecutor);
       }
+    }
+
+    /**
+     * Resolves the identity of the node at the other end of the channel via the topology monitor,
+     * then updates the channel's endpoint.
+     */
+    private CompletionStage<Void> resolveChannelNodeInfo(DriverChannel channel) {
+      return context
+          .getTopologyMonitor()
+          .getChannelEndpoint(channel)
+          .thenAccept(
+              endPoint -> {
+                if (!endPoint.equals(channel.getEndPoint())) {
+                  channel.setEndPoint(endPoint);
+                  LOG.debug("[{}] Control channel endpoint upgraded to {}", logPrefix, endPoint);
+                }
+              });
     }
 
     private void onSuccessfulReconnect() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -165,6 +165,27 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   }
 
   @Override
+  public CompletionStage<EndPoint> getChannelEndpoint(DriverChannel channel) {
+    if (closeFuture.isDone()) {
+      return CompletableFutures.failedFuture(new IllegalStateException("closed"));
+    }
+    EndPoint localEndPoint = channel.getEndPoint();
+    return query(channel, "SELECT * FROM system.local WHERE key='local'")
+        .thenApply(
+            result -> {
+              Iterator<AdminRow> iterator = result.iterator();
+              if (!iterator.hasNext()) {
+                throw new IllegalStateException(
+                    "Expected a row in system.local for endpoint resolution, got empty result");
+              }
+              AdminRow localRow = iterator.next();
+              InetSocketAddress broadcastRpcAddress =
+                  getBroadcastRpcAddress(localRow, localEndPoint);
+              return buildNodeEndPoint(localRow, broadcastRpcAddress, localEndPoint);
+            });
+  }
+
+  @Override
   public CompletionStage<Iterable<NodeInfo>> refreshNodeList() {
     if (closeFuture.isDone()) {
       return CompletableFutures.failedFuture(new IllegalStateException("closed"));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
@@ -19,8 +19,10 @@ package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import java.net.InetSocketAddress;
@@ -111,6 +113,16 @@ public interface TopologyMonitor extends AsyncAutoCloseable {
    *     always be returned in a single message (no paging).
    */
   CompletionStage<Iterable<NodeInfo>> refreshNodeList();
+
+  /**
+   * Resolves the endpoint for the node at the other end of the given channel by querying
+   * system.local. This is used by the control connection after establishing a channel to resolve
+   * the node's identity (e.g., host_id) and build the appropriate endpoint type.
+   *
+   * @param channel the channel to query system.local on.
+   * @return a future that completes with the resolved endpoint.
+   */
+  CompletionStage<EndPoint> getChannelEndpoint(DriverChannel channel);
 
   /**
    * Checks whether the nodes in the cluster agree on a common schema version.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
@@ -22,10 +22,12 @@ import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
@@ -33,6 +35,7 @@ import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.channel.MockChannelFactoryHelper;
 import com.datastax.oss.driver.internal.core.metadata.DistanceEvent;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
+import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -518,6 +521,41 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // no event because the control connection never "owned" the channel
     verify(eventBus, never()).fire(ChannelEvent.channelOpened(node2));
     verify(eventBus, never()).fire(ChannelEvent.channelClosed(node2));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_try_next_node_if_resolve_endpoint_fails() {
+    // Given
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1)
+            .success(node2, channel2)
+            .build();
+
+    // Make resolveChannelNodeInfo fail for channel1
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    CompletableFuture<EndPoint> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(new RuntimeException("mock resolve failure"));
+    when(topologyMonitor.getChannelEndpoint(channel1)).thenReturn(failedFuture);
+
+    // When
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
+
+    // Then
+    assertThatStage(initFuture)
+        .isSuccess(v -> assertThat(controlConnection.channel()).isEqualTo(channel2));
+    // channel1's resolve failed, so channelOpened should NOT have been fired for node1
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node2));
+    verify(eventBus, never()).fire(ChannelEvent.channelOpened(node1));
+    // channel1 should be force-closed (called once by resolve failure handler,
+    // and once more when channel2 succeeds and closes the previousChannel)
+    verify(channel1, timeout(500).atLeastOnce()).forceClose();
 
     factoryHelper.verifyNoMoreCalls();
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -41,6 +41,7 @@ import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.TestNodeFactory;
+import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
@@ -136,6 +137,15 @@ abstract class ControlConnectionTestBase {
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
     when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
         .thenReturn(false);
+
+    TopologyMonitor topologyMonitor = mock(TopologyMonitor.class);
+    when(topologyMonitor.getChannelEndpoint(any(DriverChannel.class)))
+        .thenAnswer(
+            invocation -> {
+              DriverChannel ch = invocation.getArgument(0);
+              return CompletableFuture.completedFuture(ch.getEndPoint());
+            });
+    when(context.getTopologyMonitor()).thenReturn(topologyMonitor);
 
     controlConnection = new ControlConnection(context);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -38,6 +38,7 @@ import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.internal.core.addresstranslation.PassThroughAddressTranslator;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
@@ -421,6 +422,25 @@ public class DefaultTopologyMonitorTest {
         Level.WARN,
         "[null] Found invalid row in system.peers_v2 for peer: /127.0.0.2. "
             + "This is likely a gossip or snitch issue, this node will be ignored.");
+  }
+
+  @Test
+  public void should_fail_get_channel_endpoint_if_local_result_is_empty() {
+    // Given
+    topologyMonitor.stubQueries(
+        new StubbedQuery("SELECT * FROM system.local WHERE key='local'", mockResult()));
+
+    // When
+    CompletionStage<EndPoint> futureEndpoint = topologyMonitor.getChannelEndpoint(channel);
+
+    // Then
+    assertThatStage(futureEndpoint)
+        .isFailed(
+            error -> {
+              assertThat(error).isInstanceOf(IllegalStateException.class);
+              assertThat(error.getMessage())
+                  .contains("Expected a row in system.local for endpoint resolution");
+            });
   }
 
   @Test

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
@@ -71,12 +71,15 @@ public class ProtocolVersionMixedClusterIT {
       assertThat(context.getControlConnection().channel().protocolVersion())
           .isEqualTo(DefaultProtocolVersion.V4);
 
-      assertThat(queries(simulacron)).hasSize(4);
+      assertThat(queries(simulacron)).hasSize(5);
 
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // connection channel endpoint
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
@@ -100,11 +103,14 @@ public class ProtocolVersionMixedClusterIT {
 
       InternalDriverContext context = (InternalDriverContext) session.getContext();
       assertThat(context.getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
-      assertThat(queries(simulacron)).hasSize(4);
+      assertThat(queries(simulacron)).hasSize(5);
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // connection channel endpoint
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
@@ -151,11 +157,14 @@ public class ProtocolVersionMixedClusterIT {
                     .build()) {
       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
 
-      assertThat(queries(simulacron)).hasSize(4);
+      assertThat(queries(simulacron)).hasSize(5);
       assertThat(protocolQueries(contactPoint, 4))
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // connection channel endpoint
+              "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");


### PR DESCRIPTION
## Summary
- Added `TopologyMonitor.getChannelNodeInfo(DriverChannel)` API that queries `system.local` and returns the proper endpoint via `buildNodeEndPoint()`
- `ControlConnection.connect()` calls this after each successful connection and updates `DriverChannel.setEndPoint()` — for ClientRoutes this upgrades from `DefaultEndPoint` to `ClientRoutesEndPoint`
- If the `system.local` query fails, the control connection retries the next node
- `DriverChannel.endPoint` becomes volatile with a `setEndPoint()` setter

## Test plan
- [x] `ControlConnectionTest` (19 tests)
- [x] `ClientRoutesTopologyMonitorTest` (51 tests)
- [x] `ClientRoutesIT` integration test against ScyllaDB Enterprise 2026.1