### PR TITLE
fix: DNS contact endpoint resolution and control connection reconnection

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -292,7 +292,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK, false);
     map.put(TypedDriverOption.REQUEST_THROTTLER_CLASS, "PassThroughRequestThrottler");
     map.put(TypedDriverOption.ADDRESS_TRANSLATOR_CLASS, "PassThroughAddressTranslator");
-    map.put(TypedDriverOption.RESOLVE_CONTACT_POINTS, true);
+    map.put(TypedDriverOption.RESOLVE_CONTACT_POINTS, false);
     map.put(TypedDriverOption.PROTOCOL_MAX_FRAME_LENGTH, 256L * 1024 * 1024);
     map.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, true);
     map.put(TypedDriverOption.REQUEST_TRACE_ATTEMPTS, 5);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -936,7 +936,7 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
       }
 
       boolean resolveAddresses =
-          defaultConfig.getBoolean(DefaultDriverOption.RESOLVE_CONTACT_POINTS, true);
+          defaultConfig.getBoolean(DefaultDriverOption.RESOLVE_CONTACT_POINTS, false);
 
       Set<EndPoint> contactPoints =
           ContactPoints.merge(programmaticContactPoints, configContactPoints, resolveAddresses);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -164,24 +164,23 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
 
   @NonNull
   public Queue<Node> newControlReconnectionQueryPlan() {
-    // First try the original way
     Queue<Node> regularQueryPlan = newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
-    if (!regularQueryPlan.isEmpty()) return regularQueryPlan;
 
     if (context
         .getConfig()
         .getDefaultProfile()
         .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)) {
       Set<DefaultNode> originalNodes = context.getMetadataManager().getContactPoints();
-      List<Node> nodes = new ArrayList<>();
+      List<Node> contactNodes = new ArrayList<>();
       for (DefaultNode node : originalNodes) {
-        nodes.add(DefaultNode.newContactPoint(node.getEndPoint(), context));
+        contactNodes.add(DefaultNode.newContactPoint(node.getEndPoint(), context));
       }
-      Collections.shuffle(nodes);
-      return new ConcurrentLinkedQueue<>(nodes);
-    } else {
-      return regularQueryPlan;
+      Collections.shuffle(contactNodes);
+      // Append contact points to the end of the regular query plan so they serve as a fallback
+      regularQueryPlan.addAll(contactNodes);
     }
+
+    return regularQueryPlan;
   }
 
   // when it comes in from the outside

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1195,10 +1195,10 @@ datastax-java-driver {
   #   IP addresses. Use a custom address translator to convert them to unresolved addresses (if
   #   you're in a containerized environment, you probably already need address translation anyway).
   #
-  # Required: no (defaults to true)
+  # Required: no (defaults to false)
   # Modifiable at runtime: no
   # Overridable in a profile: no
-  advanced.resolve-contact-points = true
+  advanced.resolve-contact-points = false
 
   advanced.protocol {
     # The native protocol version to use.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -27,10 +27,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy.DistanceReporter;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
@@ -68,6 +71,8 @@ public class LoadBalancingPolicyWrapperTest {
   private Queue<Node> defaultPolicyQueryPlan;
 
   @Mock private InternalDriverContext context;
+  @Mock private DriverConfig config;
+  @Mock private DriverExecutionProfile defaultProfile;
   @Mock private LoadBalancingPolicy policy1;
   @Mock private LoadBalancingPolicy policy2;
   @Mock private LoadBalancingPolicy policy3;
@@ -97,6 +102,11 @@ public class LoadBalancingPolicyWrapperTest {
     when(metadata.getNodes()).thenReturn(allNodes);
     when(metadataManager.getContactPoints()).thenReturn(contactPoints);
     when(context.getMetadataManager()).thenReturn(metadataManager);
+
+    when(context.getConfig()).thenReturn(config);
+    when(config.getDefaultProfile()).thenReturn(defaultProfile);
+    when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(false);
 
     defaultPolicyQueryPlan = Lists.newLinkedList(ImmutableList.of(node3, node2, node1));
     when(policy1.newQueryPlan(null, null)).thenReturn(defaultPolicyQueryPlan);
@@ -174,6 +184,63 @@ public class LoadBalancingPolicyWrapperTest {
     // no-arg newQueryPlan() uses the default profile
     verify(policy1).newQueryPlan(null, null);
     assertThat(queryPlan).isEqualTo(defaultPolicyQueryPlan);
+  }
+
+  @Test
+  public void
+      should_append_contact_points_to_query_plan_when_reconnect_contact_points_is_enabled() {
+    // Given
+    when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(true);
+    wrapper.init();
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then
+    // 3 policy nodes + 2 contact point nodes
+    assertThat(queryPlan.size()).isEqualTo(5);
+    // First nodes come from the policy query plan (node3, node2, node1)
+    assertThat(queryPlan.poll()).isEqualTo(node3);
+    assertThat(queryPlan.poll()).isEqualTo(node2);
+    assertThat(queryPlan.poll()).isEqualTo(node1);
+    // Remaining nodes are contact points appended at the end.
+    // They are new DefaultNode instances created via newContactPoint, so compare by endpoint.
+    Set<EndPoint> remainingEndpoints = new java.util.HashSet<>();
+    for (Node n : queryPlan) {
+      remainingEndpoints.add(n.getEndPoint());
+    }
+    Set<EndPoint> contactEndpoints = new java.util.HashSet<>();
+    for (DefaultNode n : contactPoints) {
+      contactEndpoints.add(n.getEndPoint());
+    }
+    assertThat(remainingEndpoints).isEqualTo(contactEndpoints);
+  }
+
+  @Test
+  public void should_return_contact_points_when_query_plan_empty_and_flag_enabled() {
+    // Given
+    when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(true);
+    wrapper.init();
+    // Make the policy return an empty query plan
+    when(policy1.newQueryPlan(null, null)).thenReturn(Lists.newLinkedList(ImmutableList.of()));
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then
+    // Should get the contact points (compare by endpoint since they are new instances)
+    assertThat(queryPlan.size()).isEqualTo(contactPoints.size());
+    Set<EndPoint> resultEndpoints = new java.util.HashSet<>();
+    for (Node n : queryPlan) {
+      resultEndpoints.add(n.getEndPoint());
+    }
+    Set<EndPoint> contactEndpoints = new java.util.HashSet<>();
+    for (DefaultNode n : contactPoints) {
+      contactEndpoints.add(n.getEndPoint());
+    }
+    assertThat(resultEndpoints).isEqualTo(contactEndpoints);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **Default `resolve-contact-points` to `false`** so that contact points are stored as unresolved DNS names, enabling proper re-resolution on reconnection.
- **Append contact points to the control reconnection query plan** when `CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS` is enabled, instead of using them only as a fallback when the LBP query plan is empty. This ensures contact endpoints are always tried as a last resort within a single reconnection attempt after all LBP-suggested nodes fail.

## Changes

- `SessionBuilder.java`: Change default for `advanced.resolve-contact-points` from `true` to `false`
- `reference.conf`: Update default and documentation accordingly
- `LoadBalancingPolicyWrapper.java`: Modify `newControlReconnectionQueryPlan()` to always append contact point nodes to the end of the regular query plan when the flag is enabled
- `LoadBalancingPolicyWrapperTest.java`: Add config mocking and two new tests covering the append behavior and the empty-query-plan case