### PR TITLE
fix: re-resolve DNS on each reconnect for hostname-based contact points

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
@@ -19,8 +19,10 @@ package com.datastax.oss.driver.internal.core;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.metadata.HostNameEndPoint;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
+import com.datastax.oss.driver.shaded.guava.common.net.InetAddresses;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -41,18 +43,17 @@ public class ContactPoints {
 
     Set<EndPoint> result = Sets.newHashSet(programmaticContactPoints);
     for (String spec : configContactPoints) {
-      for (InetSocketAddress address : extract(spec, resolve)) {
-        DefaultEndPoint endPoint = new DefaultEndPoint(address);
+      for (EndPoint endPoint : extract(spec, resolve)) {
         boolean wasNew = result.add(endPoint);
         if (!wasNew) {
-          LOG.warn("Duplicate contact point {}", address);
+          LOG.warn("Duplicate contact point {}", endPoint);
         }
       }
     }
     return ImmutableSet.copyOf(result);
   }
 
-  private static Set<InetSocketAddress> extract(String spec, boolean resolve) {
+  private static Set<EndPoint> extract(String spec, boolean resolve) {
     int separator = spec.lastIndexOf(':');
     if (separator < 0) {
       LOG.warn("Ignoring invalid contact point {} (expecting host:port)", spec);
@@ -69,8 +70,9 @@ public class ContactPoints {
       return Collections.emptySet();
     }
     if (!resolve) {
-      return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
-    } else {
+      return ImmutableSet.of(new DefaultEndPoint(InetSocketAddress.createUnresolved(host, port)));
+    } else if (InetAddresses.isInetAddress(host)) {
+      // IP literal: resolve once at startup and cache in DefaultEndPoint
       try {
         InetAddress[] inetAddresses = InetAddress.getAllByName(host);
         if (inetAddresses.length > 1) {
@@ -79,11 +81,22 @@ public class ContactPoints {
               spec,
               Arrays.deepToString(inetAddresses));
         }
-        Set<InetSocketAddress> result = new HashSet<>();
+        Set<EndPoint> result = new HashSet<>();
         for (InetAddress inetAddress : inetAddresses) {
-          result.add(new InetSocketAddress(inetAddress, port));
+          result.add(new DefaultEndPoint(new InetSocketAddress(inetAddress, port)));
         }
         return result;
+      } catch (UnknownHostException e) {
+        LOG.warn("Ignoring invalid contact point {} (unknown host {})", spec, host);
+        return Collections.emptySet();
+      }
+    } else {
+      // Hostname: validate it resolves now, but use HostNameEndPoint so DNS is re-queried on each
+      // reconnect attempt. This allows the driver to pick up a new IP after a node replacement
+      // updates the DNS entry (e.g. in cloud deployments).
+      try {
+        InetAddress.getAllByName(host);
+        return ImmutableSet.of(new HostNameEndPoint(host, port));
       } catch (UnknownHostException e) {
         LOG.warn("Ignoring invalid contact point {} (unknown host {})", spec, host);
         return Collections.emptySet();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/HostNameEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/HostNameEndPoint.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An {@link EndPoint} implementation for hostname-based contact points that re-resolves DNS on
+ * every {@link #resolve()} call. This allows the driver to automatically pick up a new IP address
+ * after a node replacement updates the DNS entry, without requiring a driver restart.
+ *
+ * <p>Contrast with {@link DefaultEndPoint}, which caches the resolved IP at construction time and
+ * never re-queries DNS regardless of how long the driver has been running.
+ *
+ * <p>Note that the JVM maintains its own DNS cache on top of the OS resolver. By default, when no
+ * security manager is installed (the common case in containerized deployments), successful lookups
+ * are cached for 30 seconds ({@code networkaddress.cache.ttl} security property). The effective
+ * recovery time after a DNS change is {@code max(networkaddress.cache.ttl, reconnection backoff)},
+ * so lowering the TTL below the reconnection base delay yields no benefit. Setting it to {@code 0}
+ * disables the JVM DNS cache entirely, causing a live DNS query on every connection attempt.
+ */
+public class HostNameEndPoint implements EndPoint {
+
+  private static final AtomicLong OFFSET = new AtomicLong();
+
+  protected final String hostName;
+  protected final int port;
+
+  public HostNameEndPoint(String hostName, int port) {
+    this.hostName =
+        Objects.requireNonNull(hostName, "hostName can't be null").toLowerCase(Locale.ROOT);
+    this.port = port;
+  }
+
+  @NonNull
+  @Override
+  public InetSocketAddress resolve() {
+    try {
+      InetAddress[] addresses = InetAddress.getAllByName(hostName);
+      if (addresses.length == 0) {
+        // Probably never happens, but the JDK docs don't explicitly say so
+        throw new IllegalArgumentException("Could not resolve contact point hostname " + hostName);
+      }
+      // Sort by IP for a true round-robin (order of getAllByName results is unspecified)
+      Arrays.sort(addresses, IP_COMPARATOR);
+      int index =
+          (addresses.length == 1)
+              ? 0
+              : (int) Math.floorMod(OFFSET.getAndIncrement(), (long) addresses.length);
+      return new InetSocketAddress(addresses[index], port);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Could not resolve contact point hostname " + hostName, e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other instanceof HostNameEndPoint) {
+      HostNameEndPoint that = (HostNameEndPoint) other;
+      return this.hostName.equals(that.hostName) && this.port == that.port;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostName, port);
+  }
+
+  @Override
+  public String toString() {
+    return hostName + ":" + port;
+  }
+
+  @NonNull
+  @Override
+  public String asMetricPrefix() {
+    return hostName.replace('.', '_') + ':' + port;
+  }
+
+  @SuppressWarnings("UnnecessaryLambda")
+  private static final Comparator<InetAddress> IP_COMPARATOR =
+      (InetAddress address1, InetAddress address2) ->
+          UnsignedBytes.lexicographicalComparator()
+              .compare(address1.getAddress(), address2.getAddress());
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/SniEndPoint.java
@@ -17,59 +17,30 @@
  */
 package com.datastax.oss.driver.internal.core.metadata;
 
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
-import com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 
-public class SniEndPoint implements EndPoint {
-  private static final AtomicLong OFFSET = new AtomicLong();
+public class SniEndPoint extends HostNameEndPoint {
 
-  private final InetSocketAddress proxyAddress;
   private final String serverName;
 
   /**
-   * @param proxyAddress the address of the proxy. If it is {@linkplain
-   *     InetSocketAddress#isUnresolved() unresolved}, each call to {@link #resolve()} will
-   *     re-resolve it, fetch all of its A-records, and if there are more than 1 pick one in a
+   * @param proxyAddress the address of the proxy. Each call to {@link #resolve()} will re-resolve
+   *     its hostname, fetch all of its A-records, and if there are more than 1 pick one in a
    *     round-robin fashion.
    * @param serverName the SNI server name. In the context of Cloud, this is the string
    *     representation of the host id.
    */
   public SniEndPoint(InetSocketAddress proxyAddress, String serverName) {
-    this.proxyAddress = Objects.requireNonNull(proxyAddress, "SNI address cannot be null");
+    super(
+        Objects.requireNonNull(proxyAddress, "SNI address cannot be null").getHostName(),
+        proxyAddress.getPort());
     this.serverName = Objects.requireNonNull(serverName, "SNI Server name cannot be null");
   }
 
   public String getServerName() {
     return serverName;
-  }
-
-  @NonNull
-  @Override
-  public InetSocketAddress resolve() {
-    try {
-      InetAddress[] aRecords = InetAddress.getAllByName(proxyAddress.getHostName());
-      if (aRecords.length == 0) {
-        // Probably never happens, but the JDK docs don't explicitly say so
-        throw new IllegalArgumentException(
-            "Could not resolve proxy address " + proxyAddress.getHostName());
-      }
-      // The order of the returned address is unspecified. Sort by IP to make sure we get a true
-      // round-robin
-      Arrays.sort(aRecords, IP_COMPARATOR);
-      int index = (aRecords.length == 1) ? 0 : (int) OFFSET.getAndIncrement() % aRecords.length;
-      return new InetSocketAddress(aRecords[index], proxyAddress.getPort());
-    } catch (UnknownHostException e) {
-      throw new IllegalArgumentException(
-          "Could not resolve proxy address " + proxyAddress.getHostName(), e);
-    }
   }
 
   @Override
@@ -78,7 +49,9 @@ public class SniEndPoint implements EndPoint {
       return true;
     } else if (other instanceof SniEndPoint) {
       SniEndPoint that = (SniEndPoint) other;
-      return this.proxyAddress.equals(that.proxyAddress) && this.serverName.equals(that.serverName);
+      return this.hostName.equals(that.hostName)
+          && this.port == that.port
+          && this.serverName.equals(that.serverName);
     } else {
       return false;
     }
@@ -86,31 +59,19 @@ public class SniEndPoint implements EndPoint {
 
   @Override
   public int hashCode() {
-    return Objects.hash(proxyAddress, serverName);
+    return Objects.hash(hostName, port, serverName);
   }
 
   @Override
   public String toString() {
-    // Note that this uses the original proxy address, so if there are multiple A-records it won't
-    // show which one was selected. If that turns out to be a problem for debugging, we might need
-    // to store the result of resolve() in Connection and log that instead of the endpoint.
-    return proxyAddress.toString() + ":" + serverName;
+    // Note that this uses the hostname rather than a specific resolved IP, so if there are multiple
+    // A-records it won't show which one was selected.
+    return hostName + ":" + port + ":" + serverName;
   }
 
   @NonNull
   @Override
   public String asMetricPrefix() {
-    String hostString = proxyAddress.getHostString();
-    if (hostString == null) {
-      throw new IllegalArgumentException(
-          "Could not extract a host string from provided proxy address " + proxyAddress);
-    }
-    return hostString.replace('.', '_') + ':' + proxyAddress.getPort() + '_' + serverName;
+    return hostName.replace('.', '_') + ':' + port + '_' + serverName;
   }
-
-  @SuppressWarnings("UnnecessaryLambda")
-  private static final Comparator<InetAddress> IP_COMPARATOR =
-      (InetAddress address1, InetAddress address2) ->
-          UnsignedBytes.lexicographicalComparator()
-              .compare(address1.getAddress(), address2.getAddress());
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1161,15 +1161,28 @@ datastax-java-driver {
 
   # Whether to resolve the addresses passed to `basic.contact-points`.
   #
-  # If this is true, addresses are created with `InetSocketAddress(String, int)`: the host name will
-  # be resolved the first time, and the driver will use the resolved IP address for all subsequent
-  # connection attempts.
+  # If this is true (default):
+  # - IP literals are resolved once at startup; the driver reuses that IP for all subsequent
+  #   connection attempts.
+  # - Hostnames (non-IP values) are re-resolved on every connection attempt via
+  #   `InetAddress.getAllByName()`. This lets the driver automatically pick up a new IP address
+  #   after a node replacement updates the DNS entry, without requiring a driver restart. The JVM
+  #   has its own DNS cache (default TTL: 30 seconds when no security manager is installed), so
+  #   the driver may observe the updated IP up to ~30 seconds after the DNS entry changes. To
+  #   reduce that lag, lower the JVM security property `networkaddress.cache.ttl`, either in
+  #   `$JAVA_HOME/conf/security/java.security` or programmatically:
+  #     java.security.Security.setProperty("networkaddress.cache.ttl", "5");
+  #   Note that the effective recovery time after a node replacement is
+  #   max(networkaddress.cache.ttl, reconnection backoff), so tuning the TTL below the
+  #   reconnection base delay yields no benefit. Setting it to 0 disables the JVM DNS cache
+  #   entirely, causing a live DNS query on every connection attempt — this trades lower lag for
+  #   increased DNS load and sensitivity to transient DNS failures.
   #
   # If this is false, addresses are created with `InetSocketAddress.createUnresolved()`: the host
-  # name will be resolved again every time the driver opens a new connection. This is useful for
-  # containerized environments where DNS records are more likely to change over time (note that the
-  # JVM and OS have their own DNS caching mechanisms, so you might need additional configuration
-  # beyond the driver).
+  # name will be resolved every time the driver opens a new connection, with resolution delegated
+  # to Netty's address resolver (which uses `InetAddress.getAllByName()` internally and is
+  # therefore still subject to the JVM DNS cache). Unlike the true case, this also re-resolves
+  # IP literals on every connection, and does not perform round-robin across multiple A-records.
   #
   # This option only applies to the contact points specified in the configuration. It has no effect
   # on:

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
@@ -19,7 +19,6 @@ package com.datastax.oss.driver.internal.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.filter;
-import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 
@@ -29,11 +28,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.metadata.HostNameEndPoint;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Set;
 import org.junit.After;
@@ -100,19 +98,22 @@ public class ContactPointsTest {
   }
 
   @Test
-  public void should_parse_host_and_port_and_resolve_all_a_records() throws UnknownHostException {
-    int localhostARecordsCount = InetAddress.getAllByName("localhost").length;
-    assumeTrue(
-        "This test assumes that localhost resolves to multiple A-records",
-        localhostARecordsCount >= 2);
-
+  public void should_create_hostname_endpoint_for_hostname_contact_point() {
     Set<EndPoint> endPoints =
         ContactPoints.merge(Collections.emptySet(), ImmutableList.of("localhost:9042"), true);
 
-    assertThat(endPoints).hasSize(localhostARecordsCount);
-    assertLog(
-        Level.INFO,
-        "Contact point localhost:9042 resolves to multiple addresses, will use them all");
+    assertThat(endPoints).hasSize(1);
+    assertThat(endPoints.iterator().next()).isInstanceOf(HostNameEndPoint.class);
+    assertThat(endPoints).containsExactly(new HostNameEndPoint("localhost", 9042));
+  }
+
+  @Test
+  public void should_create_default_endpoint_for_ip_contact_point() {
+    Set<EndPoint> endPoints =
+        ContactPoints.merge(Collections.emptySet(), ImmutableList.of("127.0.0.1:9042"), true);
+
+    assertThat(endPoints).hasSize(1);
+    assertThat(endPoints.iterator().next()).isInstanceOf(DefaultEndPoint.class);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/HostNameEndPointTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/HostNameEndPointTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class HostNameEndPointTest {
+
+  @Test
+  public void should_return_resolved_address() {
+    HostNameEndPoint endPoint = new HostNameEndPoint("localhost", 9042);
+
+    InetSocketAddress address = endPoint.resolve();
+
+    assertThat(address).isNotNull();
+    assertThat(address.getPort()).isEqualTo(9042);
+    assertThat(address.isUnresolved()).isFalse();
+  }
+
+  @Test
+  public void should_perform_dns_lookup_on_each_resolve_call() throws Exception {
+    // Re-resolution is structural: resolve() calls InetAddress.getAllByName() every time
+    // with no cached field. We verify this by calling resolve() twice and confirming both
+    // calls succeed and return consistent results (same host, same port), which would fail
+    // if DNS were broken after the first call.
+    HostNameEndPoint endPoint = new HostNameEndPoint("localhost", 9042);
+
+    InetSocketAddress address1 = endPoint.resolve();
+    InetSocketAddress address2 = endPoint.resolve();
+
+    assertThat(address1.getPort()).isEqualTo(9042);
+    assertThat(address2.getPort()).isEqualTo(9042);
+    assertThat(address1.isUnresolved()).isFalse();
+    assertThat(address2.isUnresolved()).isFalse();
+    // Both resolved addresses must belong to localhost
+    assertThat(address1.getAddress().isLoopbackAddress()).isTrue();
+    assertThat(address2.getAddress().isLoopbackAddress()).isTrue();
+  }
+
+  @Test
+  public void should_throw_on_resolve_if_hostname_unknown() {
+    HostNameEndPoint endPoint = new HostNameEndPoint("this-host-does-not-exist.invalid", 9042);
+
+    assertThatThrownBy(endPoint::resolve)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("this-host-does-not-exist.invalid");
+  }
+
+  @Test
+  public void should_normalize_hostname_to_lowercase() {
+    HostNameEndPoint endPoint = new HostNameEndPoint("MyHost.Example.COM", 9042);
+
+    assertThat(endPoint.toString()).isEqualTo("myhost.example.com:9042");
+    assertThat(endPoint.asMetricPrefix()).isEqualTo("myhost_example_com:9042");
+  }
+
+  @Test
+  public void should_implement_equals_based_on_hostname_and_port() {
+    HostNameEndPoint ep1 = new HostNameEndPoint("localhost", 9042);
+    HostNameEndPoint ep2 = new HostNameEndPoint("localhost", 9042);
+    HostNameEndPoint ep3 = new HostNameEndPoint("localhost", 9043);
+    HostNameEndPoint ep4 = new HostNameEndPoint("otherhost", 9042);
+
+    assertThat(ep1).isEqualTo(ep2);
+    assertThat(ep1).isNotEqualTo(ep3);
+    assertThat(ep1).isNotEqualTo(ep4);
+    assertThat(ep1).isNotEqualTo(new DefaultEndPoint(new InetSocketAddress("localhost", 9042)));
+  }
+
+  @Test
+  public void should_implement_hashcode_consistently_with_equals() {
+    HostNameEndPoint ep1 = new HostNameEndPoint("localhost", 9042);
+    HostNameEndPoint ep2 = new HostNameEndPoint("localhost", 9042);
+
+    assertThat(ep1.hashCode()).isEqualTo(ep2.hashCode());
+  }
+
+  @Test
+  public void should_be_equal_regardless_of_input_case() {
+    HostNameEndPoint ep1 = new HostNameEndPoint("MyHost", 9042);
+    HostNameEndPoint ep2 = new HostNameEndPoint("myhost", 9042);
+
+    assertThat(ep1).isEqualTo(ep2);
+    assertThat(ep1.hashCode()).isEqualTo(ep2.hashCode());
+  }
+
+  @Test
+  public void should_format_toString() {
+    HostNameEndPoint endPoint = new HostNameEndPoint("node-0.example.com", 9042);
+
+    assertThat(endPoint.toString()).isEqualTo("node-0.example.com:9042");
+  }
+
+  @Test
+  public void should_format_metric_prefix() {
+    HostNameEndPoint endPoint = new HostNameEndPoint("node-0.example.com", 9042);
+
+    assertThat(endPoint.asMetricPrefix()).isEqualTo("node-0_example_com:9042");
+  }
+}

--- a/manual/core/README.md
+++ b/manual/core/README.md
@@ -125,6 +125,28 @@ datastax-java-driver {
 For more details about the local datacenter, refer to the [load balancing
 policy](load_balancing/#local-only) section.
 
+When a contact point is specified as a hostname (rather than an IP literal), the driver re-resolves
+it via DNS on every connection attempt. This allows the driver to automatically pick up a new IP
+address after a node replacement updates the DNS entry, without requiring a restart. However, the
+JVM maintains its own DNS cache: by default (when no security manager is installed) successful
+lookups are cached for 30 seconds, so there may be a lag before the updated IP is used.
+
+To reduce the lag, lower the JVM security property `networkaddress.cache.ttl` in
+`$JAVA_HOME/conf/security/java.security` or programmatically before building the session:
+
+```java
+java.security.Security.setProperty("networkaddress.cache.ttl", "5");
+```
+
+The effective recovery time after a node replacement is
+`max(networkaddress.cache.ttl, reconnection backoff)`, so there is no benefit to setting the TTL
+lower than your reconnection base delay. Setting it to `0` disables the JVM DNS cache entirely,
+causing a live DNS query on every connection attempt — this minimises lag but increases DNS load
+and makes reconnection sensitive to transient DNS failures.
+
+See also the `advanced.resolve-contact-points` option in the
+[configuration reference](configuration/reference/) for further details.
+
 ##### Keyspace
 
 By default, a session isn't tied to any specific keyspace. You'll need to prefix table names in your


### PR DESCRIPTION
## Problem

When a ScyllaDB node is replaced, the replacement gets a new IP address. For clusters accessed via DNS-based contact points (e.g. `node-0.gce-us-west-1.<cluster-id>.clusters.scylla.cloud`), the DNS entry is updated to point to the new IP. However, the driver resolves DNS **once at startup** and caches the result in `DefaultEndPoint`. All subsequent reconnect attempts use the stale IP, causing perpetual `ConnectionInitException` errors until the driver is restarted.

**Error observed (CUSTOMER-258):**
```
[tc2|node-0.../172.21.3.213:19042] Error while opening new channel (ConnectionInitException: ... failed to send request)
```
Node replaced: DNS `node-0` updated from `172.21.3.213` → `172.21.3.216`. Driver kept reconnecting to old IP indefinitely.

**Root cause:** `ContactPoints.extract()` (when `resolve=true`) calls `InetAddress.getAllByName(host)` once and stores resolved IPs in `DefaultEndPoint` objects. `DefaultEndPoint.resolve()` returns the cached `InetSocketAddress` — it never re-queries DNS. Contrast with `SniEndPoint.resolve()`, which re-resolves DNS on every call (used for Cloud/SNI deployments).

## Solution

Introduce `HostNameEndPoint`, a new internal `EndPoint` implementation modelled after `SniEndPoint`. It stores the original hostname and re-resolves DNS on each `resolve()` call, allowing the driver to automatically pick up a new IP after DNS changes.

`ContactPoints.extract()` now uses `InetAddresses.isInetAddress()` to distinguish IP literals from hostnames:
- **IP literal** → existing behavior: resolve once, create `DefaultEndPoint`
- **Hostname** → validate resolves at startup (warn and skip if unknown host), then create `HostNameEndPoint` for dynamic re-resolution on each reconnect

## Changes

- `core/.../metadata/HostNameEndPoint.java` _(new)_ — EndPoint that re-resolves DNS on every `resolve()` call, with round-robin among multiple A-records (same pattern as `SniEndPoint`)
- `core/.../ContactPoints.java` — detect hostname vs IP literal; create `HostNameEndPoint` for hostnames
- `core/.../metadata/HostNameEndPointTest.java` _(new)_ — unit tests for `HostNameEndPoint`
- `core/.../ContactPointsTest.java` — add cases verifying hostname → `HostNameEndPoint`, IP → `DefaultEndPoint`

## Notes

- JVM DNS cache TTL affects how quickly re-resolution picks up changes. Users should set `networkaddress.cache.ttl=30` (or appropriate value) in the JVM security properties.
- The `resolve=false` path is unaffected (already preserves hostname via `InetSocketAddress.createUnresolved()`).
- Related commits on `scylla-4.x` (`e30a07d`, `2a6fb7c`) addressed downstream symptoms of this bug (schema refresh deadlock, control node fallback); this PR fixes the root DNS caching issue.