### PR TITLE
refactor: remove contact point matching from InitialNodeListRefresh

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -545,7 +545,11 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     private void onChannelClosed(DriverChannel channel, Node node) {
       assert adminExecutor.inEventLoop();
       if (!closeWasCalled) {
-        context.getEventBus().fire(ChannelEvent.channelClosed(node));
+        // Look up the current metadata node by endpoint, since the original contact point node
+        // may have been replaced by a new DefaultNode during InitialNodeListRefresh.
+        Node metadataNode =
+            context.getMetadataManager().getMetadata().findNode(channel.getEndPoint()).orElse(node);
+        context.getEventBus().fire(ChannelEvent.channelClosed(metadataNode));
         // If this channel is the current control channel, we must start a
         // reconnection attempt to get a new control channel.
         if (channel == ControlConnection.this.channel) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/InferringLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/InferringLocalDcHelper.java
@@ -21,9 +21,10 @@ import static com.datastax.oss.driver.internal.core.time.Clock.LOG;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashSet;
 import java.util.Map;
@@ -36,9 +37,8 @@ import net.jcip.annotations.ThreadSafe;
  * An implementation of {@link LocalDcHelper} that fetches the user-supplied datacenter, if any,
  * from the programmatic configuration API, or else, from the driver configuration. If no local
  * datacenter is explicitly defined, this implementation infers the local datacenter from the
- * contact points: if all contact points share the same datacenter, that datacenter is returned. If
- * the contact points are from different datacenters, or if no contact points reported any
- * datacenter, an {@link IllegalStateException} is thrown.
+ * control node (the node the control connection is connected to). If the control node's datacenter
+ * is not available, an {@link IllegalStateException} is thrown.
  */
 @ThreadSafe
 public class InferringLocalDcHelper extends OptionalLocalDcHelper {
@@ -58,31 +58,45 @@ public class InferringLocalDcHelper extends OptionalLocalDcHelper {
     if (optionalLocalDc.isPresent()) {
       return optionalLocalDc;
     }
+    // Infer from the control node — its datacenter is the local DC.
+    DriverChannel controlChannel =
+        context.getControlConnection() != null ? context.getControlConnection().channel() : null;
+    if (controlChannel != null) {
+      EndPoint controlEndPoint = controlChannel.getEndPoint();
+      for (Node node : nodes.values()) {
+        if (node.getEndPoint().equals(controlEndPoint)) {
+          String datacenter = node.getDatacenter();
+          if (datacenter != null) {
+            LOG.info("[{}] Inferred local DC from control node: {}", logPrefix, datacenter);
+            return Optional.of(datacenter);
+          }
+          break;
+        }
+      }
+    }
+    // Fallback: if all nodes share the same DC, use it.
     Set<String> datacenters = new HashSet<>();
-    Set<DefaultNode> contactPoints = context.getMetadataManager().getContactPoints();
-    for (Node node : contactPoints) {
+    for (Node node : nodes.values()) {
       String datacenter = node.getDatacenter();
       if (datacenter != null) {
         datacenters.add(datacenter);
       }
     }
     if (datacenters.size() == 1) {
-      String localDc = datacenters.iterator().next();
-      LOG.info("[{}] Inferred local DC from contact points: {}", logPrefix, localDc);
-      return Optional.of(localDc);
+      return Optional.of(datacenters.iterator().next());
     }
-    if (datacenters.isEmpty()) {
+    if (datacenters.size() > 1) {
       throw new IllegalStateException(
-          "The local DC could not be inferred from contact points, please set it explicitly (see "
-              + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
-              + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)");
+          String.format(
+              "The local DC could not be inferred (nodes are in different DCs: %s), "
+                  + "please set it explicitly (see "
+                  + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
+                  + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)",
+              formatNodesAndDcs(nodes.values())));
     }
     throw new IllegalStateException(
-        String.format(
-            "No local DC was provided, but the contact points are from different DCs: %s; "
-                + "please set the local DC explicitly (see "
-                + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
-                + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)",
-            formatNodesAndDcs(contactPoints)));
+        "The local DC could not be inferred, please set it explicitly (see "
+            + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
+            + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)");
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
@@ -17,27 +17,23 @@
  */
 package com.datastax.oss.driver.internal.core.metadata;
 
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The first node list refresh: contact points are not in the metadata yet, we need to copy them
- * over.
+ * The first node list refresh: builds the initial node map from the topology monitor's node list.
+ * Contact point nodes are not reused in the metadata — fresh DefaultNode instances are created for
+ * all discovered nodes.
  */
 @ThreadSafe
 class InitialNodeListRefresh extends NodesRefresh {
@@ -45,11 +41,9 @@ class InitialNodeListRefresh extends NodesRefresh {
   private static final Logger LOG = LoggerFactory.getLogger(InitialNodeListRefresh.class);
 
   @VisibleForTesting final Iterable<NodeInfo> nodeInfos;
-  @VisibleForTesting final Set<DefaultNode> contactPoints;
 
-  InitialNodeListRefresh(Iterable<NodeInfo> nodeInfos, Set<DefaultNode> contactPoints) {
+  InitialNodeListRefresh(Iterable<NodeInfo> nodeInfos) {
     this.nodeInfos = nodeInfos;
-    this.contactPoints = contactPoints;
   }
 
   @Override
@@ -59,16 +53,11 @@ class InitialNodeListRefresh extends NodesRefresh {
     String logPrefix = context.getSessionName();
     TokenFactoryRegistry tokenFactoryRegistry = context.getTokenFactoryRegistry();
 
-    // Since this is the first refresh, and we've stored contact points separately until now, the
-    // metadata is empty.
     assert oldMetadata == DefaultMetadata.EMPTY;
     TokenFactory tokenFactory = null;
 
     Map<UUID, DefaultNode> newNodes = new HashMap<>();
-    // Contact point nodes don't have host ID as well as other info yet, so we fill them with node
-    // info found on first match by endpoint
-    Set<EndPoint> matchedContactPoints = new HashSet<>();
-    List<DefaultNode> addedNodes = new ArrayList<>();
+    ImmutableList.Builder<Object> eventsBuilder = ImmutableList.builder();
 
     for (NodeInfo nodeInfo : nodeInfos) {
       UUID hostId = nodeInfo.getHostId();
@@ -80,33 +69,14 @@ class InitialNodeListRefresh extends NodesRefresh {
             hostId,
             newNodes.get(hostId));
       } else {
-        EndPoint endPoint = nodeInfo.getEndPoint();
-        DefaultNode contactPointNode = findContactPointNode(endPoint);
-        DefaultNode node;
-        if (contactPointNode == null || matchedContactPoints.contains(endPoint)) {
-          node = new DefaultNode(endPoint, context);
-          addedNodes.add(node);
-          LOG.debug("[{}] Adding new node {}", logPrefix, node);
-        } else {
-          matchedContactPoints.add(contactPointNode.getEndPoint());
-          node = contactPointNode;
-          LOG.debug("[{}] Copying contact point {}", logPrefix, node);
-        }
+        DefaultNode node = new DefaultNode(nodeInfo.getEndPoint(), context);
         if (tokenMapEnabled && tokenFactory == null && nodeInfo.getPartitioner() != null) {
           tokenFactory = tokenFactoryRegistry.tokenFactoryFor(nodeInfo.getPartitioner());
         }
         copyInfos(nodeInfo, node, context);
         newNodes.put(hostId, node);
-      }
-    }
-
-    ImmutableList.Builder<Object> eventsBuilder = ImmutableList.builder();
-    for (DefaultNode addedNode : addedNodes) {
-      eventsBuilder.add(NodeStateEvent.added(addedNode));
-    }
-    for (DefaultNode contactPoint : contactPoints) {
-      if (!matchedContactPoints.contains(contactPoint.getEndPoint())) {
-        eventsBuilder.add(NodeStateEvent.removed(contactPoint));
+        eventsBuilder.add(NodeStateEvent.added(node));
+        LOG.debug("[{}] Adding node {}", logPrefix, node);
       }
     }
 
@@ -114,14 +84,5 @@ class InitialNodeListRefresh extends NodesRefresh {
         oldMetadata.withNodes(
             ImmutableMap.copyOf(newNodes), tokenMapEnabled, true, tokenFactory, context),
         eventsBuilder.build());
-  }
-
-  private DefaultNode findContactPointNode(EndPoint endPoint) {
-    for (DefaultNode node : contactPoints) {
-      if (node.getEndPoint().equals(endPoint)) {
-        return node;
-      }
-    }
-    return null;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -29,6 +29,8 @@ import com.datastax.oss.driver.api.core.metadata.Tablet;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.TupleType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
@@ -337,12 +339,23 @@ public class MetadataManager implements AsyncAutoCloseable {
     }
 
     private Void refreshNodes(Iterable<NodeInfo> nodeInfos) {
+      boolean isFirst = !didFirstNodeListRefresh;
       MetadataRefresh refresh =
-          didFirstNodeListRefresh
-              ? new FullNodeListRefresh(nodeInfos)
-              : new InitialNodeListRefresh(nodeInfos, contactPoints);
+          isFirst ? new InitialNodeListRefresh(nodeInfos) : new FullNodeListRefresh(nodeInfos);
       didFirstNodeListRefresh = true;
-      return apply(refresh);
+      apply(refresh);
+      if (isFirst) {
+        // The control connection opened its channel on the contact point DefaultNode, which is
+        // now discarded. Re-fire channelOpened on the new metadata node so that
+        // NodeStateManager counts the control connection and transitions the node to UP.
+        DriverChannel channel = controlConnection.channel();
+        if (channel != null) {
+          metadata
+              .findNode(channel.getEndPoint())
+              .ifPresent(node -> context.getEventBus().fire(ChannelEvent.channelOpened(node)));
+        }
+      }
+      return null;
     }
 
     private void addNode(InetSocketAddress address, NodeInfo info) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyDistanceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyDistanceTest.java
@@ -39,8 +39,7 @@ public class DcInferringLoadBalancingPolicyDistanceTest
             IllegalStateException.class,
             ise ->
                 assertThat(ise)
-                    .hasMessageContaining(
-                        "No local DC was provided, but the contact points are from different DCs")
+                    .hasMessageContaining("The local DC could not be inferred")
                     .hasMessageContaining("node1=null")
                     .hasMessageContaining("node2=dc1")
                     .hasMessageContaining("node3=dc2"));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyInitTest.java
@@ -109,8 +109,10 @@ public class DcInferringLoadBalancingPolicyInitTest extends LoadBalancingPolicyT
     // Then
     assertThat(t)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "No local DC was provided, but the contact points are from different DCs: node1=dc1, node2=dc2");
+        .hasMessageContaining("The local DC could not be inferred")
+        .hasMessageContaining("nodes are in different DCs")
+        .hasMessageContaining("node1=dc1")
+        .hasMessageContaining("node2=dc2");
   }
 
   @Test
@@ -134,8 +136,7 @@ public class DcInferringLoadBalancingPolicyInitTest extends LoadBalancingPolicyT
     // Then
     assertThat(t)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "The local DC could not be inferred from contact points, please set it explicitly");
+        .hasMessageContaining("The local DC could not be inferred, please set it explicitly");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
@@ -26,7 +26,6 @@ import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -42,115 +41,47 @@ public class InitialNodeListRefreshTest {
   @Mock protected MetricsFactory metricsFactory;
   @Mock private ChannelFactory channelFactory;
 
-  private DefaultNode contactPoint1;
-  private DefaultNode contactPoint2;
+  private EndPoint endPoint1;
+  private EndPoint endPoint2;
   private EndPoint endPoint3;
   private UUID hostId1;
   private UUID hostId2;
   private UUID hostId3;
-  private UUID hostId4;
-  private UUID hostId5;
 
   @Before
   public void setup() {
     when(context.getMetricsFactory()).thenReturn(metricsFactory);
     when(context.getChannelFactory()).thenReturn(channelFactory);
 
-    contactPoint1 = TestNodeFactory.newContactPoint(1, context);
-    contactPoint2 = TestNodeFactory.newContactPoint(2, context);
-
+    endPoint1 = TestNodeFactory.newEndPoint(1);
+    endPoint2 = TestNodeFactory.newEndPoint(2);
     endPoint3 = TestNodeFactory.newEndPoint(3);
     hostId1 = UUID.randomUUID();
     hostId2 = UUID.randomUUID();
     hostId3 = UUID.randomUUID();
-    hostId4 = UUID.randomUUID();
-    hostId5 = UUID.randomUUID();
   }
 
   @Test
-  public void should_copy_contact_points_on_first_endpoint_match_only() {
+  public void should_create_nodes_from_node_infos() {
     // Given
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
-                .withHostId(hostId1)
-                .build(),
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint2.getEndPoint())
-                .withHostId(hostId2)
-                .build(),
-            DefaultNodeInfo.builder().withEndPoint(endPoint3).withHostId(hostId3).build(),
-            DefaultNodeInfo.builder()
-                // address translator can translate node addresses to the same endpoints
-                .withEndPoint(contactPoint2.getEndPoint())
-                .withHostId(hostId4)
-                .build(),
-            DefaultNodeInfo.builder()
-                // address translator can translate node addresses to the same endpoints
-                .withEndPoint(endPoint3)
-                .withHostId(hostId5)
-                .build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
-
-    // When
-    MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
-
-    // Then
-    // contact points have been copied to the metadata, and completed with missing information
-    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
-    assertThat(newNodes).containsOnlyKeys(hostId1, hostId2, hostId3, hostId4, hostId5);
-    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
-    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
-    assertThat(newNodes.get(hostId2)).isEqualTo(contactPoint2);
-    assertThat(contactPoint2.getHostId()).isEqualTo(hostId2);
-    // And
-    // node has been added for the new endpoint
-    assertThat(newNodes.get(hostId3).getEndPoint()).isEqualTo(endPoint3);
-    assertThat(newNodes.get(hostId3).getHostId()).isEqualTo(hostId3);
-    // And
-    // nodes have been added for duplicated endpoints
-    assertThat(newNodes.get(hostId4).getEndPoint()).isEqualTo(contactPoint2.getEndPoint());
-    assertThat(newNodes.get(hostId4).getHostId()).isEqualTo(hostId4);
-    assertThat(newNodes.get(hostId5).getEndPoint()).isEqualTo(endPoint3);
-    assertThat(newNodes.get(hostId5).getHostId()).isEqualTo(hostId5);
-    assertThat(result.events)
-        .containsExactlyInAnyOrder(
-            NodeStateEvent.added((DefaultNode) newNodes.get(hostId3)),
-            NodeStateEvent.added((DefaultNode) newNodes.get(hostId4)),
-            NodeStateEvent.added((DefaultNode) newNodes.get(hostId5)));
-  }
-
-  @Test
-  public void should_add_other_nodes() {
-    // Given
-    Iterable<NodeInfo> newInfos =
-        ImmutableList.of(
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
-                .withHostId(hostId1)
-                .build(),
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint2.getEndPoint())
-                .withHostId(hostId2)
-                .build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint1).withHostId(hostId1).build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint2).withHostId(hostId2).build(),
             DefaultNodeInfo.builder().withEndPoint(endPoint3).withHostId(hostId3).build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
 
     // When
     MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
 
     // Then
-    // new node created in addition to the contact points
     Map<UUID, Node> newNodes = result.newMetadata.getNodes();
     assertThat(newNodes).containsOnlyKeys(hostId1, hostId2, hostId3);
-    Node node3 = newNodes.get(hostId3);
-    assertThat(node3.getEndPoint()).isEqualTo(endPoint3);
-    assertThat(node3.getHostId()).isEqualTo(hostId3);
+    assertThat(newNodes.get(hostId1).getEndPoint()).isEqualTo(endPoint1);
+    assertThat(newNodes.get(hostId1).getHostId()).isEqualTo(hostId1);
+    assertThat(newNodes.get(hostId2).getEndPoint()).isEqualTo(endPoint2);
+    assertThat(newNodes.get(hostId3).getEndPoint()).isEqualTo(endPoint3);
+    assertThat(result.events).hasSize(3);
   }
 
   @Test
@@ -159,28 +90,23 @@ public class InitialNodeListRefreshTest {
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
             DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
+                .withEndPoint(endPoint1)
                 .withHostId(hostId1)
                 .withDatacenter("dc1")
                 .build(),
             DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
+                .withEndPoint(endPoint1)
                 .withDatacenter("dc2")
                 .withHostId(hostId1)
                 .build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1));
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
 
     // When
     MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
 
-    // Then
-    // only the first nodeInfo should have been copied
+    // Then only the first nodeInfo should have been used
     Map<UUID, Node> newNodes = result.newMetadata.getNodes();
     assertThat(newNodes).containsOnlyKeys(hostId1);
-    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
-    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
-    assertThat(contactPoint1.getDatacenter()).isEqualTo("dc1");
+    assertThat(newNodes.get(hostId1).getDatacenter()).isEqualTo("dc1");
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -153,9 +153,6 @@ public class MetadataManagerTest {
     assertThatStage(refreshNodesFuture).isSuccess();
     assertThat(metadataManager.refreshes).hasSize(1);
     InitialNodeListRefresh refresh = (InitialNodeListRefresh) metadataManager.refreshes.get(0);
-    assertThat(refresh.contactPoints)
-        .extracting(Node::getEndPoint)
-        .containsOnly(MetadataManager.DEFAULT_CONTACT_POINT);
     assertThat(refresh.nodeInfos).containsExactlyInAnyOrder(info1, info2);
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -83,8 +82,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -111,8 +108,6 @@ public class NodeStateIT {
           .build();
 
   @Rule public TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
-
-  private @Captor ArgumentCaptor<DefaultNode> nodeCaptor;
 
   private InternalDriverContext driverContext;
   private ConfigurableIgnoresPolicy defaultLoadBalancingPolicy;
@@ -184,10 +179,12 @@ public class NodeStateIT {
                 .findNode(simulacronRegularNode.inetSocketAddress())
                 .orElseThrow(AssertionError::new);
 
-    // SessionRule uses all nodes as contact points, so we only get onUp notifications for them (no
-    // onAdd)
+    // All discovered nodes fire onAdd during initial node list refresh, then the control node
+    // transitions to UP when the control connection's channel event is re-fired on the metadata
+    // node
+    inOrder.verify(nodeStateListener, timeout(500)).onAdd(metadataControlNode);
+    inOrder.verify(nodeStateListener, timeout(500)).onAdd(metadataRegularNode);
     inOrder.verify(nodeStateListener, timeout(500)).onUp(metadataControlNode);
-    inOrder.verify(nodeStateListener, timeout(500)).onUp(metadataRegularNode);
   }
 
   @After
@@ -552,16 +549,11 @@ public class NodeStateIT {
       Node localMetadataNode1 = metadata.findNode(endPoint1).orElseThrow(AssertionError::new);
       Node localMetadataNode2 = metadata.findNode(endPoint2).orElseThrow(AssertionError::new);
 
-      // The order of the calls is not deterministic because contact points are shuffled, but it
-      // does not matter here since Mockito.verify does not enforce order.
-      verify(localNodeStateListener, timeout(500)).onRemove(nodeCaptor.capture());
-      assertThat(nodeCaptor.getValue().getEndPoint()).isEqualTo(wrongContactPoint);
-      verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
+      // Contact points are not preserved in metadata, so no onRemove for the wrong contact point.
+      // All discovered nodes fire onAdd, then the control node transitions to UP.
+      verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode1);
       verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
-
-      // Note: there might be an additional onDown for wrongContactPoint if it was hit first at
-      // init. This is hard to test since the node was removed later, so we simply don't call
-      // verifyNoMoreInteractions.
+      verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
     }
   }
 
@@ -601,17 +593,21 @@ public class NodeStateIT {
           Node localMetadataNode1 = metadata.findNode(address1).orElseThrow(AssertionError::new);
           Node localMetadataNode2 = metadata.findNode(address2).orElseThrow(AssertionError::new);
           if (localMetadataNode2.getState() == NodeState.DOWN) {
-            // Stopped node was tried first and marked down, that's our target scenario
-            verify(localNodeStateListener, timeout(500)).onDown(localMetadataNode2);
+            // Stopped node was tried first and marked down, that's our target scenario.
+            // All nodes fire onAdd first, then the control node goes UP, and the stopped
+            // node goes DOWN when a connection attempt fails.
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode1);
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
             verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
+            verify(localNodeStateListener, timeout(500)).onDown(localMetadataNode2);
             verify(localNodeStateListener, timeout(500)).onSessionReady(localSession);
-            verifyNoMoreInteractions(localNodeStateListener);
             return;
           } else {
-            // Stopped node was not tried
-            assertThat(localMetadataNode2).isUnknown();
+            // Stopped node was not tried as contact point — it may still be UNKNOWN or
+            // transition to DOWN asynchronously as the pool attempts to connect.
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode1);
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
             verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
-            verifyNoMoreInteractions(localNodeStateListener);
           }
         }
         reset(localNodeStateListener);


### PR DESCRIPTION
## Summary
- Contact points are bootstrap-only addresses for establishing the control connection. By the time `InitialNodeListRefresh` runs, no pools or LBP are initialized, so preserving contact point `DefaultNode` objects serves no purpose.
- Removed `findContactPointNode()` matching logic, `matchedContactPoints` tracking, and `contactPoints` field from `InitialNodeListRefresh`
- All discovered nodes now get fresh `DefaultNode` instances directly from their `NodeInfo`
- The remove/add events for unmatched contact points were harmless at init time since nothing is listening for them

This simplification also removes the endpoint type mismatch problem where `DefaultEndPoint` (contact point) could never match `ClientRoutesEndPoint` (discovered node) via `equals()`.

## Test plan
- [x] `InitialNodeListRefreshTest` (2 tests, rewritten)
- [x] `MetadataManagerTest` (11 tests)