### PR TITLE
Resolve control node identity via system.local before initial metadata refresh

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
@@ -272,6 +272,10 @@ public final class ClientRoutesConfig {
      */
     @NonNull
     public Builder withNativeTransportPort(int port) {
+      if (port <= 0 || port > 65535) {
+        throw new IllegalArgumentException(
+            "Native transport port must be between 1 and 65535, got " + port);
+      }
       this.nativeTransportPort = port;
       return this;
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
@@ -33,6 +34,7 @@ import com.datastax.oss.driver.internal.core.channel.EventCallback;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.ClientRoutesTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.ClientRoutesUpdateEvent;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.DefaultTopologyMonitor;
 import com.datastax.oss.driver.internal.core.metadata.DistanceEvent;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
@@ -59,6 +61,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -144,6 +147,14 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
    */
   public DriverChannel channel() {
     return channel;
+  }
+
+  /**
+   * The node currently associated with the control channel, or {@code null} if the control
+   * connection is not established or the node has not been resolved yet.
+   */
+  public Node controlNode() {
+    return singleThreaded.controlNodeState.current;
   }
 
   /**
@@ -266,6 +277,7 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     private final ReconnectionPolicy reconnectionPolicy;
     private final Reconnection reconnection;
     private DriverChannelOptions channelOptions;
+    private volatile ControlNodeState controlNodeState = ControlNodeState.NONE;
     // The last events received for each node
     private final Map<Node, NodeDistance> lastNodeDistance = new WeakHashMap<>();
     private final Map<Node, NodeState> lastNodeState = new WeakHashMap<>();
@@ -363,7 +375,9 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
             result.complete(true);
             onSuccessfulReconnect();
           },
-          error -> result.complete(false));
+          error -> {
+            result.complete(false);
+          });
       return result;
     }
 
@@ -446,38 +460,56 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                       LOG.debug("[{}] New channel opened {}", logPrefix, channel);
                       DriverChannel previousChannel = ControlConnection.this.channel;
                       ControlConnection.this.channel = channel;
-                      if (previousChannel != null) {
-                        // We were reconnecting: make sure previous channel gets closed (it may
-                        // still be open if reconnection was forced)
+                      controlNodeState = new ControlNodeState(null, node);
+                      if (previousChannel != null && previousChannel != channel) {
                         LOG.debug(
                             "[{}] Forcefully closing previous channel {}",
                             logPrefix,
                             previousChannel);
                         previousChannel.forceClose();
                       }
-                      resolveChannelNodeInfo(channel)
+                      resolveChannelNodeIfNeeded(channel, (DefaultNode) node)
                           .whenCompleteAsync(
-                              (ignored, fetchError) -> {
+                              (resolvedNode, fetchError) -> {
                                 if (fetchError != null) {
+                                  controlNodeState = ControlNodeState.NONE;
                                   LOG.debug(
                                       "[{}] Failed to resolve control node endpoint from {}, "
                                           + "trying next node",
                                       logPrefix,
                                       node,
                                       fetchError);
+                                  // Null out before forceClose() so that onChannelClosed() does not
+                                  // start a redundant reconnection on top of the connect() retry
+                                  // below.
+                                  ControlConnection.this.channel = null;
                                   channel.forceClose();
                                   List<Entry<Node, Throwable>> newErrors =
                                       (errors == null) ? new ArrayList<>() : errors;
                                   newErrors.add(new SimpleEntry<>(node, fetchError));
                                   connect(nodes, newErrors, onSuccess, onFailure);
+                                } else if (channel.closeFuture().isDone()) {
+                                  controlNodeState = ControlNodeState.NONE;
+                                  ControlConnection.this.channel = null;
+                                  List<Entry<Node, Throwable>> newErrors =
+                                      (errors == null) ? new ArrayList<>() : errors;
+                                  newErrors.add(
+                                      new SimpleEntry<>(
+                                          node,
+                                          new Exception("Channel closed during endpoint resolve")));
+                                  connect(nodes, newErrors, onSuccess, onFailure);
                                 } else {
-                                  context.getEventBus().fire(ChannelEvent.channelOpened(node));
+                                  controlNodeState = new ControlNodeState(resolvedNode, null);
+                                  context
+                                      .getEventBus()
+                                      .fire(ChannelEvent.channelOpened(resolvedNode));
                                   channel
                                       .closeFuture()
                                       .addListener(
                                           f ->
                                               adminExecutor
-                                                  .submit(() -> onChannelClosed(channel, node))
+                                                  .submit(
+                                                      () -> onChannelClosed(channel, resolvedNode))
                                                   .addListener(UncaughtExceptions::log));
                                   onSuccess.run();
                                 }
@@ -497,90 +529,127 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     }
 
     /**
-     * Resolves the identity of the node at the other end of the channel via the topology monitor,
-     * then updates the channel's endpoint.
+     * Resolves the identity of the node at the other end of the channel. For contact point nodes
+     * (no hostId), queries system.local and registers a new metadata node. For nodes that already
+     * have a hostId, returns the node as-is.
      */
-    private CompletionStage<Void> resolveChannelNodeInfo(DriverChannel channel) {
+    private CompletionStage<Node> resolveChannelNodeIfNeeded(
+        DriverChannel channel, DefaultNode node) {
+      if (node.getHostId() != null) {
+        return CompletableFuture.completedFuture(node);
+      }
       return context
           .getTopologyMonitor()
-          .getChannelEndpoint(channel)
-          .thenAccept(
-              endPoint -> {
-                if (!endPoint.equals(channel.getEndPoint())) {
-                  channel.setEndPoint(endPoint);
-                  LOG.debug("[{}] Control channel endpoint upgraded to {}", logPrefix, endPoint);
+          .getChannelNodeInfo(channel)
+          .thenComposeAsync(
+              nodeInfo -> {
+                EndPoint resolvedEp = nodeInfo.getEndPoint();
+                if (resolvedEp != null && !resolvedEp.equals(channel.getEndPoint())) {
+                  channel.setEndPoint(resolvedEp);
+                  LOG.debug("[{}] Control channel endpoint upgraded to {}", logPrefix, resolvedEp);
                 }
-              });
+                return context.getMetadataManager().registerNode(nodeInfo);
+              },
+              adminExecutor);
     }
 
     private void onSuccessfulReconnect() {
+      assert adminExecutor.inEventLoop();
       // If reconnectOnFailure was true and we've never connected before, complete the future now to
-      // signal that the initialization is complete.
+      // signal that the initialization is complete. Schema refresh and LBP initialization for the
+      // first connection are handled by the session initialization path (DefaultSession.init), not
+      // here, so we skip the full refresh below.
       boolean isFirstConnection = initFuture.complete(null);
+      if (isFirstConnection) {
+        return;
+      }
 
       // Otherwise, perform a full refresh (we don't know how long we were disconnected)
-      if (!isFirstConnection) {
-        // If client routes are active, wait for the routes refresh to complete before refreshing
-        // nodes, so that buildNodeEndPoint sees up-to-date route data.
-        CompletionStage<Void> routesReady;
-        if (context.getTopologyMonitor() instanceof ClientRoutesTopologyMonitor) {
-          routesReady = ((ClientRoutesTopologyMonitor) context.getTopologyMonitor()).refresh();
-        } else {
-          routesReady = CompletableFuture.completedFuture(null);
-        }
-
-        routesReady.whenComplete(
-            (routesResult, routesError) -> {
-              if (routesError != null) {
-                LOG.debug(
-                    "[{}] Error while refreshing client routes on reconnect",
-                    logPrefix,
-                    routesError);
-              }
-              context
-                  .getMetadataManager()
-                  .refreshNodes()
-                  .whenComplete(
-                      (result, error) -> {
-                        if (error != null) {
-                          LOG.debug("[{}] Error while refreshing node list", logPrefix, error);
-                        } else {
-                          try {
-                            // A failed node list refresh at startup is not fatal, so this might
-                            // be the first successful refresh; make sure the LBP gets initialized
-                            // (this is a no-op if it was initialized already).
-                            context.getLoadBalancingPolicyWrapper().init();
-                            context
-                                .getMetadataManager()
-                                .refreshSchema(null, false, true)
-                                .whenComplete(
-                                    (metadata, schemaError) -> {
-                                      if (schemaError != null) {
-                                        Loggers.warnWithException(
-                                            LOG,
-                                            "[{}] Unexpected error while refreshing schema after"
-                                                + " a successful reconnection, keeping previous"
-                                                + " version",
-                                            logPrefix,
-                                            schemaError);
-                                      }
-                                    });
-                          } catch (Throwable t) {
-                            Loggers.warnWithException(
-                                LOG,
-                                "[{}] Unexpected error on control connection reconnect",
-                                logPrefix,
-                                t);
-                          }
-                        }
-                      });
-            });
+      // If client routes are active, wait for the routes refresh to complete before refreshing
+      // nodes, so that buildNodeEndPoint sees up-to-date route data.
+      CompletionStage<Void> routesReady;
+      if (context.getTopologyMonitor() instanceof ClientRoutesTopologyMonitor) {
+        routesReady = ((ClientRoutesTopologyMonitor) context.getTopologyMonitor()).refresh();
+      } else {
+        routesReady = CompletableFuture.completedFuture(null);
       }
+
+      routesReady.whenComplete(
+          (routesResult, routesError) -> {
+            if (routesError != null) {
+              LOG.debug(
+                  "[{}] Error while refreshing client routes on reconnect", logPrefix, routesError);
+            }
+            context
+                .getMetadataManager()
+                .refreshNodes()
+                .whenCompleteAsync(
+                    (result, error) -> {
+                      assert adminExecutor.inEventLoop();
+                      if (error != null) {
+                        LOG.debug("[{}] Error while refreshing node list", logPrefix, error);
+                      } else {
+                        try {
+                          // A failed node list refresh at startup is not fatal, so this might
+                          // be the first successful refresh; make sure the LBP gets initialized
+                          // (this is a no-op if it was initialized already).
+                          context.getLoadBalancingPolicyWrapper().init();
+                          Node controlNode = controlNodeState.current;
+                          if (controlNode != null && controlNode.getHostId() != null) {
+                            if (!context
+                                .getMetadataManager()
+                                .getMetadata()
+                                .getNodes()
+                                .containsKey(controlNode.getHostId())) {
+                              LOG.debug(
+                                  "[{}] Control node {} is no longer in metadata after "
+                                      + "reconnect refresh, triggering reconnection",
+                                  logPrefix,
+                                  controlNode);
+                              controlNodeState = ControlNodeState.NONE;
+                              DriverChannel ch = ControlConnection.this.channel;
+                              ControlConnection.this.channel = null;
+                              if (ch != null) {
+                                ch.forceClose();
+                              }
+                              reconnection.start();
+                              return;
+                            }
+                          }
+                          context
+                              .getMetadataManager()
+                              .refreshSchema(null, false, true)
+                              .whenComplete(
+                                  (metadata, schemaError) -> {
+                                    if (schemaError != null) {
+                                      Loggers.warnWithException(
+                                          LOG,
+                                          "[{}] Unexpected error while refreshing schema after"
+                                              + " a successful reconnection, keeping previous"
+                                              + " version",
+                                          logPrefix,
+                                          schemaError);
+                                    }
+                                  });
+                        } catch (Throwable t) {
+                          Loggers.warnWithException(
+                              LOG,
+                              "[{}] Unexpected error on control connection reconnect",
+                              logPrefix,
+                              t);
+                        }
+                      }
+                    },
+                    adminExecutor);
+          });
     }
 
     private void onChannelClosed(DriverChannel channel, Node node) {
       assert adminExecutor.inEventLoop();
       if (!closeWasCalled) {
+        if (channel == ControlConnection.this.channel) {
+          controlNodeState = ControlNodeState.NONE;
+        }
         context.getEventBus().fire(ChannelEvent.channelClosed(node));
         // If this channel is the current control channel, we must start a
         // reconnection attempt to get a new control channel.
@@ -606,13 +675,28 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       }
     }
 
+    private boolean isControlNode(Node eventNode) {
+      ControlNodeState state = controlNodeState;
+      if (state.current != null
+          && eventNode.getHostId() != null
+          && eventNode.getHostId().equals(state.current.getHostId())) {
+        return true;
+      }
+      if (state.current == null
+          && state.pending != null
+          && Objects.equals(eventNode.getEndPoint(), state.pending.getEndPoint())) {
+        return true;
+      }
+      return false;
+    }
+
     private void onDistanceEvent(DistanceEvent event) {
       assert adminExecutor.inEventLoop();
       this.lastNodeDistance.put(event.node, event.distance);
       if (event.distance == NodeDistance.IGNORED
           && channel != null
           && !channel.closeFuture().isDone()
-          && event.node.getEndPoint().equals(channel.getEndPoint())) {
+          && isControlNode(event.node)) {
         LOG.debug(
             "[{}] Control node {} became IGNORED, reconnecting to a different node",
             logPrefix,
@@ -627,7 +711,7 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       if ((event.newState == null /*(removed)*/ || event.newState == NodeState.FORCED_DOWN)
           && channel != null
           && !channel.closeFuture().isDone()
-          && event.node.getEndPoint().equals(channel.getEndPoint())) {
+          && isControlNode(event.node)) {
         LOG.debug(
             "[{}] Control node {} was removed or forced down, reconnecting to a different node",
             logPrefix,
@@ -679,6 +763,27 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       }
     }
     return true;
+  }
+
+  /**
+   * Immutable snapshot of the control node state. Reads from any thread see a consistent pair of
+   * (current, pending) via a single volatile read of the enclosing reference.
+   */
+  static final class ControlNodeState {
+    static final ControlNodeState NONE = new ControlNodeState(null, null);
+
+    /**
+     * The resolved control node, or {@code null} if resolution is pending or no channel is open.
+     */
+    final Node current;
+
+    /** The node whose channel is open but not yet resolved, or {@code null} otherwise. */
+    final Node pending;
+
+    ControlNodeState(Node current, Node pending) {
+      this.current = current;
+      this.pending = pending;
+    }
   }
 
   private static ImmutableList<String> buildEventTypes(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/InferringLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/InferringLocalDcHelper.java
@@ -17,13 +17,10 @@
  */
 package com.datastax.oss.driver.internal.core.loadbalancing.helper;
 
-import static com.datastax.oss.driver.internal.core.time.Clock.LOG;
-
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashSet;
 import java.util.Map;
@@ -31,17 +28,19 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of {@link LocalDcHelper} that fetches the user-supplied datacenter, if any,
  * from the programmatic configuration API, or else, from the driver configuration. If no local
- * datacenter is explicitly defined, this implementation infers the local datacenter from the
- * contact points: if all contact points share the same datacenter, that datacenter is returned. If
- * the contact points are from different datacenters, or if no contact points reported any
- * datacenter, an {@link IllegalStateException} is thrown.
+ * datacenter is explicitly defined, this implementation tries to infer it from the control
+ * connection endpoint. If that fails, an {@link IllegalStateException} is thrown.
  */
 @ThreadSafe
 public class InferringLocalDcHelper extends OptionalLocalDcHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InferringLocalDcHelper.class);
 
   public InferringLocalDcHelper(
       @NonNull InternalDriverContext context,
@@ -58,9 +57,16 @@ public class InferringLocalDcHelper extends OptionalLocalDcHelper {
     if (optionalLocalDc.isPresent()) {
       return optionalLocalDc;
     }
+    // Infer the local DC from the control connection endpoint
+    Optional<String> dcFromControl = inferDcFromControlConnection(nodes);
+    if (dcFromControl.isPresent()) {
+      LOG.info(
+          "[{}] Inferred local DC from control connection: {}", logPrefix, dcFromControl.get());
+      return dcFromControl;
+    }
+    // Fallback: try to infer from all cluster nodes
     Set<String> datacenters = new HashSet<>();
-    Set<DefaultNode> contactPoints = context.getMetadataManager().getContactPoints();
-    for (Node node : contactPoints) {
+    for (Node node : nodes.values()) {
       String datacenter = node.getDatacenter();
       if (datacenter != null) {
         datacenters.add(datacenter);
@@ -68,21 +74,21 @@ public class InferringLocalDcHelper extends OptionalLocalDcHelper {
     }
     if (datacenters.size() == 1) {
       String localDc = datacenters.iterator().next();
-      LOG.info("[{}] Inferred local DC from contact points: {}", logPrefix, localDc);
+      LOG.info("[{}] Inferred local DC from cluster nodes: {}", logPrefix, localDc);
       return Optional.of(localDc);
     }
     if (datacenters.isEmpty()) {
       throw new IllegalStateException(
-          "The local DC could not be inferred from contact points, please set it explicitly (see "
+          "The local DC could not be inferred from cluster nodes, please set it explicitly (see "
               + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
               + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)");
     }
     throw new IllegalStateException(
         String.format(
-            "No local DC was provided, but the contact points are from different DCs: %s; "
+            "No local DC was provided, but the cluster nodes resolve to nodes in different DCs: %s; "
                 + "please set the local DC explicitly (see "
                 + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
                 + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)",
-            formatNodesAndDcs(contactPoints)));
+            formatNodesAndDcs(nodes.values())));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/MandatoryLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/MandatoryLocalDcHelper.java
@@ -21,11 +21,9 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
@@ -34,14 +32,8 @@ import org.slf4j.LoggerFactory;
 /**
  * An implementation of {@link LocalDcHelper} that fetches the user-supplied datacenter, if any,
  * from the programmatic configuration API, or else, from the driver configuration. If no local
- * datacenter is explicitly defined, this implementation will consider two distinct situations:
- *
- * <ol>
- *   <li>If no explicit contact points were provided, this implementation will infer the local
- *       datacenter from the implicit contact point (localhost).
- *   <li>If explicit contact points were provided however, this implementation will throw {@link
- *       IllegalStateException}.
- * </ol>
+ * datacenter is explicitly defined, this implementation tries to infer it from the control
+ * connection endpoint. If that fails, an {@link IllegalStateException} is thrown.
  */
 @ThreadSafe
 public class MandatoryLocalDcHelper extends OptionalLocalDcHelper {
@@ -63,34 +55,18 @@ public class MandatoryLocalDcHelper extends OptionalLocalDcHelper {
     if (optionalLocalDc.isPresent()) {
       return optionalLocalDc;
     }
-    Set<DefaultNode> contactPoints = context.getMetadataManager().getContactPoints();
-    if (context.getMetadataManager().wasImplicitContactPoint()) {
-      // We only allow automatic inference of the local DC in this specific case
-      assert contactPoints.size() == 1;
-      Node contactPoint = contactPoints.iterator().next();
-      String localDc = contactPoint.getDatacenter();
-      if (localDc != null) {
-        LOG.debug(
-            "[{}] Local DC set from implicit contact point {}: {}",
-            logPrefix,
-            contactPoint,
-            localDc);
-        return Optional.of(localDc);
-      } else {
-        throw new IllegalStateException(
-            "The local DC could not be inferred from implicit contact point, please set it explicitly (see "
-                + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
-                + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter)");
-      }
-    } else {
-      throw new IllegalStateException(
-          "Since you provided explicit contact points, the local DC must be explicitly set (see "
-              + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
-              + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter). "
-              + "Current contact points are: "
-              + formatNodesAndDcs(contactPoints)
-              + ". Current DCs in this cluster are: "
-              + formatDcs(nodes.values()));
+    // Infer the local DC from the control connection endpoint
+    Optional<String> dcFromControl = inferDcFromControlConnection(nodes);
+    if (dcFromControl.isPresent()) {
+      LOG.debug("[{}] Local DC set from control connection: {}", logPrefix, dcFromControl.get());
+      return dcFromControl;
     }
+    throw new IllegalStateException(
+        "Could not infer the local DC from the control connection, "
+            + "the local DC must be explicitly set (see "
+            + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
+            + " in the config, or set it programmatically with SessionBuilder.withLocalDatacenter). "
+            + "Current DCs in this cluster are: "
+            + formatDcs(nodes.values()));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
@@ -19,11 +19,13 @@ package com.datastax.oss.driver.internal.core.loadbalancing.helper;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,52 +70,78 @@ public class OptionalLocalDcHelper implements LocalDcHelper {
     String localDc = context.getLocalDatacenter(profile.getName());
     if (localDc != null) {
       LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDc);
-      checkLocalDatacenterCompatibility(localDc, context.getMetadataManager().getContactPoints());
-      return Optional.of(localDc);
     } else if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)) {
       localDc = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
       LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDc);
-      checkLocalDatacenterCompatibility(localDc, context.getMetadataManager().getContactPoints());
-      return Optional.of(localDc);
     } else {
       LOG.debug("[{}] Local DC not set, DC awareness will be disabled", logPrefix);
       return Optional.empty();
     }
-  }
-
-  /**
-   * Checks if the contact points are compatible with the local datacenter specified either through
-   * configuration, or programmatically.
-   *
-   * <p>The default implementation logs a warning when a contact point reports a datacenter
-   * different from the local one, and only for the default profile.
-   *
-   * @param localDc The local datacenter, as specified in the config, or programmatically.
-   * @param contactPoints The contact points provided when creating the session.
-   */
-  protected void checkLocalDatacenterCompatibility(
-      @NonNull String localDc, Set<? extends Node> contactPoints) {
-    if (profile.getName().equals(DriverExecutionProfile.DEFAULT_NAME)) {
-      Set<Node> badContactPoints = new LinkedHashSet<>();
-      for (Node node : contactPoints) {
-        if (!Objects.equals(localDc, node.getDatacenter())) {
-          badContactPoints.add(node);
+    if (!nodes.isEmpty()) {
+      boolean found = false;
+      for (Node node : nodes.values()) {
+        if (localDc.equals(node.getDatacenter())) {
+          found = true;
+          break;
         }
       }
-      if (!badContactPoints.isEmpty()) {
+      if (!found) {
         LOG.warn(
-            "[{}] You specified {} as the local DC, but some contact points are from a different DC: {}; "
-                + "please provide the correct local DC, or check your contact points",
+            "[{}] Configured local DC '{}' does not match any node's datacenter"
+                + " (available DCs: {}); please verify your configuration",
             logPrefix,
             localDc,
-            formatNodesAndDcs(badContactPoints));
+            formatDcs(nodes.values()));
       }
     }
+    return Optional.of(localDc);
   }
 
   /**
-   * Formats the given nodes as a string detailing each contact point and its datacenter, for
-   * informational purposes.
+   * Infers the local datacenter from the control connection endpoint by matching it against nodes
+   * in metadata.
+   *
+   * <p>If multiple nodes share the same endpoint (e.g., behind an NLB or proxy) and they belong to
+   * different datacenters, this method logs a warning and returns empty rather than picking an
+   * arbitrary datacenter.
+   *
+   * @return the datacenter of the node matching the control connection endpoint, or empty if no
+   *     match was found or if the match is ambiguous across multiple DCs.
+   */
+  @NonNull
+  protected Optional<String> inferDcFromControlConnection(@NonNull Map<UUID, Node> nodes) {
+    Node controlNode = context.getControlConnection().controlNode();
+    if (controlNode != null && controlNode.getHostId() != null) {
+      Node metadataNode = nodes.get(controlNode.getHostId());
+      if (metadataNode != null && metadataNode.getDatacenter() != null) {
+        return Optional.of(metadataNode.getDatacenter());
+      }
+    }
+    DriverChannel channel = context.getControlConnection().channel();
+    if (channel != null) {
+      EndPoint controlEndpoint = channel.getEndPoint();
+      Set<String> candidateDcs = new HashSet<>();
+      for (Node node : nodes.values()) {
+        if (node.getDatacenter() != null && Objects.equals(controlEndpoint, node.getEndPoint())) {
+          candidateDcs.add(node.getDatacenter());
+        }
+      }
+      if (candidateDcs.size() == 1) {
+        return Optional.of(candidateDcs.iterator().next());
+      } else if (candidateDcs.size() > 1) {
+        LOG.warn(
+            "[{}] Control endpoint {} matches nodes in multiple DCs: {}, skipping inference",
+            logPrefix,
+            controlEndpoint,
+            candidateDcs);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Formats the given nodes as a string detailing each node and its datacenter, for informational
+   * purposes.
    */
   @NonNull
   protected String formatNodesAndDcs(Iterable<? extends Node> nodes) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
@@ -75,16 +75,24 @@ public class DefaultNode implements Node, Serializable {
   private volatile ShardingInfo shardingInfo;
 
   public DefaultNode(EndPoint endPoint, InternalDriverContext context) {
+    this(endPoint, context, true);
+  }
+
+  private DefaultNode(EndPoint endPoint, InternalDriverContext context, boolean metrics) {
     this.endPoint = endPoint;
     this.state = NodeState.UNKNOWN;
     this.distance = NodeDistance.IGNORED;
     this.rawTokens = Collections.emptySet();
     this.extras = Collections.emptyMap();
-    // We leak a reference to a partially constructed object (this), but in practice this won't be a
-    // problem because the node updater only needs the connect address to initialize.
-    this.metricUpdater = context.getMetricsFactory().newNodeUpdater(this);
+    this.metricUpdater =
+        metrics ? context.getMetricsFactory().newNodeUpdater(this) : NoopNodeMetricUpdater.INSTANCE;
     this.upSinceMillis = -1;
     this.shardingInfo = null;
+  }
+
+  /** Creates a contact point node without registering metrics. */
+  public static DefaultNode newContactPoint(EndPoint endPoint, InternalDriverContext context) {
+    return new DefaultNode(endPoint, context, false);
   }
 
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
@@ -96,11 +96,12 @@ public class DefaultNode implements Node, Serializable {
   public void setEndPoint(@NonNull EndPoint newEndPoint, @NonNull InternalDriverContext context) {
     if (!newEndPoint.equals(endPoint)) {
       endPoint = newEndPoint;
-
-      // The endpoint is also used to build metric names, so make sure they get updated
+      // metricUpdater is transient, so it can be null on deserialized nodes.
       NodeMetricUpdater previousMetricUpdater = metricUpdater;
-      if (!(previousMetricUpdater instanceof NoopNodeMetricUpdater)) {
+      if (previousMetricUpdater != null
+          && !(previousMetricUpdater instanceof NoopNodeMetricUpdater)) {
         metricUpdater = context.getMetricsFactory().newNodeUpdater(this);
+        previousMetricUpdater.clearMetrics();
       }
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -165,7 +165,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   }
 
   @Override
-  public CompletionStage<EndPoint> getChannelEndpoint(DriverChannel channel) {
+  public CompletionStage<NodeInfo> getChannelNodeInfo(DriverChannel channel) {
     if (closeFuture.isDone()) {
       return CompletableFutures.failedFuture(new IllegalStateException("closed"));
     }
@@ -176,12 +176,12 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
               Iterator<AdminRow> iterator = result.iterator();
               if (!iterator.hasNext()) {
                 throw new IllegalStateException(
-                    "Expected a row in system.local for endpoint resolution, got empty result");
+                    "Expected a row in system.local for node info resolution, got empty result");
               }
               AdminRow localRow = iterator.next();
               InetSocketAddress broadcastRpcAddress =
                   getBroadcastRpcAddress(localRow, localEndPoint);
-              return buildNodeEndPoint(localRow, broadcastRpcAddress, localEndPoint);
+              return nodeInfoBuilder(localRow, broadcastRpcAddress, localEndPoint).build();
             });
   }
 
@@ -382,7 +382,10 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
             .withCassandraVersion(row.getString("release_version"))
             .withTokens(row.getSetOfString("tokens"))
             .withPartitioner(row.getString("partitioner"))
-            .withHostId(Objects.requireNonNull(row.getUuid("host_id")))
+            .withHostId(
+                Objects.requireNonNull(
+                    row.getUuid("host_id"),
+                    "host_id is null in system.local, node may still be bootstrapping"))
             .withSchemaVersion(row.getUuid("schema_version"));
 
     // Handle DSE-specific columns, if present

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
@@ -17,27 +17,24 @@
  */
 package com.datastax.oss.driver.internal.core.metadata;
 
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The first node list refresh: contact points are not in the metadata yet, we need to copy them
- * over.
+ * The first node list refresh: creates new nodes from the discovered node list, reusing any node
+ * already in metadata (e.g. the control node registered by the control connection) so that
+ * connection state is preserved.
  */
 @ThreadSafe
 class InitialNodeListRefresh extends NodesRefresh {
@@ -45,11 +42,9 @@ class InitialNodeListRefresh extends NodesRefresh {
   private static final Logger LOG = LoggerFactory.getLogger(InitialNodeListRefresh.class);
 
   @VisibleForTesting final Iterable<NodeInfo> nodeInfos;
-  @VisibleForTesting final Set<DefaultNode> contactPoints;
 
-  InitialNodeListRefresh(Iterable<NodeInfo> nodeInfos, Set<DefaultNode> contactPoints) {
+  InitialNodeListRefresh(Iterable<NodeInfo> nodeInfos) {
     this.nodeInfos = nodeInfos;
-    this.contactPoints = contactPoints;
   }
 
   @Override
@@ -59,16 +54,15 @@ class InitialNodeListRefresh extends NodesRefresh {
     String logPrefix = context.getSessionName();
     TokenFactoryRegistry tokenFactoryRegistry = context.getTokenFactoryRegistry();
 
-    // Since this is the first refresh, and we've stored contact points separately until now, the
-    // metadata is empty.
-    assert oldMetadata == DefaultMetadata.EMPTY;
     TokenFactory tokenFactory = null;
 
+    Map<UUID, DefaultNode> existingByHostId = new HashMap<>();
+    for (Node n : oldMetadata.getNodes().values()) {
+      existingByHostId.put(n.getHostId(), (DefaultNode) n);
+    }
+
     Map<UUID, DefaultNode> newNodes = new HashMap<>();
-    // Contact point nodes don't have host ID as well as other info yet, so we fill them with node
-    // info found on first match by endpoint
-    Set<EndPoint> matchedContactPoints = new HashSet<>();
-    List<DefaultNode> addedNodes = new ArrayList<>();
+    ImmutableList.Builder<Object> eventsBuilder = ImmutableList.builder();
 
     for (NodeInfo nodeInfo : nodeInfos) {
       UUID hostId = nodeInfo.getHostId();
@@ -80,17 +74,15 @@ class InitialNodeListRefresh extends NodesRefresh {
             hostId,
             newNodes.get(hostId));
       } else {
-        EndPoint endPoint = nodeInfo.getEndPoint();
-        DefaultNode contactPointNode = findContactPointNode(endPoint);
         DefaultNode node;
-        if (contactPointNode == null || matchedContactPoints.contains(endPoint)) {
-          node = new DefaultNode(endPoint, context);
-          addedNodes.add(node);
-          LOG.debug("[{}] Adding new node {}", logPrefix, node);
+        DefaultNode existing = existingByHostId.get(hostId);
+        if (existing != null) {
+          node = existing;
+          LOG.debug("[{}] Reusing existing node {}", logPrefix, node);
         } else {
-          matchedContactPoints.add(contactPointNode.getEndPoint());
-          node = contactPointNode;
-          LOG.debug("[{}] Copying contact point {}", logPrefix, node);
+          node = new DefaultNode(nodeInfo.getEndPoint(), context);
+          LOG.debug("[{}] Adding new node {}", logPrefix, node);
+          eventsBuilder.add(NodeStateEvent.added(node));
         }
         if (tokenMapEnabled && tokenFactory == null && nodeInfo.getPartitioner() != null) {
           tokenFactory = tokenFactoryRegistry.tokenFactoryFor(nodeInfo.getPartitioner());
@@ -100,13 +92,13 @@ class InitialNodeListRefresh extends NodesRefresh {
       }
     }
 
-    ImmutableList.Builder<Object> eventsBuilder = ImmutableList.builder();
-    for (DefaultNode addedNode : addedNodes) {
-      eventsBuilder.add(NodeStateEvent.added(addedNode));
-    }
-    for (DefaultNode contactPoint : contactPoints) {
-      if (!matchedContactPoints.contains(contactPoint.getEndPoint())) {
-        eventsBuilder.add(NodeStateEvent.removed(contactPoint));
+    for (Map.Entry<UUID, DefaultNode> entry : existingByHostId.entrySet()) {
+      if (!newNodes.containsKey(entry.getKey())) {
+        LOG.warn(
+            "[{}] Pre-registered node {} was not found in the node list refresh",
+            logPrefix,
+            entry.getValue());
+        eventsBuilder.add(NodeStateEvent.removed(entry.getValue()));
       }
     }
 
@@ -114,14 +106,5 @@ class InitialNodeListRefresh extends NodesRefresh {
         oldMetadata.withNodes(
             ImmutableMap.copyOf(newNodes), tokenMapEnabled, true, tokenFactory, context),
         eventsBuilder.build());
-  }
-
-  private DefaultNode findContactPointNode(EndPoint endPoint) {
-    for (DefaultNode node : contactPoints) {
-      if (node.getEndPoint().equals(endPoint)) {
-        return node;
-      }
-    }
-    return null;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -175,7 +175,7 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
       Set<DefaultNode> originalNodes = context.getMetadataManager().getContactPoints();
       List<Node> nodes = new ArrayList<>();
       for (DefaultNode node : originalNodes) {
-        nodes.add(new DefaultNode(node.getEndPoint(), context));
+        nodes.add(DefaultNode.newContactPoint(node.getEndPoint(), context));
       }
       Collections.shuffle(nodes);
       return new ConcurrentLinkedQueue<>(nodes);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -150,10 +150,10 @@ public class MetadataManager implements AsyncAutoCloseable {
       LOG.info(
           "[{}] No contact points provided, defaulting to {}", logPrefix, DEFAULT_CONTACT_POINT);
       this.wasImplicitContactPoint = true;
-      contactPointsBuilder.add(new DefaultNode(DEFAULT_CONTACT_POINT, context));
+      contactPointsBuilder.add(DefaultNode.newContactPoint(DEFAULT_CONTACT_POINT, context));
     } else {
       for (EndPoint endPoint : providedContactPoints) {
-        contactPointsBuilder.add(new DefaultNode(endPoint, context));
+        contactPointsBuilder.add(DefaultNode.newContactPoint(endPoint, context));
       }
     }
     this.contactPoints = contactPointsBuilder.build();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -44,15 +44,19 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.core.util.concurrent.Debouncer;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.netty.util.concurrent.EventExecutor;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import net.jcip.annotations.ThreadSafe;
@@ -82,6 +86,7 @@ public class MetadataManager implements AsyncAutoCloseable {
   private volatile boolean tokenMapEnabled;
   private volatile Set<DefaultNode> contactPoints;
   private volatile boolean wasImplicitContactPoint;
+
   private volatile TypeCodec<TupleValue> tabletPayloadCodec = null;
 
   public MetadataManager(InternalDriverContext context) {
@@ -163,8 +168,6 @@ public class MetadataManager implements AsyncAutoCloseable {
   /**
    * The contact points that were used by the driver to initialize. If none were provided
    * explicitly, this will be the default (127.0.0.1:9042).
-   *
-   * @see #wasImplicitContactPoint()
    */
   public Set<DefaultNode> getContactPoints() {
     return contactPoints;
@@ -173,6 +176,61 @@ public class MetadataManager implements AsyncAutoCloseable {
   /** Whether the default contact point was used (because none were provided explicitly). */
   public boolean wasImplicitContactPoint() {
     return wasImplicitContactPoint;
+  }
+
+  /**
+   * Creates a new metadata node from the given {@link NodeInfo} and registers it into metadata so
+   * that subsequent refreshes can find and reuse it by hostId. If a node with the same hostId
+   * already exists, returns the existing node.
+   *
+   * <p>Note: this always creates a new {@link DefaultNode} rather than reusing the caller's contact
+   * point node. Contact point nodes are ephemeral objects used only for the connection query plan;
+   * they are never added to metadata and never exposed to user-facing APIs (events, {@link
+   * com.datastax.oss.driver.api.core.metadata.Metadata#getNodes()}, or {@link
+   * com.datastax.oss.driver.api.core.metadata.NodeStateListener} callbacks).
+   */
+  public CompletionStage<Node> registerNode(NodeInfo nodeInfo) {
+    Preconditions.checkNotNull(nodeInfo.getHostId(), "Cannot register node without hostId");
+    CompletableFuture<Node> result = new CompletableFuture<>();
+    RunOrSchedule.on(
+        adminExecutor,
+        () -> {
+          try {
+            assert adminExecutor.inEventLoop();
+            Node existing = metadata.getNodes().get(nodeInfo.getHostId());
+            if (existing != null) {
+              LOG.debug(
+                  "[{}] Node with hostId {} already in metadata, returning existing node",
+                  logPrefix,
+                  nodeInfo.getHostId());
+              result.complete(existing);
+              return;
+            }
+            DefaultNode newNode = new DefaultNode(nodeInfo.getEndPoint(), context);
+            NodesRefresh.copyInfos(nodeInfo, newNode, context);
+            Map<UUID, Node> newNodes = new HashMap<>(metadata.getNodes());
+            newNodes.put(newNode.getHostId(), newNode);
+            this.metadata =
+                new DefaultMetadata(
+                    ImmutableMap.copyOf(newNodes),
+                    metadata.getKeyspaces(),
+                    metadata.getTokenMap().orElse(null),
+                    metadata.getClusterName().orElse(null),
+                    metadata.getTabletMap().orElse(DefaultTabletMap.emptyMap()));
+            if (singleThreaded.didFirstNodeListRefresh) {
+              LOG.debug(
+                  "[{}] registerNode inserting new node {} after initial refresh, "
+                      + "firing added event",
+                  logPrefix,
+                  nodeInfo.getHostId());
+              context.getEventBus().fire(NodeStateEvent.added(newNode));
+            }
+            result.complete(newNode);
+          } catch (Exception e) {
+            result.completeExceptionally(e);
+          }
+        });
+    return result;
   }
 
   public CompletionStage<Void> refreshNodes() {
@@ -340,7 +398,7 @@ public class MetadataManager implements AsyncAutoCloseable {
       MetadataRefresh refresh =
           didFirstNodeListRefresh
               ? new FullNodeListRefresh(nodeInfos)
-              : new InitialNodeListRefresh(nodeInfos, contactPoints);
+              : new InitialNodeListRefresh(nodeInfos);
       didFirstNodeListRefresh = true;
       return apply(refresh);
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodesRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodesRefresh.java
@@ -35,8 +35,7 @@ abstract class NodesRefresh implements MetadataRefresh {
    * @return whether the node's token have changed as a result of this operation (unfortunately we
    *     mutate the tokens in-place, so there is no way to check this after the fact).
    */
-  protected static boolean copyInfos(
-      NodeInfo nodeInfo, DefaultNode node, InternalDriverContext context) {
+  static boolean copyInfos(NodeInfo nodeInfo, DefaultNode node, InternalDriverContext context) {
 
     node.setEndPoint(nodeInfo.getEndPoint(), context);
     node.broadcastRpcAddress = nodeInfo.getBroadcastRpcAddress().orElse(null);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
@@ -19,7 +19,6 @@ package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
@@ -115,14 +114,14 @@ public interface TopologyMonitor extends AsyncAutoCloseable {
   CompletionStage<Iterable<NodeInfo>> refreshNodeList();
 
   /**
-   * Resolves the endpoint for the node at the other end of the given channel by querying
-   * system.local. This is used by the control connection after establishing a channel to resolve
-   * the node's identity (e.g., host_id) and build the appropriate endpoint type.
+   * Resolves the full identity and metadata of the node at the other end of the given channel by
+   * querying system.local. This is used by the control connection after establishing a channel to
+   * resolve the contact point's full identity (hostId, datacenter, rack, endpoint, etc.).
    *
    * @param channel the channel to query system.local on.
-   * @return a future that completes with the resolved endpoint.
+   * @return a future that completes with the resolved node info.
    */
-  CompletionStage<EndPoint> getChannelEndpoint(DriverChannel channel);
+  CompletionStage<NodeInfo> getChannelNodeInfo(DriverChannel channel);
 
   /**
    * Checks whether the nodes in the cluster agree on a common schema version.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
@@ -27,22 +27,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.channel.MockChannelFactoryHelper;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
 import com.datastax.oss.driver.internal.core.metadata.DistanceEvent;
+import com.datastax.oss.driver.internal.core.metadata.NodeInfo;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
+import com.datastax.oss.driver.internal.core.metadata.TestNodeFactory;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 
 @RunWith(DataProviderRunner.class)
 public class ControlConnectionTest extends ControlConnectionTestBase {
@@ -199,9 +204,11 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
         .isSuccess(v -> assertThat(controlConnection.channel()).isEqualTo(channel1));
     verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node1));
 
-    // When
+    // When — use a separate node with the same hostId to simulate a real event
+    // (real-world events come from different Node objects with matching hostIds)
+    DefaultNode eventNode1 = TestNodeFactory.newNode(1, node1.getHostId(), context);
     mockQueryPlan(node2);
-    eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, node1));
+    eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, eventNode1));
 
     // Then
     // an immediate reconnection was started
@@ -218,12 +225,17 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
 
   @Test
   public void should_reconnect_if_node_is_removed() {
-    should_reconnect_if_event(NodeStateEvent.removed(node1));
+    // Use a separate node with the same hostId to simulate a real event
+    DefaultNode eventNode1 = TestNodeFactory.newNode(1, node1.getHostId(), context);
+    should_reconnect_if_event(NodeStateEvent.removed(eventNode1));
   }
 
   @Test
   public void should_reconnect_if_node_is_forced_down() {
-    should_reconnect_if_event(NodeStateEvent.changed(NodeState.UP, NodeState.FORCED_DOWN, node1));
+    // Use a separate node with the same hostId to simulate a real event
+    DefaultNode eventNode1 = TestNodeFactory.newNode(1, node1.getHostId(), context);
+    should_reconnect_if_event(
+        NodeStateEvent.changed(NodeState.UP, NodeState.FORCED_DOWN, eventNode1));
   }
 
   private void should_reconnect_if_event(NodeStateEvent event) {
@@ -527,7 +539,11 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
 
   @Test
   public void should_try_next_node_if_resolve_endpoint_fails() {
-    // Given
+    // Given — use a contact point (no hostId) so resolveChannelNodeIfNeeded
+    // actually calls getChannelNodeInfo instead of short-circuiting
+    node1 = TestNodeFactory.newContactPoint(1, context);
+    mockQueryPlan(node1, node2);
+
     DriverChannel channel1 = newMockDriverChannel(1);
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
@@ -538,9 +554,9 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
 
     // Make resolveChannelNodeInfo fail for channel1
     TopologyMonitor topologyMonitor = context.getTopologyMonitor();
-    CompletableFuture<EndPoint> failedFuture = new CompletableFuture<>();
+    CompletableFuture<NodeInfo> failedFuture = new CompletableFuture<>();
     failedFuture.completeExceptionally(new RuntimeException("mock resolve failure"));
-    when(topologyMonitor.getChannelEndpoint(channel1)).thenReturn(failedFuture);
+    when(topologyMonitor.getChannelNodeInfo(channel1)).thenReturn(failedFuture);
 
     // When
     CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
@@ -553,9 +569,105 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // channel1's resolve failed, so channelOpened should NOT have been fired for node1
     verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node2));
     verify(eventBus, never()).fire(ChannelEvent.channelOpened(node1));
-    // channel1 should be force-closed (called once by resolve failure handler,
-    // and once more when channel2 succeeds and closes the previousChannel)
-    verify(channel1, timeout(500).atLeastOnce()).forceClose();
+    // channel1 should be force-closed by the resolve failure handler (previousChannel is null
+    // at that point, so channel2's success does not close channel1 a second time)
+    verify(channel1, timeout(500)).forceClose();
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_try_next_node_if_channel_closes_during_init_resolve() {
+    // Given — use a contact point (no hostId) so resolveChannelNodeIfNeeded is async
+    DefaultNode contactPoint1 = TestNodeFactory.newContactPoint(1, context);
+    mockQueryPlan(contactPoint1, node2);
+
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(contactPoint1, channel1)
+            .success(node2, channel2)
+            .build();
+
+    // Make getChannelNodeInfo return a pending future for channel1
+    CompletableFuture<NodeInfo> pendingResolve = new CompletableFuture<>();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel1)).thenReturn(pendingResolve);
+
+    // When — start init, channel1 opens successfully
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(contactPoint1);
+
+    // Close the channel before the resolve completes
+    channel1.close();
+
+    // Now complete the resolve — the code should detect channel is closed and try next node
+    pendingResolve.complete(
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel1.getEndPoint())
+            .withHostId(UUID.randomUUID())
+            .build());
+
+    // Then — should fall through to node2
+    factoryHelper.waitForCall(node2);
+    assertThatStage(initFuture)
+        .isSuccess(v -> assertThat(controlConnection.channel()).isEqualTo(channel2));
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node2));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_try_next_node_if_channel_closes_during_reconnect_resolve() throws Exception {
+    // Given — init normally with node1 (has hostId, resolve is synchronous)
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    DriverChannel channel3 = newMockDriverChannel(3);
+
+    // Contact point for reconnection (no hostId → async resolve)
+    DefaultNode contactPoint2 = TestNodeFactory.newContactPoint(2, context);
+
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1) // init
+            .success(contactPoint2, channel2) // reconnect: first attempt
+            .success(node1, channel3) // reconnect: fallback after channel2 closes during resolve
+            .build();
+
+    // Init with node1
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture).isSuccess();
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node1));
+
+    // Make getChannelNodeInfo return a pending future for channel2
+    CompletableFuture<NodeInfo> pendingResolve = new CompletableFuture<>();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel2)).thenReturn(pendingResolve);
+
+    // When — channel1 goes down, reconnect query plan returns contactPoint2 then node1
+    mockQueryPlan(contactPoint2, node1);
+    channel1.close();
+    verify(reconnectionSchedule, VERIFY_TIMEOUT).nextDelay();
+    factoryHelper.waitForCall(contactPoint2);
+
+    // Close channel2 before resolve completes
+    channel2.close();
+
+    // Complete the resolve — should detect channel is closed and try node1
+    pendingResolve.complete(
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel2.getEndPoint())
+            .withHostId(UUID.randomUUID())
+            .build());
+
+    // Then — should fall through to node1 with channel3
+    factoryHelper.waitForCall(node1);
+    await().untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel3));
+    // channelOpened(node1) fires twice: once during init, once during reconnect fallback
+    verify(eventBus, timeout(500).times(2)).fire(ChannelEvent.channelOpened(node1));
 
     factoryHelper.verifyNoMoreCalls();
   }
@@ -597,6 +709,259 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // should never try channel2 because the reconnection has detected that it can stop after the
     // first failure
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_reconnect_via_contact_point_fallback_and_resolve() throws Exception {
+    // Given — init normally with node1
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+
+    // Contact point node (no hostId) for reconnection fallback
+    DefaultNode contactPoint = TestNodeFactory.newContactPoint(2, context);
+    UUID resolvedHostId = UUID.randomUUID();
+
+    // The resolved metadata node that registerNode will return
+    DefaultNode resolvedNode = TestNodeFactory.newNode(2, resolvedHostId, context);
+
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1)
+            .success(contactPoint, channel2)
+            .build();
+
+    // Init with node1
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture)
+        .isSuccess(v -> assertThat(controlConnection.channel()).isEqualTo(channel1));
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node1));
+
+    // Mock topology monitor to return resolved info for the contact point channel
+    NodeInfo resolvedInfo =
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel2.getEndPoint())
+            .withHostId(resolvedHostId)
+            .build();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel2))
+        .thenReturn(CompletableFuture.completedFuture(resolvedInfo));
+
+    // registerNode should return the resolved node and add it to metadata
+    when(metadataManager.registerNode(any()))
+        .thenAnswer(
+            invocation -> {
+              registeredNodes.put(resolvedNode.getHostId(), resolvedNode);
+              return CompletableFuture.completedFuture(resolvedNode);
+            });
+
+    // When — channel goes down, reconnect query plan returns the contact point
+    mockQueryPlan(contactPoint);
+    channel1.close();
+
+    // Then
+    verify(reconnectionSchedule, VERIFY_TIMEOUT).nextDelay();
+    factoryHelper.waitForCall(contactPoint);
+    await().untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel2));
+
+    // resolveChannelNodeIfNeeded was called (via topology monitor)
+    verify(topologyMonitor, VERIFY_TIMEOUT).getChannelNodeInfo(channel2);
+    // registerNode was called with the resolved info (verify content, not just any)
+    ArgumentCaptor<NodeInfo> nodeInfoCaptor = ArgumentCaptor.forClass(NodeInfo.class);
+    verify(metadataManager, VERIFY_TIMEOUT).registerNode(nodeInfoCaptor.capture());
+    assertThat(nodeInfoCaptor.getValue().getHostId()).isEqualTo(resolvedHostId);
+    assertThat(nodeInfoCaptor.getValue().getEndPoint()).isEqualTo(channel2.getEndPoint());
+    // The channelOpened event fires for the resolved node, not the contact point
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(resolvedNode));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_resolve_contact_point_to_existing_metadata_node_on_reconnect() {
+    // Given — a contact point with no hostId, and an existing metadata node with a known hostId
+    UUID knownHostId = UUID.randomUUID();
+    node1 = TestNodeFactory.newContactPoint(1, context);
+    node2 = TestNodeFactory.newNode(2, knownHostId, context);
+
+    mockQueryPlan(node1);
+
+    DriverChannel channel1 = newMockDriverChannel(1);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
+
+    // Mock getChannelNodeInfo to return a NodeInfo with the same hostId as node2.
+    // Pre-evaluate channel1.getEndPoint() to avoid nested mock calls inside when().
+    NodeInfo resolvedInfo =
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel1.getEndPoint())
+            .withHostId(knownHostId)
+            .build();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel1))
+        .thenReturn(CompletableFuture.completedFuture(resolvedInfo));
+
+    // registerNode atomically checks for existing nodes — mock it to return node2
+    // (simulating that metadata already has a node with this hostId)
+    when(metadataManager.registerNode(any())).thenReturn(CompletableFuture.completedFuture(node2));
+
+    // When
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+
+    // Then — the control connection should resolve to the existing metadata node (node2)
+    assertThatStage(initFuture).isSuccess();
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node2));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_return_control_node_after_init() {
+    // Given
+    DriverChannel channel1 = newMockDriverChannel(1);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
+
+    // Before init, controlNode should be null
+    assertThat(controlConnection.controlNode()).isNull();
+
+    // When
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+
+    // Then — after init, controlNode should be set
+    assertThatStage(initFuture).isSuccess();
+    await().untilAsserted(() -> assertThat(controlConnection.controlNode()).isNotNull());
+    assertThat(controlConnection.controlNode().getHostId()).isEqualTo(node1.getHostId());
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_clear_control_node_on_channel_close_and_restore_after_reconnect() {
+    // Given
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    CompletableFuture<DriverChannel> channel2Future = new CompletableFuture<>();
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1)
+            .failure(node1, "mock failure")
+            .pending(node2, channel2Future)
+            .build();
+
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture).isSuccess();
+    await().untilAsserted(() -> assertThat(controlConnection.controlNode()).isNotNull());
+    assertThat(controlConnection.controlNode().getHostId()).isEqualTo(node1.getHostId());
+
+    // When — channel closes, reconnection starts but pending on node2
+    channel1.close();
+    verify(reconnectionSchedule, VERIFY_TIMEOUT).nextDelay();
+    factoryHelper.waitForCall(node1); // fails
+    factoryHelper.waitForCall(node2); // pending
+
+    // Then — controlNode should be null during reconnection window
+    assertThat(controlConnection.controlNode()).isNull();
+
+    // Complete the pending reconnection
+    channel2Future.complete(channel2);
+
+    // After reconnection, controlNode should be set to node2
+    await().untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel2));
+    await().untilAsserted(() -> assertThat(controlConnection.controlNode()).isNotNull());
+    assertThat(controlConnection.controlNode().getHostId()).isEqualTo(node2.getHostId());
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_not_reconnect_on_event_for_non_control_node() {
+    // Given — init with node1 (has hostId)
+    DriverChannel channel1 = newMockDriverChannel(1);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
+
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture).isSuccess();
+    await().untilAsserted(() -> assertThat(controlConnection.controlNode()).isNotNull());
+
+    // When — fire a distance event for node2 (not the control node)
+    eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, node2));
+
+    // Then — should NOT trigger reconnection (channel stays the same)
+    await()
+        .during(Duration.ofMillis(200))
+        .untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel1));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_reconnect_when_control_node_removed_from_metadata_after_reconnect() {
+    // Given — init with node1
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    DriverChannel channel3 = newMockDriverChannel(3);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1) // init
+            .success(node2, channel2) // first reconnect
+            .failure(node2, "decommissioned") // second reconnect: node2 fails
+            .success(node1, channel3) // second reconnect: falls back to node1
+            .build();
+
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture).isSuccess();
+
+    // Remove node2 from metadata before triggering reconnect
+    // (simulating node2 was decommissioned during the outage)
+    registeredNodes.remove(node2.getHostId());
+
+    // When — channel1 goes down, reconnects to node2
+    mockQueryPlan(node2, node1);
+    channel1.close();
+
+    // Then — onSuccessfulReconnect detects node2 is gone → triggers second reconnection
+    // which eventually connects to node1 (channel3)
+    factoryHelper.waitForCall(node2); // first reconnect
+
+    // onSuccessfulReconnect detects node2 is removed from metadata → force-closes channel2
+    verify(channel2, VERIFY_TIMEOUT).forceClose();
+
+    factoryHelper.waitForCall(node2); // second reconnect: node2 fails
+    factoryHelper.waitForCall(node1); // second reconnect: node1 succeeds
+    await().untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel3));
+    // channelOpened(node1) fires twice: once during init, once during second reconnect
+    verify(eventBus, timeout(500).times(2)).fire(ChannelEvent.channelOpened(node1));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_not_call_getChannelNodeInfo_for_metadata_node_with_hostId() {
+    // Given — node1 already has a hostId (it's a metadata node, not a contact point)
+    DriverChannel channel1 = newMockDriverChannel(1);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
+
+    // When
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+
+    // Then — resolveChannelNodeIfNeeded should short-circuit
+    assertThatStage(initFuture).isSuccess();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    verify(topologyMonitor, never()).getChannelNodeInfo(any(DriverChannel.class));
+
     factoryHelper.verifyNoMoreCalls();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -19,7 +19,6 @@ package com.datastax.oss.driver.internal.core.control;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -29,6 +28,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
@@ -38,8 +38,10 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNodeInfo;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
+import com.datastax.oss.driver.internal.core.metadata.NodeInfo;
 import com.datastax.oss.driver.internal.core.metadata.TestNodeFactory;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
@@ -49,6 +51,9 @@ import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Exchanger;
@@ -81,6 +86,7 @@ abstract class ControlConnectionTestBase {
 
   protected DefaultNode node1;
   protected DefaultNode node2;
+  protected Map<UUID, Node> registeredNodes;
 
   protected ControlConnection controlConnection;
 
@@ -124,8 +130,24 @@ abstract class ControlConnectionTestBase {
     mockQueryPlan(node1, node2);
 
     when(metadataManager.refreshNodes()).thenReturn(CompletableFuture.completedFuture(null));
-    when(metadataManager.refreshSchema(anyString(), anyBoolean(), anyBoolean()))
+    when(metadataManager.refreshSchema(any(), anyBoolean(), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
+    // Track registered nodes so that getMetadata().getNodes() returns them
+    // (used by onSuccessfulReconnect to verify the control node is still in metadata).
+    registeredNodes = new HashMap<>();
+    registeredNodes.put(node1.getHostId(), node1);
+    registeredNodes.put(node2.getHostId(), node2);
+    when(metadataManager.registerNode(any(NodeInfo.class)))
+        .thenAnswer(
+            invocation -> {
+              NodeInfo info = invocation.getArgument(0);
+              DefaultNode n = TestNodeFactory.newNode(info, context);
+              registeredNodes.put(n.getHostId(), n);
+              return CompletableFuture.completedFuture(n);
+            });
+    Metadata metadata = mock(Metadata.class);
+    when(metadata.getNodes()).thenAnswer(invocation -> new HashMap<>(registeredNodes));
+    when(metadataManager.getMetadata()).thenReturn(metadata);
     when(context.getMetadataManager()).thenReturn(metadataManager);
 
     when(context.getConfig()).thenReturn(config);
@@ -139,11 +161,15 @@ abstract class ControlConnectionTestBase {
         .thenReturn(false);
 
     TopologyMonitor topologyMonitor = mock(TopologyMonitor.class);
-    when(topologyMonitor.getChannelEndpoint(any(DriverChannel.class)))
+    when(topologyMonitor.getChannelNodeInfo(any(DriverChannel.class)))
         .thenAnswer(
             invocation -> {
               DriverChannel ch = invocation.getArgument(0);
-              return CompletableFuture.completedFuture(ch.getEndPoint());
+              return CompletableFuture.completedFuture(
+                  DefaultNodeInfo.builder()
+                      .withEndPoint(ch.getEndPoint())
+                      .withHostId(UUID.randomUUID())
+                      .build());
             });
     when(context.getTopologyMonitor()).thenReturn(topologyMonitor);
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyDcFailoverTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyDcFailoverTest.java
@@ -36,9 +36,11 @@ import static org.mockito.Mockito.when;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
@@ -120,9 +122,17 @@ public class BasicLoadBalancingPolicyDcFailoverTest extends BasicLoadBalancingPo
     when(node4.getDatacenter()).thenReturn("dc2");
     when(node5.getDatacenter()).thenReturn("dc2");
     when(node6.getDatacenter()).thenReturn("dc2");
+    when(node6.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.6", 9042)));
     when(node7.getDatacenter()).thenReturn("dc3");
+    when(node7.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.7", 9042)));
     when(node8.getDatacenter()).thenReturn("dc3");
+    when(node8.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.8", 9042)));
     when(node9.getDatacenter()).thenReturn("dc3");
+    when(node9.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.9", 9042)));
     // Accept 2 nodes per remote DC
     when(defaultProfile.getInt(
             DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC))

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyInitTest.java
@@ -18,14 +18,10 @@
 package com.datastax.oss.driver.internal.core.loadbalancing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.filter;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
@@ -99,33 +95,6 @@ public class BasicLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestBas
     assertThat(policy.getLocalDatacenter()).isNull();
     // should not warn about contact points not being in the same DC
     verify(appender, never()).doAppend(loggingEventCaptor.capture());
-  }
-
-  @Test
-  public void should_warn_if_contact_points_not_in_local_dc() {
-    // Given
-    when(context.getLocalDatacenter(DriverExecutionProfile.DEFAULT_NAME)).thenReturn("dc1");
-    when(node2.getDatacenter()).thenReturn("dc2");
-    when(node3.getDatacenter()).thenReturn("dc3");
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1, node2, node3));
-    BasicLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    policy.init(
-        ImmutableMap.of(
-            UUID.randomUUID(), node1, UUID.randomUUID(), node2, UUID.randomUUID(), node3),
-        distanceReporter);
-
-    // Then
-    verify(appender, atLeast(1)).doAppend(loggingEventCaptor.capture());
-    Iterable<ILoggingEvent> warnLogs =
-        filter(loggingEventCaptor.getAllValues()).with("level", Level.WARN).get();
-    assertThat(warnLogs).hasSize(1);
-    assertThat(warnLogs.iterator().next().getFormattedMessage())
-        .contains(
-            "You specified dc1 as the local DC, but some contact points are from a different DC")
-        .contains("node2=dc2")
-        .contains("node3=dc3");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyPreferredRemoteDcsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyPreferredRemoteDcsTest.java
@@ -31,9 +31,11 @@ import static org.mockito.Mockito.when;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
@@ -132,14 +134,32 @@ public class BasicLoadBalancingPolicyPreferredRemoteDcsTest
     when(node4.getDatacenter()).thenReturn("dc1");
     when(node5.getDatacenter()).thenReturn("dc1");
     when(node6.getDatacenter()).thenReturn("dc2");
+    when(node6.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.6", 9042)));
     when(node7.getDatacenter()).thenReturn("dc2");
+    when(node7.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.7", 9042)));
     when(node8.getDatacenter()).thenReturn("dc2");
+    when(node8.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.8", 9042)));
     when(node9.getDatacenter()).thenReturn("dc3");
+    when(node9.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.9", 9042)));
     when(node10.getDatacenter()).thenReturn("dc3");
+    when(node10.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.10", 9042)));
     when(node11.getDatacenter()).thenReturn("dc3");
+    when(node11.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.11", 9042)));
     when(node12.getDatacenter()).thenReturn("dc4");
+    when(node12.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.12", 9042)));
     when(node13.getDatacenter()).thenReturn("dc4");
+    when(node13.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.13", 9042)));
     when(node14.getDatacenter()).thenReturn("dc4");
+    when(node14.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.14", 9042)));
 
     // Accept 2 nodes per remote DC
     when(defaultProfile.getInt(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyDistanceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyDistanceTest.java
@@ -40,8 +40,7 @@ public class DcInferringLoadBalancingPolicyDistanceTest
             ise ->
                 assertThat(ise)
                     .hasMessageContaining(
-                        "No local DC was provided, but the contact points are from different DCs")
-                    .hasMessageContaining("node1=null")
+                        "No local DC was provided, but the cluster nodes resolve to nodes in different DCs")
                     .hasMessageContaining("node2=dc1")
                     .hasMessageContaining("node3=dc2"));
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DcInferringLoadBalancingPolicyInitTest.java
@@ -18,25 +18,28 @@
 package com.datastax.oss.driver.internal.core.loadbalancing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.filter;
-import static org.mockito.Mockito.atLeast;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetSocketAddress;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -75,7 +78,8 @@ public class DcInferringLoadBalancingPolicyInitTest extends LoadBalancingPolicyT
   }
 
   @Test
-  public void should_infer_local_dc_from_contact_points() {
+  public void
+      should_infer_local_dc_from_cluster_nodes_if_not_configured_and_no_control_connection() {
     // Given
     when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
         .thenReturn(false);
@@ -87,81 +91,6 @@ public class DcInferringLoadBalancingPolicyInitTest extends LoadBalancingPolicyT
 
     // Then
     assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
-  }
-
-  @Test
-  public void should_require_local_dc_if_contact_points_from_different_dcs() {
-    // Given
-    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
-        .thenReturn(false);
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1, node2));
-    when(node2.getDatacenter()).thenReturn("dc2");
-    BasicLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    Throwable t =
-        catchThrowable(
-            () ->
-                policy.init(
-                    ImmutableMap.of(UUID.randomUUID(), node1, UUID.randomUUID(), node2),
-                    distanceReporter));
-
-    // Then
-    assertThat(t)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "No local DC was provided, but the contact points are from different DCs: node1=dc1, node2=dc2");
-  }
-
-  @Test
-  public void should_require_local_dc_if_contact_points_have_null_dcs() {
-    // Given
-    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
-        .thenReturn(false);
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1, node2));
-    when(node1.getDatacenter()).thenReturn(null);
-    when(node2.getDatacenter()).thenReturn(null);
-    BasicLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    Throwable t =
-        catchThrowable(
-            () ->
-                policy.init(
-                    ImmutableMap.of(UUID.randomUUID(), node1, UUID.randomUUID(), node2),
-                    distanceReporter));
-
-    // Then
-    assertThat(t)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "The local DC could not be inferred from contact points, please set it explicitly");
-  }
-
-  @Test
-  public void should_warn_if_contact_points_not_in_local_dc() {
-    // Given
-    when(node2.getDatacenter()).thenReturn("dc2");
-    when(node3.getDatacenter()).thenReturn("dc3");
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1, node2, node3));
-    BasicLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    policy.init(
-        ImmutableMap.of(
-            UUID.randomUUID(), node1, UUID.randomUUID(), node2, UUID.randomUUID(), node3),
-        distanceReporter);
-
-    // Then
-    verify(appender, atLeast(1)).doAppend(loggingEventCaptor.capture());
-    Iterable<ILoggingEvent> warnLogs =
-        filter(loggingEventCaptor.getAllValues()).with("level", Level.WARN).get();
-    assertThat(warnLogs).hasSize(1);
-    assertThat(warnLogs.iterator().next().getFormattedMessage())
-        .contains(
-            "You specified dc1 as the local DC, but some contact points are from a different DC")
-        .contains("node2=dc2")
-        .contains("node3=dc3");
   }
 
   @Test
@@ -229,6 +158,136 @@ public class DcInferringLoadBalancingPolicyInitTest extends LoadBalancingPolicyT
     verify(distanceReporter).setDistance(node2, NodeDistance.LOCAL);
     verify(distanceReporter).setDistance(node3, NodeDistance.LOCAL);
     assertThat(policy.getLiveNodes().dc("dc1")).containsExactly(node2, node3);
+  }
+
+  @Test
+  public void should_infer_local_dc_from_control_node_hostId() {
+    // Given — DC not configured, but controlNode returns a node whose hostId is in the nodes map
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    UUID node1HostId = UUID.randomUUID();
+    when(node1.getHostId()).thenReturn(node1HostId);
+    when(controlConnection.controlNode()).thenReturn(node1);
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(node1HostId, node1), distanceReporter);
+
+    // Then — DC should be inferred from the control node's hostId lookup
+    assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
+  }
+
+  @Test
+  public void should_throw_when_nodes_from_different_dcs_and_no_control_connection() {
+    // Given — DC not configured, nodes span multiple DCs, no control connection
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    when(node1.getDatacenter()).thenReturn("dc1");
+    when(node2.getDatacenter()).thenReturn("dc2");
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When/Then
+    assertThatThrownBy(
+            () ->
+                policy.init(
+                    ImmutableMap.of(UUID.randomUUID(), node1, UUID.randomUUID(), node2),
+                    distanceReporter))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("different DCs");
+  }
+
+  @Test
+  public void should_throw_when_all_nodes_have_null_dc_and_no_control_connection() {
+    // Given — DC not configured, all nodes have null DC, no control connection
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    when(node1.getDatacenter()).thenReturn(null);
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When/Then
+    assertThatThrownBy(
+            () -> policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("could not be inferred");
+  }
+
+  @Test
+  public void should_warn_if_configured_dc_matches_no_node() {
+    // Given — DC is configured as "dc1" but nodes are all in "dc2"
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+    when(node1.getDatacenter()).thenReturn("dc2");
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter);
+
+    // Then — should log a warning about the configured DC not matching any node
+    verify(appender, atLeastOnce()).doAppend(loggingEventCaptor.capture());
+    assertThat(
+            loggingEventCaptor.getAllValues().stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .anyMatch(
+                    e -> e.getFormattedMessage().contains("does not match any node's datacenter")))
+        .isTrue();
+  }
+
+  @Test
+  public void should_infer_local_dc_from_control_channel_endpoint() {
+    // Given — DC not configured, controlNode has no hostId,
+    // but channel endpoint matches a node in the nodes map
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    when(controlConnection.controlNode()).thenReturn(null);
+    DriverChannel channel = mock(DriverChannel.class);
+    Mockito.when(channel.getEndPoint())
+        .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042)));
+    when(controlConnection.channel()).thenReturn(channel);
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    UUID node1Id = UUID.randomUUID();
+    policy.init(ImmutableMap.of(node1Id, node1), distanceReporter);
+
+    // Then — DC should be inferred from the channel endpoint matching node1
+    assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
+  }
+
+  @Test
+  public void should_throw_when_control_channel_endpoint_matches_multiple_dcs() {
+    // Given — DC not configured, controlNode has no hostId,
+    // channel endpoint matches nodes in different DCs (ambiguous)
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    when(controlConnection.controlNode()).thenReturn(null);
+    DriverChannel channel = mock(DriverChannel.class);
+    // Both node1 and node2 share the same endpoint but different DCs
+    DefaultEndPoint sharedEndpoint = new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042));
+    Mockito.when(channel.getEndPoint()).thenReturn(sharedEndpoint);
+    when(controlConnection.channel()).thenReturn(channel);
+    when(node1.getEndPoint()).thenReturn(sharedEndpoint);
+    when(node1.getDatacenter()).thenReturn("dc1");
+    when(node2.getEndPoint()).thenReturn(sharedEndpoint);
+    when(node2.getDatacenter()).thenReturn("dc2");
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+
+    BasicLoadBalancingPolicy policy = createPolicy();
+
+    // When/Then — inference fails due to ambiguity, falls through to "different DCs" error
+    assertThatThrownBy(
+            () ->
+                policy.init(
+                    ImmutableMap.of(UUID.randomUUID(), node1, UUID.randomUUID(), node2),
+                    distanceReporter))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("different DCs");
   }
 
   @NonNull

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyDistanceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyDistanceTest.java
@@ -39,9 +39,6 @@ public class DefaultLoadBalancingPolicyDistanceTest extends BasicLoadBalancingPo
             ise ->
                 assertThat(ise)
                     .hasMessageContaining("the local DC must be explicitly set")
-                    .hasMessageContaining("node1=null")
-                    .hasMessageContaining("node2=dc1")
-                    .hasMessageContaining("node3=dc2")
                     .hasMessageContaining("Current DCs in this cluster are: dc1, dc2"));
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
@@ -19,14 +19,12 @@ package com.datastax.oss.driver.internal.core.loadbalancing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.filter;
-import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
@@ -92,61 +90,17 @@ public class DefaultLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestB
   }
 
   @Test
-  public void should_infer_local_dc_if_no_explicit_contact_points() {
+  public void should_require_local_dc_if_not_configured_and_no_control_connection() {
     // Given
     when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
         .thenReturn(false);
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
-    when(metadataManager.wasImplicitContactPoint()).thenReturn(true);
-    DefaultLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter);
-
-    // Then
-    assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
-  }
-
-  @Test
-  public void should_require_local_dc_if_explicit_contact_points() {
-    // Given
-    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
-        .thenReturn(false);
-    when(metadataManager.wasImplicitContactPoint()).thenReturn(false);
     DefaultLoadBalancingPolicy policy = createPolicy();
 
     // When
     assertThatThrownBy(
-            () -> policy.init(ImmutableMap.of(UUID.randomUUID(), node2), distanceReporter))
+            () -> policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "Since you provided explicit contact points, the local DC must be explicitly set");
-  }
-
-  @Test
-  public void should_warn_if_contact_points_not_in_local_dc() {
-    // Given
-    when(node2.getDatacenter()).thenReturn("dc2");
-    when(node3.getDatacenter()).thenReturn("dc3");
-    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1, node2, node3));
-    DefaultLoadBalancingPolicy policy = createPolicy();
-
-    // When
-    policy.init(
-        ImmutableMap.of(
-            UUID.randomUUID(), node1, UUID.randomUUID(), node2, UUID.randomUUID(), node3),
-        distanceReporter);
-
-    // Then
-    verify(appender, atLeast(1)).doAppend(loggingEventCaptor.capture());
-    Iterable<ILoggingEvent> warnLogs =
-        filter(loggingEventCaptor.getAllValues()).with("level", Level.WARN).get();
-    assertThat(warnLogs).hasSize(1);
-    assertThat(warnLogs.iterator().next().getFormattedMessage())
-        .contains(
-            "You specified dc1 as the local DC, but some contact points are from a different DC")
-        .contains("node2=dc2")
-        .contains("node3=dc3");
+        .hasMessageContaining("the local DC must be explicitly set");
   }
 
   @Test
@@ -216,6 +170,44 @@ public class DefaultLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestB
     verify(distanceReporter).setDistance(node2, NodeDistance.LOCAL);
     verify(distanceReporter).setDistance(node3, NodeDistance.LOCAL);
     assertThat(policy.getLiveNodes().dc("dc1")).containsExactly(node2, node3);
+  }
+
+  @Test
+  public void should_infer_local_dc_from_control_node_hostId() {
+    // Given — DC not configured, but controlNode returns a node whose hostId is in the nodes map
+    when(defaultProfile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
+        .thenReturn(false);
+    UUID node1HostId = UUID.randomUUID();
+    when(node1.getHostId()).thenReturn(node1HostId);
+    when(controlConnection.controlNode()).thenReturn(node1);
+
+    DefaultLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(node1HostId, node1), distanceReporter);
+
+    // Then — DC should be inferred from the control node's hostId lookup
+    assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
+  }
+
+  @Test
+  public void should_warn_if_configured_dc_matches_no_node() {
+    // Given — DC is configured as "dc1" but nodes are all in "dc2"
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(node1));
+    when(node1.getDatacenter()).thenReturn("dc2");
+    DefaultLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter);
+
+    // Then — should log a warning about the configured DC not matching any node
+    verify(appender, atLeastOnce()).doAppend(loggingEventCaptor.capture());
+    assertThat(
+            loggingEventCaptor.getAllValues().stream()
+                .filter(e -> e.getLevel() == Level.WARN)
+                .anyMatch(
+                    e -> e.getFormattedMessage().contains("does not match any node's datacenter")))
+        .isTrue();
   }
 
   @NonNull

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/LoadBalancingPolicyTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/LoadBalancingPolicyTestBase.java
@@ -27,12 +27,14 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
-import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.control.ControlConnection;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.net.InetSocketAddress;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -53,6 +55,7 @@ public abstract class LoadBalancingPolicyTestBase {
   @Mock protected LoadBalancingPolicy.DistanceReporter distanceReporter;
   @Mock protected Appender<ILoggingEvent> appender;
   @Mock protected MetadataManager metadataManager;
+  @Mock protected ControlConnection controlConnection;
 
   @Captor protected ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
 
@@ -83,13 +86,19 @@ public abstract class LoadBalancingPolicyTestBase {
         .thenReturn("REGULAR");
 
     when(context.getMetadataManager()).thenReturn(metadataManager);
+    when(context.getControlConnection()).thenReturn(controlConnection);
+    when(controlConnection.channel()).thenReturn(null);
 
     logger =
         (Logger) LoggerFactory.getLogger("com.datastax.oss.driver.internal.core.loadbalancing");
     logger.addAppender(appender);
 
-    for (Node node : ImmutableList.of(node1, node2, node3, node4, node5)) {
+    int i = 1;
+    for (DefaultNode node : ImmutableList.of(node1, node2, node3, node4, node5)) {
       when(node.getDatacenter()).thenReturn("dc1");
+      when(node.getEndPoint())
+          .thenReturn(new DefaultEndPoint(new InetSocketAddress("127.0.0." + i, 9042)));
+      i++;
     }
 
     when(context.getLocalDatacenter(anyString())).thenReturn(null);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -1161,12 +1161,11 @@ public class ClientRoutesTopologyMonitorTest {
   // ---- savePort() --------------------------------------------------------
 
   @Test
-  public void savePort_should_use_native_transport_port_from_config() {
+  public void port_should_be_set_from_config_in_constructor() {
     DriverChannel channel = Mockito.mock(DriverChannel.class);
     handler.savePort(channel);
 
-    // Should use the default native transport port from ClientRoutesConfig (9042),
-    // NOT the NLB proxy port from the routes cache or the channel endpoint.
+    // Port is set from ClientRoutesConfig in the constructor (default 9042), savePort is a no-op.
     assertThat(handler.port).isEqualTo(9042);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -38,7 +38,6 @@ import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.internal.core.addresstranslation.PassThroughAddressTranslator;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
@@ -425,21 +424,21 @@ public class DefaultTopologyMonitorTest {
   }
 
   @Test
-  public void should_fail_get_channel_endpoint_if_local_result_is_empty() {
+  public void should_fail_get_channel_node_info_if_local_result_is_empty() {
     // Given
     topologyMonitor.stubQueries(
         new StubbedQuery("SELECT * FROM system.local WHERE key='local'", mockResult()));
 
     // When
-    CompletionStage<EndPoint> futureEndpoint = topologyMonitor.getChannelEndpoint(channel);
+    CompletionStage<NodeInfo> futureNodeInfo = topologyMonitor.getChannelNodeInfo(channel);
 
     // Then
-    assertThatStage(futureEndpoint)
+    assertThatStage(futureNodeInfo)
         .isFailed(
             error -> {
               assertThat(error).isInstanceOf(IllegalStateException.class);
               assertThat(error.getMessage())
-                  .contains("Expected a row in system.local for endpoint resolution");
+                  .contains("Expected a row in system.local for node info resolution");
             });
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
@@ -26,7 +26,8 @@ import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -41,9 +42,10 @@ public class InitialNodeListRefreshTest {
   @Mock private InternalDriverContext context;
   @Mock protected MetricsFactory metricsFactory;
   @Mock private ChannelFactory channelFactory;
+  @Mock private MetadataManager metadataManager;
 
-  private DefaultNode contactPoint1;
-  private DefaultNode contactPoint2;
+  private EndPoint endPoint1;
+  private EndPoint endPoint2;
   private EndPoint endPoint3;
   private UUID hostId1;
   private UUID hostId2;
@@ -56,9 +58,8 @@ public class InitialNodeListRefreshTest {
     when(context.getMetricsFactory()).thenReturn(metricsFactory);
     when(context.getChannelFactory()).thenReturn(channelFactory);
 
-    contactPoint1 = TestNodeFactory.newContactPoint(1, context);
-    contactPoint2 = TestNodeFactory.newContactPoint(2, context);
-
+    endPoint1 = TestNodeFactory.newEndPoint(1);
+    endPoint2 = TestNodeFactory.newEndPoint(2);
     endPoint3 = TestNodeFactory.newEndPoint(3);
     hostId1 = UUID.randomUUID();
     hostId2 = UUID.randomUUID();
@@ -68,23 +69,16 @@ public class InitialNodeListRefreshTest {
   }
 
   @Test
-  public void should_copy_contact_points_on_first_endpoint_match_only() {
+  public void should_create_new_nodes_for_all_endpoints() {
     // Given
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
-                .withHostId(hostId1)
-                .build(),
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint2.getEndPoint())
-                .withHostId(hostId2)
-                .build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint1).withHostId(hostId1).build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint2).withHostId(hostId2).build(),
             DefaultNodeInfo.builder().withEndPoint(endPoint3).withHostId(hostId3).build(),
             DefaultNodeInfo.builder()
                 // address translator can translate node addresses to the same endpoints
-                .withEndPoint(contactPoint2.getEndPoint())
+                .withEndPoint(endPoint2)
                 .withHostId(hostId4)
                 .build(),
             DefaultNodeInfo.builder()
@@ -92,65 +86,52 @@ public class InitialNodeListRefreshTest {
                 .withEndPoint(endPoint3)
                 .withHostId(hostId5)
                 .build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
 
     // When
     MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
 
     // Then
-    // contact points have been copied to the metadata, and completed with missing information
     Map<UUID, Node> newNodes = result.newMetadata.getNodes();
     assertThat(newNodes).containsOnlyKeys(hostId1, hostId2, hostId3, hostId4, hostId5);
-    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
-    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
-    assertThat(newNodes.get(hostId2)).isEqualTo(contactPoint2);
-    assertThat(contactPoint2.getHostId()).isEqualTo(hostId2);
-    // And
-    // node has been added for the new endpoint
+    assertThat(newNodes.get(hostId1).getEndPoint()).isEqualTo(endPoint1);
+    assertThat(newNodes.get(hostId1).getHostId()).isEqualTo(hostId1);
+    assertThat(newNodes.get(hostId2).getEndPoint()).isEqualTo(endPoint2);
+    assertThat(newNodes.get(hostId2).getHostId()).isEqualTo(hostId2);
     assertThat(newNodes.get(hostId3).getEndPoint()).isEqualTo(endPoint3);
     assertThat(newNodes.get(hostId3).getHostId()).isEqualTo(hostId3);
-    // And
-    // nodes have been added for duplicated endpoints
-    assertThat(newNodes.get(hostId4).getEndPoint()).isEqualTo(contactPoint2.getEndPoint());
+    assertThat(newNodes.get(hostId4).getEndPoint()).isEqualTo(endPoint2);
     assertThat(newNodes.get(hostId4).getHostId()).isEqualTo(hostId4);
     assertThat(newNodes.get(hostId5).getEndPoint()).isEqualTo(endPoint3);
     assertThat(newNodes.get(hostId5).getHostId()).isEqualTo(hostId5);
     assertThat(result.events)
         .containsExactlyInAnyOrder(
+            NodeStateEvent.added((DefaultNode) newNodes.get(hostId1)),
+            NodeStateEvent.added((DefaultNode) newNodes.get(hostId2)),
             NodeStateEvent.added((DefaultNode) newNodes.get(hostId3)),
             NodeStateEvent.added((DefaultNode) newNodes.get(hostId4)),
             NodeStateEvent.added((DefaultNode) newNodes.get(hostId5)));
   }
 
   @Test
-  public void should_add_other_nodes() {
+  public void should_add_all_nodes() {
     // Given
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
-                .withHostId(hostId1)
-                .build(),
-            DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint2.getEndPoint())
-                .withHostId(hostId2)
-                .build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint1).withHostId(hostId1).build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint2).withHostId(hostId2).build(),
             DefaultNodeInfo.builder().withEndPoint(endPoint3).withHostId(hostId3).build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
 
     // When
     MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
 
     // Then
-    // new node created in addition to the contact points
     Map<UUID, Node> newNodes = result.newMetadata.getNodes();
     assertThat(newNodes).containsOnlyKeys(hostId1, hostId2, hostId3);
-    Node node3 = newNodes.get(hostId3);
-    assertThat(node3.getEndPoint()).isEqualTo(endPoint3);
-    assertThat(node3.getHostId()).isEqualTo(hostId3);
+    assertThat(newNodes.get(hostId1).getEndPoint()).isEqualTo(endPoint1);
+    assertThat(newNodes.get(hostId2).getEndPoint()).isEqualTo(endPoint2);
+    assertThat(newNodes.get(hostId3).getEndPoint()).isEqualTo(endPoint3);
   }
 
   @Test
@@ -159,28 +140,91 @@ public class InitialNodeListRefreshTest {
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
             DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
-                // in practice there are more fields, but hostId is enough to validate the logic
+                .withEndPoint(endPoint1)
                 .withHostId(hostId1)
                 .withDatacenter("dc1")
                 .build(),
             DefaultNodeInfo.builder()
-                .withEndPoint(contactPoint1.getEndPoint())
+                .withEndPoint(endPoint1)
                 .withDatacenter("dc2")
                 .withHostId(hostId1)
                 .build());
-    InitialNodeListRefresh refresh =
-        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1));
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
 
     // When
     MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
 
     // Then
-    // only the first nodeInfo should have been copied
+    // only the first nodeInfo should have been used
     Map<UUID, Node> newNodes = result.newMetadata.getNodes();
     assertThat(newNodes).containsOnlyKeys(hostId1);
-    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
-    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
-    assertThat(contactPoint1.getDatacenter()).isEqualTo("dc1");
+    assertThat(newNodes.get(hostId1).getEndPoint()).isEqualTo(endPoint1);
+    assertThat(newNodes.get(hostId1).getHostId()).isEqualTo(hostId1);
+    assertThat(((DefaultNode) newNodes.get(hostId1)).getDatacenter()).isEqualTo("dc1");
+  }
+
+  @Test
+  public void should_reuse_control_node_from_metadata() {
+    // Given — the control connection registered this node in metadata before the refresh
+    DefaultNode controlNode = TestNodeFactory.newNode(1, hostId1, context);
+    controlNode.openConnections = 1; // simulate control connection
+    DefaultMetadata metadataWithControlNode =
+        new DefaultMetadata(
+            ImmutableMap.of(hostId1, controlNode), Collections.emptyMap(), null, null);
+
+    Iterable<NodeInfo> newInfos =
+        ImmutableList.of(
+            DefaultNodeInfo.builder()
+                .withEndPoint(controlNode.getEndPoint())
+                .withHostId(hostId1)
+                .withDatacenter("dc1")
+                .build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint2).withHostId(hostId2).build());
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
+
+    // When
+    MetadataRefresh.Result result = refresh.compute(metadataWithControlNode, false, context);
+
+    // Then
+    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
+    assertThat(newNodes).containsOnlyKeys(hostId1, hostId2);
+    // The control node instance should be reused (same object)
+    assertThat(newNodes.get(hostId1)).isSameAs(controlNode);
+    // Connection state should be preserved
+    assertThat(newNodes.get(hostId1).getOpenConnections()).isEqualTo(1);
+    // But metadata should be populated from NodeInfo
+    assertThat(((DefaultNode) newNodes.get(hostId1)).getDatacenter()).isEqualTo("dc1");
+    // No added event for the reused control node; only for the new node
+    assertThat(result.events)
+        .containsExactly(NodeStateEvent.added((DefaultNode) newNodes.get(hostId2)));
+  }
+
+  @Test
+  public void should_emit_removed_event_when_control_node_not_in_discovered_list() {
+    // Given — the control connection registered this node in metadata before the refresh
+    DefaultNode controlNode = TestNodeFactory.newNode(1, hostId1, context);
+    controlNode.openConnections = 1;
+    DefaultMetadata metadataWithControlNode =
+        new DefaultMetadata(
+            ImmutableMap.of(hostId1, controlNode), Collections.emptyMap(), null, null);
+
+    // The discovered node list does NOT contain the control node's hostId
+    Iterable<NodeInfo> newInfos =
+        ImmutableList.of(
+            DefaultNodeInfo.builder().withEndPoint(endPoint2).withHostId(hostId2).build());
+    InitialNodeListRefresh refresh = new InitialNodeListRefresh(newInfos);
+
+    // When
+    MetadataRefresh.Result result = refresh.compute(metadataWithControlNode, false, context);
+
+    // Then
+    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
+    assertThat(newNodes).containsOnlyKeys(hostId2);
+    assertThat(newNodes).doesNotContainKey(hostId1);
+    // Should emit removed for the control node and added for the new node
+    assertThat(result.events)
+        .containsExactlyInAnyOrder(
+            NodeStateEvent.added((DefaultNode) newNodes.get(hostId2)),
+            NodeStateEvent.removed(controlNode));
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -120,7 +120,6 @@ public class MetadataManagerTest {
     assertThat(metadataManager.getContactPoints())
         .extracting(Node::getEndPoint)
         .containsOnly(END_POINT2);
-    assertThat(metadataManager.wasImplicitContactPoint()).isFalse();
   }
 
   @Test
@@ -132,11 +131,10 @@ public class MetadataManagerTest {
     assertThat(metadataManager.getContactPoints())
         .extracting(Node::getEndPoint)
         .containsOnly(MetadataManager.DEFAULT_CONTACT_POINT);
-    assertThat(metadataManager.wasImplicitContactPoint()).isTrue();
   }
 
   @Test
-  public void should_copy_contact_points_on_refresh_of_all_nodes() {
+  public void should_create_initial_refresh_on_first_node_list() {
     // Given
     // Run previous scenario to trigger the addition of the default contact point:
     should_use_default_if_no_contact_points_provided();
@@ -154,9 +152,6 @@ public class MetadataManagerTest {
     assertThatStage(refreshNodesFuture).isSuccess();
     assertThat(metadataManager.refreshes).hasSize(1);
     InitialNodeListRefresh refresh = (InitialNodeListRefresh) metadataManager.refreshes.get(0);
-    assertThat(refresh.contactPoints)
-        .extracting(Node::getEndPoint)
-        .containsOnly(MetadataManager.DEFAULT_CONTACT_POINT);
     assertThat(refresh.nodeInfos).containsExactlyInAnyOrder(info1, info2);
   }
 
@@ -165,7 +160,7 @@ public class MetadataManagerTest {
     // Given
     // Run previous scenario to trigger the addition of the default contact point and a first
     // refresh:
-    should_copy_contact_points_on_refresh_of_all_nodes();
+    should_create_initial_refresh_on_first_node_list();
     // Discard that first refresh, we don't really care about it in the context of this test, only
     // that the next one won't be the first
     metadataManager.refreshes.clear();
@@ -403,6 +398,96 @@ public class MetadataManagerTest {
         () -> result1.toCompletableFuture().isDone() && result2.toCompletableFuture().isDone());
     assertThatStage(result1).isFailed(t -> assertThat(t).isEqualTo(expectedException));
     assertThatStage(result2).isFailed(t -> assertThat(t).isEqualTo(expectedException));
+  }
+
+  @Test
+  public void should_reuse_existing_node_on_duplicate_registerNode() {
+    // Given — register a node with a specific hostId
+    UUID hostId = UUID.randomUUID();
+    NodeInfo nodeInfo =
+        DefaultNodeInfo.builder().withEndPoint(END_POINT2).withHostId(hostId).build();
+
+    // When — register the node
+    CompletionStage<Node> firstResult = metadataManager.registerNode(nodeInfo);
+    waitForPendingAdminTasks(() -> firstResult.toCompletableFuture().isDone());
+
+    // Then — node should be registered
+    assertThatStage(firstResult).isSuccess();
+    Node firstNode = firstResult.toCompletableFuture().join();
+    assertThat(firstNode.getHostId()).isEqualTo(hostId);
+    assertThat(metadataManager.getMetadata().getNodes()).containsKey(hostId);
+
+    // When — register again with the same hostId (simulating concurrent refresh)
+    NodeInfo duplicateInfo =
+        DefaultNodeInfo.builder().withEndPoint(END_POINT3).withHostId(hostId).build();
+    CompletionStage<Node> secondResult = metadataManager.registerNode(duplicateInfo);
+    waitForPendingAdminTasks(() -> secondResult.toCompletableFuture().isDone());
+
+    // Then — should return the same node instance, not create a duplicate
+    assertThatStage(secondResult).isSuccess();
+    Node secondNode = secondResult.toCompletableFuture().join();
+    assertThat(secondNode).isSameAs(firstNode);
+    assertThat(metadataManager.getMetadata().getNodes()).hasSize(1);
+  }
+
+  @Test
+  public void should_handle_concurrent_registerNode_calls_with_same_hostId() {
+    // Given — two concurrent registerNode calls for the same hostId
+    UUID hostId = UUID.randomUUID();
+    NodeInfo nodeInfo1 =
+        DefaultNodeInfo.builder().withEndPoint(END_POINT2).withHostId(hostId).build();
+    NodeInfo nodeInfo2 =
+        DefaultNodeInfo.builder().withEndPoint(END_POINT3).withHostId(hostId).build();
+
+    // When — submit both calls before either completes on the admin executor
+    CompletionStage<Node> result1 = metadataManager.registerNode(nodeInfo1);
+    CompletionStage<Node> result2 = metadataManager.registerNode(nodeInfo2);
+
+    // Then — both should complete successfully, returning the same node
+    waitForPendingAdminTasks(
+        () -> result1.toCompletableFuture().isDone() && result2.toCompletableFuture().isDone());
+    assertThatStage(result1).isSuccess();
+    assertThatStage(result2).isSuccess();
+    Node node1 = result1.toCompletableFuture().join();
+    Node node2 = result2.toCompletableFuture().join();
+    assertThat(node1.getHostId()).isEqualTo(hostId);
+    assertThat(node2).isSameAs(node1);
+    assertThat(metadataManager.getMetadata().getNodes()).hasSize(1);
+  }
+
+  @Test
+  public void should_fire_added_event_on_registerNode_after_initial_refresh() {
+    // Given — trigger a refresh cycle to set didFirstNodeListRefresh = true
+    NodeInfo info = mock(NodeInfo.class);
+    when(topologyMonitor.refreshNodeList())
+        .thenReturn(CompletableFuture.completedFuture(ImmutableList.of(info)));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    metadataManager.refreshNodes();
+    waitForPendingAdminTasks(() -> metadataManager.refreshes.size() == 1);
+
+    // When — register a new node after the initial refresh
+    UUID hostId = UUID.randomUUID();
+    NodeInfo nodeInfo =
+        DefaultNodeInfo.builder().withEndPoint(END_POINT2).withHostId(hostId).build();
+    CompletionStage<Node> result = metadataManager.registerNode(nodeInfo);
+    waitForPendingAdminTasks(() -> result.toCompletableFuture().isDone());
+
+    // Then — NodeStateEvent.added should have been fired
+    assertThatStage(result).isSuccess();
+    Node registeredNode = result.toCompletableFuture().join();
+    verify(eventBus, timeout(500)).fire(NodeStateEvent.added((DefaultNode) registeredNode));
+  }
+
+  @Test
+  public void should_throw_on_registerNode_with_null_hostId() {
+    // Given — a NodeInfo with null hostId
+    NodeInfo nodeInfo = DefaultNodeInfo.builder().withEndPoint(END_POINT2).build();
+
+    // When/Then — should throw NullPointerException from Preconditions.checkNotNull
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> metadataManager.registerNode(nodeInfo))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Cannot register node without hostId");
   }
 
   private static class TestMetadataManager extends MetadataManager {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
@@ -39,6 +39,13 @@ public class TestNodeFactory {
     return node;
   }
 
+  public static DefaultNode newNode(NodeInfo nodeInfo, InternalDriverContext context) {
+    DefaultNode node = new DefaultNode(nodeInfo.getEndPoint(), context);
+    node.hostId = nodeInfo.getHostId();
+    nodeInfo.getBroadcastRpcAddress().ifPresent(addr -> node.broadcastRpcAddress = addr);
+    return node;
+  }
+
   public static DefaultNode newContactPoint(int lastIpByte, InternalDriverContext context) {
     DefaultEndPoint endPoint = newEndPoint(lastIpByte);
     return DefaultNode.newContactPoint(endPoint, context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
@@ -24,14 +24,16 @@ import java.util.UUID;
 public class TestNodeFactory {
 
   public static DefaultNode newNode(int lastIpByte, InternalDriverContext context) {
-    DefaultNode node = newContactPoint(lastIpByte, context);
+    DefaultEndPoint endPoint = newEndPoint(lastIpByte);
+    DefaultNode node = new DefaultNode(endPoint, context);
     node.hostId = UUID.randomUUID();
     node.broadcastRpcAddress = ((InetSocketAddress) node.getEndPoint().resolve());
     return node;
   }
 
   public static DefaultNode newNode(int lastIpByte, UUID hostId, InternalDriverContext context) {
-    DefaultNode node = newContactPoint(lastIpByte, context);
+    DefaultEndPoint endPoint = newEndPoint(lastIpByte);
+    DefaultNode node = new DefaultNode(endPoint, context);
     node.hostId = hostId;
     node.broadcastRpcAddress = ((InetSocketAddress) node.getEndPoint().resolve());
     return node;
@@ -39,7 +41,7 @@ public class TestNodeFactory {
 
   public static DefaultNode newContactPoint(int lastIpByte, InternalDriverContext context) {
     DefaultEndPoint endPoint = newEndPoint(lastIpByte);
-    return new DefaultNode(endPoint, context);
+    return DefaultNode.newContactPoint(endPoint, context);
   }
 
   public static DefaultEndPoint newEndPoint(int lastByteOfIp) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
@@ -20,7 +20,6 @@ package com.datastax.oss.driver.core;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.rows;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.awaitility.Awaitility.await;
 
@@ -30,9 +29,11 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
+import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
@@ -43,8 +44,11 @@ import com.datastax.oss.simulacron.common.stubbing.PrimeDsl;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.RejectScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Map;
+import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -125,28 +129,25 @@ public class ConnectIT {
   }
 
   /**
-   * Test for JAVA-1948. This ensures that when the LBP initialization fails that any connections
-   * are cleaned up appropriately.
+   * Test for JAVA-1948, updated after control-connection-based DC inference was added. The driver
+   * can now infer the local DC from the control connection endpoint, so explicit contact points
+   * without a local DC no longer fail — the session should connect successfully.
    */
   @Test
-  public void should_cleanup_on_lbp_init_failure() {
+  public void should_infer_local_dc_from_control_connection() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .without(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)
             .build();
-    assertThatThrownBy(
-            () ->
-                CqlSession.builder()
-                    .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
-                    .withConfigLoader(loader)
-                    .build())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(
-            "Since you provided explicit contact points, the local DC must be explicitly set");
-    // One second should be plenty of time for connections to close server side
-    await()
-        .atMost(1, TimeUnit.SECONDS)
-        .until(() -> SIMULACRON_RULE.cluster().getConnections().getConnections().isEmpty());
+    try (CqlSession session =
+        CqlSession.builder()
+            .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+            .withConfigLoader(loader)
+            .build()) {
+      assertThat(session.getMetadata().getNodes()).isNotEmpty();
+      Node controlNode = session.getMetadata().getNodes().values().iterator().next();
+      assertThat(controlNode.getDatacenter()).isEqualTo("dc1");
+    }
   }
 
   /**
@@ -185,6 +186,40 @@ public class ConnectIT {
     }
   }
 
+  /**
+   * Tests that when the load balancing policy fails to initialize, the session cleans up properly
+   * (closes all connections) and surfaces the error.
+   */
+  @Test
+  public void should_cleanup_on_lbp_init_failure() {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withClass(
+                DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, FailingLoadBalancingPolicy.class)
+            .build();
+
+    Throwable t =
+        catchThrowable(
+            () ->
+                CqlSession.builder()
+                    .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+                    .withConfigLoader(loader)
+                    .build());
+
+    assertThat(t).isInstanceOf(IllegalStateException.class);
+    assertThat(t).hasMessageContaining("LBP init failure for testing");
+
+    // Verify that all connections were cleaned up
+    await()
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(SIMULACRON_RULE.cluster().getActiveConnections())
+                    .as("All connections should be cleaned up after LBP init failure")
+                    .isEqualTo(0));
+  }
+
   @SuppressWarnings("unchecked")
   private CompletionStage<? extends Session> newSessionAsync(DriverConfigLoader loader) {
     return SessionUtils.baseBuilder()
@@ -215,5 +250,43 @@ public class ConnectIT {
             "should not be called with isInitialConnection==false");
       }
     }
+  }
+
+  /**
+   * Test policy that always fails during {@link #init}. Used to verify that the session cleans up
+   * connections properly when the LBP fails to initialize.
+   */
+  public static class FailingLoadBalancingPolicy implements LoadBalancingPolicy {
+
+    @SuppressWarnings("unused")
+    public FailingLoadBalancingPolicy(DriverContext context, String profileName) {
+      // constructor needed for loading via config.
+    }
+
+    @Override
+    public void init(@NonNull Map<UUID, Node> nodes, @NonNull DistanceReporter distanceReporter) {
+      throw new IllegalStateException("LBP init failure for testing");
+    }
+
+    @NonNull
+    @Override
+    public Queue<Node> newQueryPlan(@Nullable Request request, @Nullable Session session) {
+      return new ArrayDeque<>();
+    }
+
+    @Override
+    public void onAdd(@NonNull Node node) {}
+
+    @Override
+    public void onUp(@NonNull Node node) {}
+
+    @Override
+    public void onDown(@NonNull Node node) {}
+
+    @Override
+    public void onRemove(@NonNull Node node) {}
+
+    @Override
+    public void close() {}
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
@@ -77,7 +77,7 @@ public class ProtocolVersionMixedClusterIT {
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
-              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
               // connection channel endpoint
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",
@@ -108,7 +108,7 @@ public class ProtocolVersionMixedClusterIT {
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
-              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
               // connection channel endpoint
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",
@@ -162,7 +162,7 @@ public class ProtocolVersionMixedClusterIT {
           .containsExactly(
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
-              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
+              // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
               // connection channel endpoint
               "SELECT * FROM system.local WHERE key='local'",
               "SELECT * FROM system.local WHERE key='local'",

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
@@ -138,6 +138,10 @@ public class NlbSimulator implements Closeable {
     if (discoveryProxy != null) {
       String nodeIp = ccmBridge.getNodeIpAddress(nodeId);
       discoveryProxy.removeTarget(new InetSocketAddress(nodeIp, 9042));
+      if (activeNodes.isEmpty()) {
+        discoveryProxy.close();
+        discoveryProxy = null;
+      }
     }
 
     LOG.info("NLB: removed node{}", nodeId);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/RoundRobinProxy.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/RoundRobinProxy.java
@@ -31,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,8 +98,14 @@ public class RoundRobinProxy implements Closeable {
         }
         activeSockets.add(client);
 
+        List<InetSocketAddress> snapshot = new ArrayList<>(targets);
+        if (snapshot.isEmpty()) {
+          closeQuietly(client);
+          LOG.warn("RoundRobinProxy has no targets, rejecting connection");
+          continue;
+        }
         InetSocketAddress target =
-            targets.get(Math.floorMod(counter.getAndIncrement(), targets.size()));
+            snapshot.get(Math.floorMod(counter.getAndIncrement(), snapshot.size()));
         Socket remote = new Socket();
         activeSockets.add(remote);
         try {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/AllLoadBalancingPoliciesSimulacronIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/AllLoadBalancingPoliciesSimulacronIT.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
@@ -403,18 +404,22 @@ public class AllLoadBalancingPoliciesSimulacronIT {
       boolean allowLocalCl,
       boolean tokenAware,
       Predicate<Node> nodeFilter) {
-    DriverConfigLoader loader =
+    ProgrammaticDriverConfigLoaderBuilder builder =
         SessionUtils.configLoaderBuilder()
             .withBoolean(DefaultDriverOption.METADATA_SCHEMA_ENABLED, tokenAware)
             .withString(DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, lbp)
-            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, dc)
             .withInt(
                 DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC,
                 maxRemoteNodes)
             .withBoolean(
                 DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS,
-                allowLocalCl)
-            .build();
+                allowLocalCl);
+    if (dc != null) {
+      builder.withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, dc);
+    } else {
+      builder.without(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
+    }
+    DriverConfigLoader loader = builder.build();
     return SessionUtils.newSession(SIMULACRON_RULE, null, null, null, nodeFilter, loader);
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -83,8 +82,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -111,8 +108,6 @@ public class NodeStateIT {
           .build();
 
   @Rule public TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
-
-  private @Captor ArgumentCaptor<DefaultNode> nodeCaptor;
 
   private InternalDriverContext driverContext;
   private ConfigurableIgnoresPolicy defaultLoadBalancingPolicy;
@@ -184,10 +179,14 @@ public class NodeStateIT {
                 .findNode(simulacronRegularNode.inetSocketAddress())
                 .orElseThrow(AssertionError::new);
 
-    // SessionRule uses all nodes as contact points, so we only get onUp notifications for them (no
-    // onAdd)
-    inOrder.verify(nodeStateListener, timeout(500)).onUp(metadataControlNode);
-    inOrder.verify(nodeStateListener, timeout(500)).onUp(metadataRegularNode);
+    // The control node was pre-registered via registerNode, so no onAdd event is fired for it.
+    // The regular node is new to metadata (contact points are no longer copied into
+    // InitialNodeListRefresh), so it gets an onAdd event when first discovered.
+    verify(nodeStateListener, timeout(500)).onUp(metadataControlNode);
+    verify(nodeStateListener, timeout(500)).onUp(metadataRegularNode);
+    verify(nodeStateListener, timeout(500)).onAdd(metadataRegularNode);
+    // Create fresh inOrder for subsequent test method verifications
+    inOrder = inOrder(nodeStateListener);
   }
 
   @After
@@ -552,16 +551,10 @@ public class NodeStateIT {
       Node localMetadataNode1 = metadata.findNode(endPoint1).orElseThrow(AssertionError::new);
       Node localMetadataNode2 = metadata.findNode(endPoint2).orElseThrow(AssertionError::new);
 
-      // The order of the calls is not deterministic because contact points are shuffled, but it
-      // does not matter here since Mockito.verify does not enforce order.
-      verify(localNodeStateListener, timeout(500)).onRemove(nodeCaptor.capture());
-      assertThat(nodeCaptor.getValue().getEndPoint()).isEqualTo(wrongContactPoint);
+      // Node1 is a reused contact point (no onAdd), node2 is discovered fresh (onAdd).
+      // The wrong contact point is simply not in the discovered list.
       verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
       verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
-
-      // Note: there might be an additional onDown for wrongContactPoint if it was hit first at
-      // init. This is hard to test since the node was removed later, so we simply don't call
-      // verifyNoMoreInteractions.
     }
   }
 
@@ -604,14 +597,21 @@ public class NodeStateIT {
             // Stopped node was tried first and marked down, that's our target scenario
             verify(localNodeStateListener, timeout(500)).onDown(localMetadataNode2);
             verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
+            // The non-control node is new to metadata (contact points are no longer copied
+            // into InitialNodeListRefresh) and gets an onAdd event when first discovered.
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
             verify(localNodeStateListener, timeout(500)).onSessionReady(localSession);
-            verifyNoMoreInteractions(localNodeStateListener);
+            // Note: there may also be an onDown for the contact point node (a temporary object
+            // separate from the metadata node) when the control connection first fails to connect
+            // to it. We don't assert strict verifyNoMoreInteractions because of this.
             return;
           } else {
             // Stopped node was not tried
             assertThat(localMetadataNode2).isUnknown();
             verify(localNodeStateListener, timeout(500)).onUp(localMetadataNode1);
-            verifyNoMoreInteractions(localNodeStateListener);
+            // The non-control node is new to metadata (contact points are no longer copied
+            // into InitialNodeListRefresh) and gets an onAdd event when first discovered.
+            verify(localNodeStateListener, timeout(500)).onAdd(localMetadataNode2);
           }
         }
         reset(localNodeStateListener);


### PR DESCRIPTION
## Summary

Refactors how contact points transition into metadata nodes:

- **ControlConnection resolves contact points eagerly**: After opening a channel to a contact point, the control connection queries `system.local` via `getChannelNodeInfo()` and registers the node into metadata (`MetadataManager.registerNode()`) before `InitialNodeListRefresh` runs.
- **InitialNodeListRefresh simplified**: No longer receives contact points. Creates new nodes for all discovered hosts, reusing any pre-registered node (matched by hostId) to preserve connection state.
- **New `MetadataManager.registerNode()`**: Atomically creates and inserts a metadata node from `NodeInfo` on the admin executor, preventing races with concurrent metadata refreshes.
- **Control node tracking by hostId**: New `controlNode()` accessor and `isControlNode()` method match by hostId instead of endpoint comparison, fixing false matches behind NLB/proxy where multiple nodes share the same endpoint.
- **Local DC inference from control connection**: LBP helpers (`OptionalLocalDcHelper`, `MandatoryLocalDcHelper`, `InferringLocalDcHelper`) infer the local DC from the control connection node instead of contact points, removing `wasImplicitContactPoint()` and contact-point DC checks.
- **Contact points without metrics**: `DefaultNode.newContactPoint()` creates nodes with `NoopNodeMetricUpdater` since contact points are temporary objects replaced by real metadata nodes.
- **TopologyMonitor API**: `getChannelEndpoint()` renamed to `getChannelNodeInfo()`, returning full `NodeInfo` instead of just `EndPoint`.
- **Edge case handling**: Channel closed during resolve, control node removed from metadata on reconnect, empty proxy targets in `RoundRobinProxy`, NlbSimulator cleanup when all nodes removed.

## Test plan

- [x] Existing unit tests updated and pass: `ControlConnectionTest`, `InitialNodeListRefreshTest`, `MetadataManagerTest`, LBP init/distance tests
- [x] New unit tests: control node lifecycle (resolve, clear on close, restore after reconnect), `registerNode` idempotency, contact-point-to-metadata-node resolution
- [x] Integration tests updated: `ConnectIT` (DC inference from control connection, LBP init failure cleanup), `NodeStateIT` (event expectations for new node lifecycle)
- [x] CI/CD pipeline passes