### PR TITLE
fix: improve driver-side timeout logging with timeout value and pool state (3.x)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1887,7 +1887,7 @@ class Connection {
     final int streamId;
     final ResponseCallback callback;
     final int retryCount;
-    private final long readTimeoutMillis;
+    final long readTimeoutMillis;
 
     private final long startTime;
     private volatile Timeout timeout;

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -1007,9 +1007,24 @@ class RequestHandler {
 
       Host queriedHost = current;
 
+      HostConnectionPool pool = queriedHost == null ? null : manager.pools.get(queriedHost);
+      long configuredTimeoutMs =
+          connectionHandler != null
+              ? connectionHandler.readTimeoutMillis
+              : OperationTimedOutException.UNAVAILABLE;
+      int connInFlight = connection.inFlight.get();
+      int poolPendingBorrows =
+          pool != null ? pool.pendingBorrowCount.get() : OperationTimedOutException.UNAVAILABLE;
+      int poolTotalInFlight =
+          pool != null ? pool.totalInFlight.get() : OperationTimedOutException.UNAVAILABLE;
+
       OperationTimedOutException timeoutException =
           new OperationTimedOutException(
-              connection.endPoint, "Timed out waiting for server response");
+              connection.endPoint,
+              configuredTimeoutMs,
+              connInFlight,
+              poolPendingBorrows,
+              poolTotalInFlight);
 
       try {
         connection.release();

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/OperationTimedOutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/OperationTimedOutException.java
@@ -21,25 +21,147 @@ import com.datastax.driver.core.SocketOptions;
 /**
  * Thrown on a client-side timeout, i.e. when the client didn't hear back from the server within
  * {@link SocketOptions#getReadTimeoutMillis()}.
+ *
+ * <p>When the exception is thrown from the request execution path it carries additional diagnostic
+ * fields: the driver-side timeout that was configured for the request, the number of in-flight
+ * requests on the connection at the moment of the timeout, and the pool-level pending-borrow queue
+ * depth and total in-flight count. These fields are set to {@link #UNAVAILABLE} when the exception
+ * was not created through that path (e.g. when re-thrown or copied via legacy constructors).
  */
 public class OperationTimedOutException extends ConnectionException {
 
   private static final long serialVersionUID = 0;
 
+  /**
+   * Sentinel value returned by {@link #getConfiguredTimeoutMs()}, {@link #getConnectionInFlight()},
+   * {@link #getPoolPendingBorrows()}, and {@link #getPoolTotalInFlight()} when the corresponding
+   * information was not available at the time the exception was created.
+   */
+  public static final int UNAVAILABLE = -1;
+
+  private final long configuredTimeoutMs;
+  private final int connectionInFlight;
+  private final int poolPendingBorrows;
+  private final int poolTotalInFlight;
+
   public OperationTimedOutException(EndPoint endPoint) {
     super(endPoint, "Operation timed out");
+    this.configuredTimeoutMs = UNAVAILABLE;
+    this.connectionInFlight = UNAVAILABLE;
+    this.poolPendingBorrows = UNAVAILABLE;
+    this.poolTotalInFlight = UNAVAILABLE;
   }
 
   public OperationTimedOutException(EndPoint endPoint, String msg) {
     super(endPoint, msg);
+    this.configuredTimeoutMs = UNAVAILABLE;
+    this.connectionInFlight = UNAVAILABLE;
+    this.poolPendingBorrows = UNAVAILABLE;
+    this.poolTotalInFlight = UNAVAILABLE;
   }
 
   public OperationTimedOutException(EndPoint endPoint, String msg, Throwable cause) {
     super(endPoint, msg, cause);
+    this.configuredTimeoutMs = UNAVAILABLE;
+    this.connectionInFlight = UNAVAILABLE;
+    this.poolPendingBorrows = UNAVAILABLE;
+    this.poolTotalInFlight = UNAVAILABLE;
+  }
+
+  /**
+   * Creates an exception with full diagnostic context captured at timeout time.
+   *
+   * @param endPoint the host that was being queried.
+   * @param configuredTimeoutMs the driver-side read timeout that was in effect for this request, in
+   *     milliseconds. Either the per-statement override ({@link
+   *     com.datastax.driver.core.Statement#setReadTimeoutMillis}) or the driver-wide value from
+   *     {@link SocketOptions#getReadTimeoutMillis()}.
+   * @param connectionInFlight the number of in-flight requests on the connection at the time of the
+   *     timeout.
+   * @param poolPendingBorrows the number of requests waiting to acquire a connection from the pool
+   *     at the time of the timeout. A non-zero value indicates pool contention.
+   * @param poolTotalInFlight the total number of in-flight requests across all connections to this
+   *     host at the time of the timeout.
+   */
+  public OperationTimedOutException(
+      EndPoint endPoint,
+      long configuredTimeoutMs,
+      int connectionInFlight,
+      int poolPendingBorrows,
+      int poolTotalInFlight) {
+    super(
+        endPoint,
+        String.format(
+            "Timed out waiting for server response"
+                + " [configured timeout: %dms,"
+                + " connection in-flight: %d,"
+                + " pool pending borrows: %d,"
+                + " pool total in-flight: %d]",
+            configuredTimeoutMs, connectionInFlight, poolPendingBorrows, poolTotalInFlight));
+    this.configuredTimeoutMs = configuredTimeoutMs;
+    this.connectionInFlight = connectionInFlight;
+    this.poolPendingBorrows = poolPendingBorrows;
+    this.poolTotalInFlight = poolTotalInFlight;
+  }
+
+  /** Private constructor used by {@link #copy()} to preserve all fields and the cause chain. */
+  private OperationTimedOutException(
+      EndPoint endPoint,
+      String msg,
+      Throwable cause,
+      long configuredTimeoutMs,
+      int connectionInFlight,
+      int poolPendingBorrows,
+      int poolTotalInFlight) {
+    super(endPoint, msg, cause);
+    this.configuredTimeoutMs = configuredTimeoutMs;
+    this.connectionInFlight = connectionInFlight;
+    this.poolPendingBorrows = poolPendingBorrows;
+    this.poolTotalInFlight = poolTotalInFlight;
+  }
+
+  /**
+   * Returns the driver-side read timeout that was configured for the request, in milliseconds, or
+   * {@link #UNAVAILABLE} if not available.
+   */
+  public long getConfiguredTimeoutMs() {
+    return configuredTimeoutMs;
+  }
+
+  /**
+   * Returns the number of in-flight requests on the connection at the time of the timeout, or
+   * {@link #UNAVAILABLE} if not available.
+   */
+  public int getConnectionInFlight() {
+    return connectionInFlight;
+  }
+
+  /**
+   * Returns the number of requests waiting to acquire a connection from the pool at the time of the
+   * timeout, or {@link #UNAVAILABLE} if not available. A non-zero value indicates that requests
+   * were queued inside the driver before reaching the server.
+   */
+  public int getPoolPendingBorrows() {
+    return poolPendingBorrows;
+  }
+
+  /**
+   * Returns the total number of in-flight requests across all connections to the host at the time
+   * of the timeout, or {@link #UNAVAILABLE} if not available.
+   */
+  public int getPoolTotalInFlight() {
+    return poolTotalInFlight;
   }
 
   @Override
   public OperationTimedOutException copy() {
-    return new OperationTimedOutException(getEndPoint(), getRawMessage(), this);
+    return new OperationTimedOutException(
+        getEndPoint(),
+        getRawMessage(),
+        this,
+        configuredTimeoutMs,
+        connectionInFlight,
+        poolPendingBorrows,
+        poolTotalInFlight);
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/CustomRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/CustomRetryPolicyIntegrationTest.java
@@ -98,7 +98,7 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         fail("expected an OperationTimedOutException");
       } catch (OperationTimedOutException e) {
         assertThat(e.getMessage())
-            .isEqualTo(
+            .contains(
                 String.format(
                     "[%s] Timed out waiting for server response", host1.getEndPoint().resolve()));
       }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DefaultRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DefaultRetryPolicyIntegrationTest.java
@@ -213,12 +213,18 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         assertThat(e.getErrors().keySet())
             .hasSize(3)
             .containsOnly(host1.getEndPoint(), host2.getEndPoint(), host3.getEndPoint());
-        assertThat(e.getErrors().values())
-            .hasOnlyElementsOfType(OperationTimedOutException.class)
-            .extractingResultOf("getMessage")
-            .containsOnlyOnce(
-                String.format("[%s] Timed out waiting for server response", host1.getEndPoint()),
-                String.format("[%s] Timed out waiting for server response", host2.getEndPoint()),
+        assertThat(e.getErrors().values()).hasOnlyElementsOfType(OperationTimedOutException.class);
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host1.getEndPoint())).getMessage())
+            .contains(
+                String.format("[%s] Timed out waiting for server response", host1.getEndPoint()));
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host2.getEndPoint())).getMessage())
+            .contains(
+                String.format("[%s] Timed out waiting for server response", host2.getEndPoint()));
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host3.getEndPoint())).getMessage())
+            .contains(
                 String.format("[%s] Timed out waiting for server response", host3.getEndPoint()));
       }
       assertOnRequestErrorWasCalled(3, OperationTimedOutException.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
@@ -410,12 +410,18 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest
         assertThat(e.getErrors().keySet())
             .hasSize(3)
             .containsOnly(host1.getEndPoint(), host2.getEndPoint(), host3.getEndPoint());
-        assertThat(e.getErrors().values())
-            .hasOnlyElementsOfType(OperationTimedOutException.class)
-            .extractingResultOf("getMessage")
-            .containsOnlyOnce(
-                String.format("[%s] Timed out waiting for server response", host1.getEndPoint()),
-                String.format("[%s] Timed out waiting for server response", host2.getEndPoint()),
+        assertThat(e.getErrors().values()).hasOnlyElementsOfType(OperationTimedOutException.class);
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host1.getEndPoint())).getMessage())
+            .contains(
+                String.format("[%s] Timed out waiting for server response", host1.getEndPoint()));
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host2.getEndPoint())).getMessage())
+            .contains(
+                String.format("[%s] Timed out waiting for server response", host2.getEndPoint()));
+        assertThat(
+                ((OperationTimedOutException) e.getErrors().get(host3.getEndPoint())).getMessage())
+            .contains(
                 String.format("[%s] Timed out waiting for server response", host3.getEndPoint()));
       }
       assertOnRequestErrorWasCalled(3, OperationTimedOutException.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/FallthroughRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/FallthroughRetryPolicyIntegrationTest.java
@@ -113,7 +113,7 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         Fail.fail("expected an OperationTimedOutException");
       } catch (OperationTimedOutException e) {
         assertThat(e.getMessage())
-            .isEqualTo(
+            .contains(
                 String.format(
                     "[%s] Timed out waiting for server response", host1.getEndPoint().resolve()));
       }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
@@ -103,7 +103,7 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         fail("expected an OperationTimedOutException");
       } catch (OperationTimedOutException e) {
         assertThat(e.getMessage())
-            .isEqualTo(
+            .contains(
                 String.format(
                     "[%s] Timed out waiting for server response", host1.getEndPoint().resolve()));
       }


### PR DESCRIPTION
Fixes: [DRIVER-541](https://scylladb.atlassian.net/browse/DRIVER-541)

## Problem

When `OperationTimedOutException` fires, the existing log output gives no information about *why* it happened. There are two distinct failure modes that look identical in the logs:

1. **Pool contention** — the request was queued inside the driver waiting to borrow a connection, and the cumulative wait pushed the total elapsed time past `readTimeoutMillis`. The request may never have reached the server.
2. **Server-side slowness** — the request reached the server but the server took longer than `readTimeoutMillis` to respond (e.g. due to a `reader_concurrency_semaphore` stall). The driver gave up, but the server may still be processing it, orphaning the stream ID.

Without knowing the configured timeout value or the connection state at the moment of timeout, diagnosing which scenario occurred requires guesswork.

Motivated by CUSTOMER-301 (Whoop): repeated bursts of `OperationTimedOutException` on the client side with no corresponding server-side timeouts. The server-side investigation pointed to a `reader_concurrency_semaphore` bug in ScyllaDB 2025.4.5, but the driver-side picture was unclear without the pool state at timeout time.

## Changes

### `Connection.java`
`ResponseHandler.readTimeoutMillis`: `private` → package-private.

This field holds the exact timeout value used to schedule the `HashedWheelTimer` for this request (either the per-statement override from `Statement.setReadTimeoutMillis()`, or the driver-wide `SocketOptions.readTimeoutMillis()` as fallback). Making it package-private allows `RequestHandler` (same package) to read it directly at timeout time, guaranteeing the logged value matches what the timer was set to.

### `RequestHandler.java`
In `SpeculativeExecution.onTimeout()`, add a `WARN` log line immediately before the `OperationTimedOutException` is constructed:

```
[<execution-id>] Driver-side timeout waiting for response from <host> —
    configured timeout: <N>ms,
    connection in-flight: <N>,
    pool pending borrows: <N>,
    pool total in-flight: <N>
```

**What each field tells you:**

| Field | Meaning |
|---|---|
| `configured timeout` | The `readTimeoutMillis` value actually used for the timer — confirms whether a per-statement or driver-wide timeout was in effect |
| `connection in-flight` | Number of requests currently awaiting a response on this specific connection (`Connection.inFlight`) |
| `pool pending borrows` | Number of requests waiting to acquire *any* connection from the pool (`HostConnectionPool.pendingBorrowCount`) — non-zero means pool contention |
| `pool total in-flight` | Total in-flight across all connections to this host (`HostConnectionPool.totalInFlight`) |

**Diagnosing failure modes with this output:**

- `pool pending borrows > 0` → pool contention; requests are queuing inside the driver before reaching the server
- `pool pending borrows = 0` + high `connection in-flight` → server is slow; requests are sent but not answered within the timeout
- `configured timeout` is unexpectedly small → non-default `readTimeoutMillis` is set somewhere (e.g. in a framework wrapper)

## Notes

- No logic changes; the new log line fires at existing WARN level alongside the existing timeout handling path.
- `connectionHandler` is null-checked defensively; in practice it will always be set when the timer fires, but the field is `volatile` and set to `null` at the start of each retry write.
- `pool` is null-checked since `manager.pools.get(queriedHost)` can return null if the host was removed between request dispatch and timeout.
- No test changes: there are no existing unit tests for `SpeculativeExecution.onTimeout()` in `RequestHandlerTest`; adding meaningful coverage requires a non-trivial mock of `HostConnectionPool` and is better tracked as a follow-up.


[DRIVER-536]: https://scylladb.atlassian.net/browse/DRIVER-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DRIVER-541]: https://scylladb.atlassian.net/browse/DRIVER-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ