### PR TITLE
refactor: clarify client route address override naming

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRouteProxy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRouteProxy.java
@@ -42,7 +42,7 @@ public final class ClientRouteProxy {
   private static final Pattern VALID_HOSTNAME_OR_IP = Pattern.compile("^[a-zA-Z0-9._:\\[\\]-]+$");
 
   private final String connectionId;
-  private final String connectionAddr;
+  private final String connectionAddrOverride;
 
   /**
    * Creates a new endpoint with the given connection ID and no connection address.
@@ -57,35 +57,35 @@ public final class ClientRouteProxy {
    * Creates a new endpoint with the given connection ID and connection address.
    *
    * @param connectionId the connection ID (must not be null).
-   * @param connectionAddr the DNS name or IP address used to override the {@code address} column
-   *     from the {@code system.client_routes} table for the matching {@code connection_id} (may be
-   *     null). Must be a plain hostname or IP address without a port (e.g. {@code
+   * @param connectionAddrOverride the DNS name or IP address used to override the {@code address}
+   *     column from the {@code system.client_routes} table for the matching {@code connection_id}
+   *     (may be null). Must be a plain hostname or IP address without a port (e.g. {@code
    *     "my-cluster.example.com"} or {@code "10.0.1.5"}).
    */
-  public ClientRouteProxy(@NonNull String connectionId, @Nullable String connectionAddr) {
+  public ClientRouteProxy(@NonNull String connectionId, @Nullable String connectionAddrOverride) {
     this.connectionId = Objects.requireNonNull(connectionId, "connectionId must not be null");
     if (connectionId.trim().isEmpty()) {
       throw new IllegalArgumentException("connectionId must not be empty");
     }
-    if (connectionAddr != null) {
-      if (connectionAddr.trim().isEmpty()) {
+    if (connectionAddrOverride != null) {
+      if (connectionAddrOverride.trim().isEmpty()) {
         throw new IllegalArgumentException(
-            "connectionAddr must not be empty or blank when non-null");
+            "connectionAddrOverride must not be empty or blank when non-null");
       }
-      if (containsPort(connectionAddr)) {
+      if (containsPort(connectionAddrOverride)) {
         throw new IllegalArgumentException(
-            "connectionAddr must be a plain hostname or IP address without a port, got: "
-                + connectionAddr);
+            "connectionAddrOverride must be a plain hostname or IP address without a port, got: "
+                + connectionAddrOverride);
       }
-      if (!VALID_HOSTNAME_OR_IP.matcher(connectionAddr).matches()) {
+      if (!VALID_HOSTNAME_OR_IP.matcher(connectionAddrOverride).matches()) {
         throw new IllegalArgumentException(
-            "connectionAddr contains invalid characters "
+            "connectionAddrOverride contains invalid characters "
                 + "(expected hostname or IP address with only alphanumeric characters, "
                 + "dots, hyphens, underscores, colons, or brackets): "
-                + connectionAddr);
+                + connectionAddrOverride);
       }
     }
-    this.connectionAddr = connectionAddr;
+    this.connectionAddrOverride = connectionAddrOverride;
   }
 
   /**
@@ -124,10 +124,25 @@ public final class ClientRouteProxy {
    * <p>This is a plain hostname or IP address (e.g. {@code "my-cluster.example.com"} or {@code
    * "10.0.1.5"}). When provided, the {@code address} column from the {@code system.client_routes}
    * table is overridden with this value for the matching {@code connection_id}.
+   *
+   * @deprecated use {@link ClientRouteProxy#getConnectionAddrOverride()} instead
    */
   @Nullable
+  @Deprecated
   public String getConnectionAddr() {
-    return connectionAddr;
+    return connectionAddrOverride;
+  }
+
+  /**
+   * Returns the connection address override for this endpoint, or null if not specified.
+   *
+   * <p>This is a plain hostname or IP address (e.g. {@code "my-cluster.example.com"} or {@code
+   * "10.0.1.5"}). When provided, the {@code address} column from the {@code system.client_routes}
+   * table is overridden with this value for the matching {@code connection_id}.
+   */
+  @Nullable
+  public String getConnectionAddrOverride() {
+    return connectionAddrOverride;
   }
 
   @Override
@@ -140,12 +155,12 @@ public final class ClientRouteProxy {
     }
     ClientRouteProxy that = (ClientRouteProxy) o;
     return connectionId.equals(that.connectionId)
-        && Objects.equals(connectionAddr, that.connectionAddr);
+        && Objects.equals(connectionAddrOverride, that.connectionAddrOverride);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionId, connectionAddr);
+    return Objects.hash(connectionId, connectionAddrOverride);
   }
 
   @Override
@@ -154,7 +169,9 @@ public final class ClientRouteProxy {
         + "connectionId='"
         + connectionId
         + "'"
-        + (connectionAddr != null ? ", connectionAddr='" + connectionAddr + "'" : "")
+        + (connectionAddrOverride != null
+            ? ", connectionAddrOverride='" + connectionAddrOverride + "'"
+            : "")
         + "}";
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -139,10 +139,11 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
     this.connectionAddrOverrides =
         Collections.unmodifiableMap(
             config.getEndpoints().stream()
-                .filter(ep -> ep.getConnectionAddr() != null)
+                .filter(ep -> ep.getConnectionAddrOverride() != null)
                 .collect(
                     Collectors.toMap(
-                        ClientRouteProxy::getConnectionId, ClientRouteProxy::getConnectionAddr)));
+                        ClientRouteProxy::getConnectionId,
+                        ClientRouteProxy::getConnectionAddrOverride)));
     this.logPrefix = context.getSessionName();
     this.resolvedRoutesCache = new AtomicReference<>(Collections.emptyMap());
     this.useSSL = context.getSslEngineFactory().isPresent();

--- a/core/src/test/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfigTest.java
@@ -36,7 +36,7 @@ public class ClientRoutesConfigTest {
 
     assertThat(config.getEndpoints()).hasSize(1);
     assertThat(config.getEndpoints().get(0).getConnectionId()).isEqualTo(connectionId);
-    assertThat(config.getEndpoints().get(0).getConnectionAddr()).isEqualTo(connectionAddr);
+    assertThat(config.getEndpoints().get(0).getConnectionAddrOverride()).isEqualTo(connectionAddr);
     assertThat(config.getTableName()).isEqualTo("system.client_routes");
   }
 
@@ -80,7 +80,7 @@ public class ClientRoutesConfigTest {
     ClientRouteProxy endpoint = new ClientRouteProxy(connectionId);
 
     assertThat(endpoint.getConnectionId()).isEqualTo(connectionId);
-    assertThat(endpoint.getConnectionAddr()).isNull();
+    assertThat(endpoint.getConnectionAddrOverride()).isNull();
   }
 
   @Test
@@ -90,7 +90,7 @@ public class ClientRoutesConfigTest {
     ClientRouteProxy endpoint = new ClientRouteProxy(connectionId, connectionAddr);
 
     assertThat(endpoint.getConnectionId()).isEqualTo(connectionId);
-    assertThat(endpoint.getConnectionAddr()).isEqualTo(connectionAddr);
+    assertThat(endpoint.getConnectionAddrOverride()).isEqualTo(connectionAddr);
   }
 
   @Test
@@ -118,7 +118,7 @@ public class ClientRoutesConfigTest {
   public void should_reject_blank_connection_addr() {
     assertThatThrownBy(() -> new ClientRouteProxy("conn-id-1", "  "))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("connectionAddr must not be empty");
+        .hasMessageContaining("connectionAddrOverride must not be empty");
   }
 
   @Test
@@ -220,20 +220,20 @@ public class ClientRoutesConfigTest {
   @Test
   public void should_accept_plain_hostname_connection_addr() {
     ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "host.example.com");
-    assertThat(ep.getConnectionAddr()).isEqualTo("host.example.com");
+    assertThat(ep.getConnectionAddrOverride()).isEqualTo("host.example.com");
   }
 
   @Test
   public void should_accept_ipv4_connection_addr() {
     ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "10.0.1.5");
-    assertThat(ep.getConnectionAddr()).isEqualTo("10.0.1.5");
+    assertThat(ep.getConnectionAddrOverride()).isEqualTo("10.0.1.5");
   }
 
   @Test
   public void should_accept_bare_ipv6_connection_addr() {
     // Bare IPv6 contains multiple colons — should NOT be treated as host:port
     ClientRouteProxy ep = new ClientRouteProxy("conn-id-1", "::1");
-    assertThat(ep.getConnectionAddr()).isEqualTo("::1");
+    assertThat(ep.getConnectionAddrOverride()).isEqualTo("::1");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/ClientRoutesConfigFromFileTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/ClientRoutesConfigFromFileTest.java
@@ -109,7 +109,7 @@ public class ClientRoutesConfigFromFileTest {
     assertThat(cfg.getEndpoints()).hasSize(1);
     ClientRouteProxy ep = cfg.getEndpoints().get(0);
     assertThat(ep.getConnectionId()).isEqualTo("11111111-1111-1111-1111-111111111111");
-    assertThat(ep.getConnectionAddr()).isNull();
+    assertThat(ep.getConnectionAddrOverride()).isNull();
   }
 
   @Test
@@ -128,7 +128,7 @@ public class ClientRoutesConfigFromFileTest {
     List<ClientRouteProxy> eps = cfg.getEndpoints();
     assertThat(eps).hasSize(1);
     assertThat(eps.get(0).getConnectionId()).isEqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    assertThat(eps.get(0).getConnectionAddr()).isEqualTo("cluster.example.com");
+    assertThat(eps.get(0).getConnectionAddrOverride()).isEqualTo("cluster.example.com");
   }
 
   @Test
@@ -147,10 +147,11 @@ public class ClientRoutesConfigFromFileTest {
     assertThat(cfg.getEndpoints()).hasSize(2);
     assertThat(cfg.getEndpoints().get(0).getConnectionId())
         .isEqualTo("11111111-1111-1111-1111-111111111111");
-    assertThat(cfg.getEndpoints().get(0).getConnectionAddr()).isEqualTo("node1.example.com");
+    assertThat(cfg.getEndpoints().get(0).getConnectionAddrOverride())
+        .isEqualTo("node1.example.com");
     assertThat(cfg.getEndpoints().get(1).getConnectionId())
         .isEqualTo("22222222-2222-2222-2222-222222222222");
-    assertThat(cfg.getEndpoints().get(1).getConnectionAddr()).isNull();
+    assertThat(cfg.getEndpoints().get(1).getConnectionAddrOverride()).isNull();
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- rename the `ClientRouteProxy` address field and constructor argument from `connectionAddr` to `connectionAddrOverride` to better reflect intent.
- add `getConnectionAddrOverride()` and keep `getConnectionAddr()` as a deprecated compatibility accessor.
- update client routes topology monitor and related tests to use the new accessor consistently.

## Testing
- not run (not requested)