### PR TITLE
perf: replace SELECT * with explicit projections in topology monitor queries

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminResult.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminResult.java
@@ -20,6 +20,7 @@ package com.datastax.oss.driver.internal.core.adminrequest;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.AbstractIterator;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
 import com.datastax.oss.protocol.internal.response.result.Rows;
@@ -69,6 +70,12 @@ public class AdminResult implements Iterable<AdminRow> {
             : new AdminRow(columnSpecs, rowData, protocolVersion);
       }
     };
+  }
+
+  /** Returns the names of all columns in this result set, in response metadata order. */
+  @NonNull
+  public List<String> getColumnNames() {
+    return ImmutableList.copyOf(columnSpecs.keySet());
   }
 
   public boolean hasNextPage() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -565,6 +565,10 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       }
 
       // Otherwise, perform a full refresh (we don't know how long we were disconnected)
+      // Reset any cached column projections so the next topology refresh re-learns what
+      // columns are available via SELECT * (the cluster may have changed after reconnect).
+      context.getTopologyMonitor().resetColumnCaches();
+
       // If client routes are active, wait for the routes refresh to complete before refreshing
       // nodes, so that buildNodeEndPoint sees up-to-date route data.
       CompletionStage<Void> routesReady;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -32,6 +32,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
@@ -74,6 +75,121 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
   private static final String NATIVE_PORT = "native_port";
   private static final String NATIVE_TRANSPORT_PORT = "native_transport_port";
 
+  /**
+   * The columns we actually read from {@code system.local}. Used to intersect with the full column
+   * list returned by the first {@code SELECT *} response, so that subsequent projected queries only
+   * fetch columns the driver uses.
+   *
+   * <p>Includes DSE-specific columns; absent columns are silently ignored by the intersection step.
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> LOCAL_COLUMNS_OF_INTEREST =
+      ImmutableSet.of(
+          // Topology / addressing
+          "broadcast_address",
+          "broadcast_port",
+          "listen_address",
+          "listen_port",
+          "rpc_address",
+          "rpc_port",
+          "native_address",
+          "native_transport_address",
+          "native_transport_port",
+          "native_transport_port_ssl",
+          // Node metadata
+          "data_center",
+          "rack",
+          "release_version",
+          "tokens",
+          "partitioner",
+          "host_id",
+          "schema_version",
+          // DSE-specific
+          "dse_version",
+          "graph",
+          "workload",
+          "workloads",
+          "server_id",
+          "storage_port",
+          "storage_port_ssl",
+          "jmx_port");
+
+  /**
+   * The columns we actually read from {@code system.peers}. Mirrors {@link
+   * #LOCAL_COLUMNS_OF_INTEREST} but replaces {@code listen_address}/{@code listen_port} with the
+   * {@code peer} column used as a broadcast-address fallback and peer-row identifier.
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> PEERS_COLUMNS_OF_INTEREST =
+      ImmutableSet.of(
+          // Peer identifier / broadcast address fallback
+          "peer",
+          // Topology / addressing
+          "broadcast_address",
+          "broadcast_port",
+          "rpc_address",
+          "rpc_port",
+          "native_address",
+          "native_transport_address",
+          "native_transport_port",
+          "native_transport_port_ssl",
+          // Node metadata
+          "data_center",
+          "rack",
+          "release_version",
+          "tokens",
+          "partitioner",
+          "host_id",
+          "schema_version",
+          // DSE-specific
+          "dse_version",
+          "graph",
+          "workload",
+          "workloads",
+          "server_id",
+          "storage_port",
+          "storage_port_ssl",
+          "jmx_port");
+
+  /**
+   * The columns we actually read from {@code system.peers_v2} (Cassandra ≥ 4.0). Replaces {@code
+   * rpc_address} with {@code native_address}/{@code native_port} as the primary RPC endpoint
+   * columns, and adds {@code peer_port}.
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> PEERS_V2_COLUMNS_OF_INTEREST =
+      ImmutableSet.of(
+          // Peer identifier
+          "peer",
+          "peer_port",
+          // Primary RPC endpoint (peers_v2-specific)
+          "native_address",
+          "native_port",
+          // Topology / addressing
+          "broadcast_address",
+          "broadcast_port",
+          "rpc_address",
+          "native_transport_address",
+          "native_transport_port",
+          "native_transport_port_ssl",
+          // Node metadata
+          "data_center",
+          "rack",
+          "release_version",
+          "tokens",
+          "partitioner",
+          "host_id",
+          "schema_version",
+          // DSE-specific
+          "dse_version",
+          "graph",
+          "workload",
+          "workloads",
+          "server_id",
+          "storage_port",
+          "storage_port_ssl",
+          "jmx_port");
+
   private final String logPrefix;
   protected final InternalDriverContext context;
   private final ControlConnection controlConnection;
@@ -83,6 +199,14 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
 
   @VisibleForTesting volatile boolean isSchemaV2;
   @VisibleForTesting volatile int port = -1;
+
+  // Column name caches: null means "not yet learned — use SELECT *".
+  // Populated on the first successful response as the intersection of the server's column list
+  // and the *_COLUMNS_OF_INTEREST set, so subsequent queries project only columns the driver reads.
+  // Reset to null on reconnect.
+  private volatile List<String> localColumns = null;
+  private volatile List<String> peersColumns = null;
+  private volatile List<String> peersV2Columns = null;
 
   public DefaultTopologyMonitor(InternalDriverContext context) {
     this.logPrefix = context.getSessionName();
@@ -95,6 +219,63 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     // Set this to true initially, after the first refreshNodes is called this will either stay true
     // or be set to false;
     this.isSchemaV2 = true;
+  }
+
+  /**
+   * Resets all column name caches to null, causing the next query to use {@code SELECT *} and
+   * re-learn the available columns from the response. Should be called on reconnect.
+   */
+  @Override
+  public void resetColumnCaches() {
+    localColumns = null;
+    peersColumns = null;
+    peersV2Columns = null;
+  }
+
+  /**
+   * Returns a new list containing only the elements of {@code serverColumns} that are present in
+   * {@code needed}, preserving the server-response order. Returns an empty list (never {@code
+   * null}) if no columns match.
+   *
+   * <p>This is used when populating the column caches from a {@code SELECT *} response: rather than
+   * caching all server columns, we cache only the subset the driver actually reads, so that
+   * subsequent projected queries skip unused columns (e.g. large collection columns the driver
+   * never inspects).
+   */
+  private static List<String> intersectWithNeeded(
+      List<String> serverColumns, ImmutableSet<String> needed) {
+    return serverColumns.stream().filter(needed::contains).collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Builds a {@code SELECT} query string.
+   *
+   * @param columns the column names to project, in the order they will appear in the query, or
+   *     {@code null} to use {@code SELECT *}
+   * @param table the table name (e.g. {@code "system.local"})
+   * @return the query string without a trailing WHERE clause
+   */
+  private String buildQuery(List<String> columns, String table) {
+    String projection = (columns == null) ? "*" : String.join(", ", columns);
+    return "SELECT " + projection + " FROM " + table;
+  }
+
+  /**
+   * Builds a {@code SELECT} query string with a WHERE clause.
+   *
+   * @param columns the column names to project, in the order they will appear in the query, or
+   *     {@code null} to use {@code SELECT *}
+   * @param table the table name
+   * @param where the WHERE clause (without the {@code WHERE} keyword)
+   * @return the full query string
+   */
+  private String buildQuery(List<String> columns, String table, String where) {
+    return buildQuery(columns, table) + " WHERE " + where;
+  }
+
+  /** Returns the peers column cache appropriate for the current schema version. */
+  private List<String> getPeerColumnsCache() {
+    return isSchemaV2 ? peersV2Columns : peersColumns;
   }
 
   @Override
@@ -127,12 +308,12 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     } else if (node.getBroadcastAddress().isPresent()) {
       CompletionStage<AdminResult> query;
       if (isSchemaV2) {
+        // Use SELECT * for narrow WHERE-clause queries: projecting a single-row result gives
+        // negligible benefit, and the fixed WHERE form is easier to prime in test infrastructure.
         query =
             query(
                 channel,
-                "SELECT * FROM "
-                    + getPeerTableName()
-                    + " WHERE peer = :address and peer_port = :port",
+                buildQuery(null, getPeerTableName(), "peer = :address and peer_port = :port"),
                 ImmutableMap.of(
                     "address",
                     node.getBroadcastAddress().get().getAddress(),
@@ -142,12 +323,12 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
         query =
             query(
                 channel,
-                "SELECT * FROM " + getPeerTableName() + " WHERE peer = :address",
+                buildQuery(null, getPeerTableName(), "peer = :address"),
                 ImmutableMap.of("address", node.getBroadcastAddress().get().getAddress()));
       }
       return query.thenApply(result -> firstPeerRowAsNodeInfo(result, localEndPoint));
     } else {
-      return query(channel, "SELECT * FROM " + getPeerTableName())
+      return query(channel, buildQuery(getPeerColumnsCache(), getPeerTableName()))
           .thenApply(result -> findInPeers(result, node.getHostId(), localEndPoint));
     }
   }
@@ -160,7 +341,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     LOG.debug("[{}] Fetching info for new node {}", logPrefix, broadcastRpcAddress);
     DriverChannel channel = controlConnection.channel();
     EndPoint localEndPoint = channel.getEndPoint();
-    return query(channel, "SELECT * FROM " + getPeerTableName())
+    return query(channel, buildQuery(getPeerColumnsCache(), getPeerTableName()))
         .thenApply(result -> findInPeers(result, broadcastRpcAddress, localEndPoint));
   }
 
@@ -170,9 +351,13 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
       return CompletableFutures.failedFuture(new IllegalStateException("closed"));
     }
     EndPoint localEndPoint = channel.getEndPoint();
-    return query(channel, "SELECT * FROM system.local WHERE key='local'")
+    return query(channel, buildQuery(localColumns, "system.local", "key='local'"))
         .thenApply(
             result -> {
+              if (localColumns == null && !result.getColumnNames().isEmpty()) {
+                localColumns =
+                    intersectWithNeeded(result.getColumnNames(), LOCAL_COLUMNS_OF_INTEREST);
+              }
               Iterator<AdminRow> iterator = result.iterator();
               if (!iterator.hasNext()) {
                 throw new IllegalStateException(
@@ -197,8 +382,9 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     savePort(channel);
 
     CompletionStage<AdminResult> localQuery =
-        query(channel, "SELECT * FROM system.local WHERE key='local'");
-    CompletionStage<AdminResult> peersV2Query = query(channel, "SELECT * FROM system.peers_v2");
+        query(channel, buildQuery(localColumns, "system.local", "key='local'"));
+    CompletionStage<AdminResult> peersV2Query =
+        query(channel, buildQuery(peersV2Columns, "system.peers_v2"));
     CompletableFuture<AdminResult> peersQuery = new CompletableFuture<>();
 
     peersV2Query.whenComplete(
@@ -215,12 +401,16 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
                       && error.message.contains("Unknown keyspace/cf pair (system.peers_v2)"))) {
                 this.isSchemaV2 = false; // We should not attempt this query in the future.
                 CompletableFutures.completeFrom(
-                    query(channel, "SELECT * FROM system.peers"), peersQuery);
+                    query(channel, buildQuery(peersColumns, "system.peers")), peersQuery);
                 return;
               }
             }
             peersQuery.completeExceptionally(t);
           } else {
+            if (peersV2Columns == null && !r.getColumnNames().isEmpty()) {
+              peersV2Columns =
+                  intersectWithNeeded(r.getColumnNames(), PEERS_V2_COLUMNS_OF_INTEREST);
+            }
             peersQuery.complete(r);
           }
         });
@@ -228,6 +418,14 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     return localQuery.thenCombine(
         peersQuery,
         (controlNodeResult, peersResult) -> {
+          if (localColumns == null && !controlNodeResult.getColumnNames().isEmpty()) {
+            localColumns =
+                intersectWithNeeded(controlNodeResult.getColumnNames(), LOCAL_COLUMNS_OF_INTEREST);
+          }
+          if (!isSchemaV2 && peersColumns == null && !peersResult.getColumnNames().isEmpty()) {
+            peersColumns =
+                intersectWithNeeded(peersResult.getColumnNames(), PEERS_COLUMNS_OF_INTEREST);
+          }
           List<NodeInfo> nodeInfos = new ArrayList<>();
           AdminRow localRow = controlNodeResult.iterator().next();
           InetSocketAddress localBroadcastRpcAddress =

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
@@ -130,4 +130,15 @@ public interface TopologyMonitor extends AsyncAutoCloseable {
    * take a while to replicate across nodes.
    */
   CompletionStage<Boolean> checkSchemaAgreement();
+
+  /**
+   * Resets any cached column name sets learned from previous system table query responses.
+   *
+   * <p>Called by the control connection on reconnect so that the next topology refresh re-learns
+   * the available columns via {@code SELECT *} instead of reusing a potentially stale projection.
+   *
+   * <p>The default implementation is a no-op; implementations that cache column names (such as
+   * {@link DefaultTopologyMonitor}) should override this method.
+   */
+  default void resetColumnCaches() {}
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/adminrequest/AdminResultTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/adminrequest/AdminResultTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.adminrequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
+import com.datastax.oss.protocol.internal.response.result.DefaultRows;
+import com.datastax.oss.protocol.internal.response.result.RawType;
+import com.datastax.oss.protocol.internal.response.result.Rows;
+import com.datastax.oss.protocol.internal.response.result.RowsMetadata;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Queue;
+import org.junit.Test;
+
+public class AdminResultTest {
+
+  @Test
+  public void getColumnNames_should_return_all_column_names() {
+    // Given
+    ColumnSpec col1 =
+        new ColumnSpec(
+            "system",
+            "local",
+            "rpc_address",
+            0,
+            RawType.PRIMITIVES.get(ProtocolConstants.DataType.INET));
+    ColumnSpec col2 =
+        new ColumnSpec(
+            "system",
+            "local",
+            "data_center",
+            1,
+            RawType.PRIMITIVES.get(ProtocolConstants.DataType.VARCHAR));
+    ColumnSpec col3 =
+        new ColumnSpec(
+            "system",
+            "local",
+            "host_id",
+            2,
+            RawType.PRIMITIVES.get(ProtocolConstants.DataType.UUID));
+    RowsMetadata metadata = new RowsMetadata(ImmutableList.of(col1, col2, col3), null, null, null);
+    Queue<List<ByteBuffer>> data = Lists.newLinkedList();
+    Rows rows = new DefaultRows(metadata, data);
+
+    AdminResult result = new AdminResult(rows, null, ProtocolVersion.DEFAULT);
+
+    // When
+    List<String> columnNames = result.getColumnNames();
+
+    // Then
+    // Order must match the server response (rpc_address, data_center, host_id)
+    assertThat(columnNames).containsExactly("rpc_address", "data_center", "host_id");
+  }
+
+  @Test
+  public void getColumnNames_should_return_empty_list_for_empty_metadata() {
+    // Given
+    RowsMetadata metadata = new RowsMetadata(ImmutableList.of(), null, null, null);
+    Queue<List<ByteBuffer>> data = Lists.newLinkedList();
+    Rows rows = new DefaultRows(metadata, data);
+
+    AdminResult result = new AdminResult(rows, null, ProtocolVersion.DEFAULT);
+
+    // When
+    List<String> columnNames = result.getColumnNames();
+
+    // Then
+    assertThat(columnNames).isEmpty();
+  }
+
+  @Test
+  public void getColumnNames_should_return_unmodifiable_list() {
+    // Given
+    ColumnSpec col =
+        new ColumnSpec(
+            "system",
+            "local",
+            "host_id",
+            0,
+            RawType.PRIMITIVES.get(ProtocolConstants.DataType.UUID));
+    RowsMetadata metadata = new RowsMetadata(ImmutableList.of(col), null, null, null);
+    Queue<List<ByteBuffer>> data = Lists.newLinkedList();
+    Rows rows = new DefaultRows(metadata, data);
+
+    AdminResult result = new AdminResult(rows, null, ProtocolVersion.DEFAULT);
+    List<String> columnNames = result.getColumnNames();
+
+    // When / Then
+    assertThat(columnNames).containsExactly("host_id");
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> columnNames.add("extra_column"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AdminResultTestHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AdminResultTestHelper.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
+import java.util.List;
 
 /** Test utility for constructing {@link AdminResult} mocks without network access. */
 public class AdminResultTestHelper {
@@ -34,6 +35,17 @@ public class AdminResultTestHelper {
   public static AdminResult mockResult(AdminRow... rows) {
     AdminResult result = mock(AdminResult.class);
     when(result.iterator()).thenAnswer(invocation -> Iterators.forArray(rows));
+    return result;
+  }
+
+  /**
+   * Returns a mock {@link AdminResult} whose iterator yields the given rows and whose {@link
+   * AdminResult#getColumnNames()} returns the given column names. Use this in warm-cache tests that
+   * need the monitor to learn a specific projected column set from the response.
+   */
+  public static AdminResult mockResultWithColumns(List<String> columnNames, AdminRow... rows) {
+    AdminResult result = mockResult(rows);
+    when(result.getColumnNames()).thenReturn(columnNames);
     return result;
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -48,6 +48,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
@@ -612,6 +613,119 @@ public class DefaultTopologyMonitorTest {
               assertThat(peer1nodeInfo.getEndPoint().resolve())
                   .isEqualTo(new InetSocketAddress("127.0.0.2", 9043));
             });
+  }
+
+  @Test
+  public void should_use_projected_query_on_second_refresh_node_list_call() {
+    // Given — first call uses SELECT * and teaches the monitor the available columns
+    AdminRow local = mockLocalRow(1, node1.getHostId());
+    AdminRow peer2 = mockPeersV2Row(2, node2.getHostId());
+    ImmutableList<String> localCols = ImmutableList.of("rpc_address", "data_center", "host_id");
+    ImmutableList<String> peersCols = ImmutableList.of("native_address", "native_port", "host_id");
+    topologyMonitor.isSchemaV2 = true;
+    topologyMonitor.stubQueries(
+        // First call — SELECT *
+        new StubbedQuery(
+            "SELECT * FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(localCols, local)),
+        new StubbedQuery(
+            "SELECT * FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(peersCols, peer2)));
+    topologyMonitor.refreshNodeList().toCompletableFuture().join();
+
+    // Second call — caches are warm, should use projected query with learned columns
+    AdminRow local2 = mockLocalRow(1, node1.getHostId());
+    AdminRow peer2b = mockPeersV2Row(2, node2.getHostId());
+    topologyMonitor.stubQueries(
+        new StubbedQuery(
+            "SELECT " + String.join(", ", localCols) + " FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(localCols, local2)),
+        new StubbedQuery(
+            "SELECT " + String.join(", ", peersCols) + " FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(peersCols, peer2b)));
+
+    // When
+    CompletionStage<Iterable<NodeInfo>> futureInfos = topologyMonitor.refreshNodeList();
+
+    // Then
+    assertThatStage(futureInfos).isSuccess(infos -> assertThat(infos).hasSize(2));
+  }
+
+  @Test
+  public void should_revert_to_select_star_after_reset_column_caches() {
+    // Given — warm the caches with a first call
+    AdminRow local = mockLocalRow(1, node1.getHostId());
+    AdminRow peer2 = mockPeersV2Row(2, node2.getHostId());
+    ImmutableList<String> localCols = ImmutableList.of("rpc_address", "data_center", "host_id");
+    ImmutableList<String> peersCols = ImmutableList.of("native_address", "native_port", "host_id");
+    topologyMonitor.isSchemaV2 = true;
+    topologyMonitor.stubQueries(
+        new StubbedQuery(
+            "SELECT * FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(localCols, local)),
+        new StubbedQuery(
+            "SELECT * FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(peersCols, peer2)));
+    topologyMonitor.refreshNodeList().toCompletableFuture().join();
+
+    // Reset the caches (as done on reconnect)
+    topologyMonitor.resetColumnCaches();
+
+    // Second call must revert to SELECT * since caches were cleared
+    AdminRow local2 = mockLocalRow(1, node1.getHostId());
+    AdminRow peer2b = mockPeersV2Row(2, node2.getHostId());
+    topologyMonitor.stubQueries(
+        new StubbedQuery(
+            "SELECT * FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(localCols, local2)),
+        new StubbedQuery(
+            "SELECT * FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(peersCols, peer2b)));
+
+    // When
+    CompletionStage<Iterable<NodeInfo>> futureInfos = topologyMonitor.refreshNodeList();
+
+    // Then
+    assertThatStage(futureInfos).isSuccess(infos -> assertThat(infos).hasSize(2));
+  }
+
+  @Test
+  public void should_not_cache_empty_column_set_from_zero_row_peers_result() {
+    // Given — single-node cluster where system.peers_v2 returns 0 rows and empty column metadata.
+    // The driver must NOT cache the empty set; the next call must still use SELECT *.
+    AdminRow local = mockLocalRow(1, node1.getHostId());
+    topologyMonitor.isSchemaV2 = true;
+
+    // First call: system.peers_v2 returns 0 rows with an empty column set (simulates a
+    // single-node cluster whose server omits column metadata for empty result sets).
+    topologyMonitor.stubQueries(
+        new StubbedQuery(
+            "SELECT * FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(
+                ImmutableList.of("rpc_address", "data_center", "host_id"), local)),
+        new StubbedQuery(
+            "SELECT * FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(
+                Collections.emptyList() /* empty column metadata */)));
+    topologyMonitor.refreshNodeList().toCompletableFuture().join();
+
+    // Second call must still use SELECT * for system.peers_v2 because the empty list was not
+    // cached.
+    AdminRow local2 = mockLocalRow(1, node1.getHostId());
+    ImmutableList<String> localCols = ImmutableList.of("rpc_address", "data_center", "host_id");
+    topologyMonitor.stubQueries(
+        new StubbedQuery(
+            "SELECT " + String.join(", ", localCols) + " FROM system.local WHERE key='local'",
+            AdminResultTestHelper.mockResultWithColumns(localCols, local2)),
+        new StubbedQuery(
+            "SELECT * FROM system.peers_v2",
+            AdminResultTestHelper.mockResultWithColumns(Collections.emptyList())));
+
+    // When
+    CompletionStage<Iterable<NodeInfo>> futureInfos = topologyMonitor.refreshNodeList();
+
+    // Then — driver still starts up successfully even though peers are absent
+    assertThatStage(futureInfos).isSuccess(infos -> assertThat(infos).hasSize(1));
   }
 
   @DataProvider

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
@@ -87,9 +87,10 @@ public class PeersV2NodeRefreshIT {
   private boolean hasNodeRefreshQuery() {
     for (QueryLog log : cluster.getLogs().getQueryLogs()) {
       if (log.getFrame().message instanceof Query) {
+        // Match both the legacy "SELECT *" form and the optimized projected-column form;
+        // only the WHERE clause suffix is stable regardless of which columns are selected.
         if (((Query) log.getFrame().message)
-            .query.contains(
-                "SELECT * FROM system.peers_v2 WHERE peer = :address and peer_port = :port")) {
+            .query.contains("FROM system.peers_v2 WHERE peer = :address and peer_port = :port")) {
           return true;
         }
       }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
@@ -49,6 +49,20 @@ import org.junit.experimental.categories.Category;
 @Category(ParallelizableTests.class)
 public class ProtocolVersionMixedClusterIT {
 
+  /**
+   * The projected system.local query issued on the second call once the column cache has been
+   * warmed by {@code getChannelNodeInfo()}. The column list is the intersection of Simulacron's
+   * {@code PeerMetadataHandler#buildSystemLocalRowsMetadata} column order and {@code
+   * DefaultTopologyMonitor#LOCAL_COLUMNS_OF_INTEREST}: columns the server returns but the driver
+   * never reads (e.g. {@code key}, {@code bootstrapped}, {@code cluster_name}, {@code cql_version})
+   * are excluded.
+   */
+  private static final String PROJECTED_LOCAL_QUERY =
+      "SELECT rpc_address, rpc_port, broadcast_address, broadcast_port,"
+          + " data_center, listen_address, listen_port, partitioner,"
+          + " rack, release_version, tokens, host_id, schema_version"
+          + " FROM system.local WHERE key='local'";
+
   @Test
   public void should_downgrade_if_peer_does_not_support_negotiated_version() {
     DriverConfigLoader loader =
@@ -78,9 +92,10 @@ public class ProtocolVersionMixedClusterIT {
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
               // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
-              // connection channel endpoint
+              // connection channel endpoint; warms localColumns cache
               "SELECT * FROM system.local WHERE key='local'",
-              "SELECT * FROM system.local WHERE key='local'",
+              // refreshNodeList uses cached column projection on second system.local call
+              PROJECTED_LOCAL_QUERY,
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
     }
@@ -109,9 +124,10 @@ public class ProtocolVersionMixedClusterIT {
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
               // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
-              // connection channel endpoint
+              // connection channel endpoint; warms localColumns cache
               "SELECT * FROM system.local WHERE key='local'",
-              "SELECT * FROM system.local WHERE key='local'",
+              // refreshNodeList uses cached column projection on second system.local call
+              PROJECTED_LOCAL_QUERY,
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
     }
@@ -163,9 +179,10 @@ public class ProtocolVersionMixedClusterIT {
               // Initial connection with protocol v4
               "SELECT cluster_name FROM system.local WHERE key='local'",
               // An extra query done by TopologyMonitor.getChannelNodeInfo to resolve control
-              // connection channel endpoint
+              // connection channel endpoint; warms localColumns cache
               "SELECT * FROM system.local WHERE key='local'",
-              "SELECT * FROM system.local WHERE key='local'",
+              // refreshNodeList uses cached column projection on second system.local call
+              PROJECTED_LOCAL_QUERY,
               "SELECT * FROM system.peers_v2",
               "SELECT * FROM system.peers");
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
@@ -104,14 +104,19 @@ public class PreparedStatementCancellationIT {
     CompletableFuture<PreparedStatement> cf2 = toCompletableFuture(session, cql);
     assertThat(cache.size()).isEqualTo(1);
 
-    CompletableFuture<PreparedStatement> future = Iterables.get(cache.asMap().values(), 0);
-    PreparedStatement stmt = future.get();
+    // Wait for cf1 and cf2 directly — they are dependent futures wrapping the cached future,
+    // so the cached future completing does not synchronously guarantee cf1/cf2 are done yet.
+    PreparedStatement stmt1 = cf1.get(30, TimeUnit.SECONDS);
+    PreparedStatement stmt2 = cf2.get(30, TimeUnit.SECONDS);
 
     assertThat(cf1.isDone()).isTrue();
     assertThat(cf2.isDone()).isTrue();
 
-    assertThat(cf1.join()).isEqualTo(stmt);
-    assertThat(cf2.join()).isEqualTo(stmt);
+    CompletableFuture<PreparedStatement> future = Iterables.get(cache.asMap().values(), 0);
+    PreparedStatement stmt = future.get(30, TimeUnit.SECONDS);
+
+    assertThat(stmt1).isEqualTo(stmt);
+    assertThat(stmt2).isEqualTo(stmt);
   }
 
   // A holdover from work done on JAVA-3055.  This probably isn't _desired_ behaviour but this test


### PR DESCRIPTION
## Summary

- Replaces `SELECT *` queries in `DefaultTopologyMonitor` with dynamic column projections that only fetch the columns the driver actually reads.
- On the first query, `SELECT *` is still issued to discover which columns the server actually has. The response column list is then intersected with `LOCAL_COLUMNS_OF_INTEREST` / `PEERS_COLUMNS_OF_INTEREST` / `PEERS_V2_COLUMNS_OF_INTEREST` — three `ImmutableSet<String>` constants listing every column the driver reads from each table. Subsequent queries use the resulting projected column list.
- A private `intersectWithNeeded(List<String> serverColumns, ImmutableSet<String> needed)` helper performs the intersection, preserving server-response order and silently dropping columns absent from the server (e.g. DSE-specific columns on non-DSE clusters, or version-specific columns).
- DSE-specific columns (`dse_version`, `graph`, `workload`, `workloads`, `server_id`, `storage_port`, `storage_port_ssl`, `jmx_port`) are included in all `*_COLUMNS_OF_INTEREST` sets and are silently dropped by the intersection when the server does not expose them.
- Calling `resetColumnCaches()` resets all three caches to `null`, causing the next query to re-issue `SELECT *` and re-learn the projection (used on schema-change events).

## Motivation

`SELECT * FROM system.local WHERE key='local'` and `SELECT * FROM system.peers*` fetch 30–40 columns per row, many of which are never accessed by the topology monitor (e.g. `key`, `bootstrapped`, `cluster_name`, `cql_version`, `supported_features`). This causes unnecessary serialization on the server, wire transfer, and deserialization on the client — contributing to the session initialization slowdown reported in scylladb/java-driver#282.

Note: `tokens` is still fetched — it is required for token-aware routing and is read by `nodeInfoBuilder()`. The optimization eliminates columns the driver **never reads**, not all large columns.

`SchemaAgreementChecker` already follows the explicit-projection pattern. This PR applies the equivalent approach to `DefaultTopologyMonitor`, using a dynamic intersection rather than hard-coded query strings so that the projection adapts to whatever columns the server exposes.

## Testing

- All 27 `DefaultTopologyMonitorTest` tests pass.
- `ProtocolVersionMixedClusterIT` updated to expect the 13-column projected query string that results from intersecting Simulacron's mock column list with `LOCAL_COLUMNS_OF_INTEREST`.

Closes: [DRIVER-367](https://scylladb.atlassian.net/browse/DRIVER-367)
Parent epic: [DRIVER-274](https://scylladb.atlassian.net/browse/DRIVER-274)

[DRIVER-367]: https://scylladb.atlassian.net/browse/DRIVER-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ