### PR TITLE
Pin GitHub Actions to specific commit SHAs (DRIVER-583)

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -20,19 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 
       - name: Set up JDK 8.0
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 8.0
           distribution: 'temurin'

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 
       - name: Set up JDK 8.0
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 8.0
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Checkout Code One Commit Before ${{ inputs.version_tag }}
         if: inputs.target-tag != 'scylla-3.x'
@@ -40,7 +40,7 @@ jobs:
         run: make checkout-one-commit-before
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload release logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: maven-stdout
           path: /tmp/java-driver-release-logs/*.log

--- a/.github/workflows/tests-reports-4x@v1.yml
+++ b/.github/workflows/tests-reports-4x@v1.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Generate test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         with:
           artifact: 'test-results'
           name: 'Test report'

--- a/.github/workflows/tests-reports@v1.yml
+++ b/.github/workflows/tests-reports@v1.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Generate test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         with:
           artifact: 'test-results'
           name: 'Test report'

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -53,7 +53,7 @@ jobs:
         run: echo "value=${{ hashFiles('**/pom.xml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Restore maven repository cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: java-cache
         with:
           path: ~/.m2/repository
@@ -67,7 +67,7 @@ jobs:
         run: make download-all-dependencies
 
       - name: Save maven repository cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: steps.java-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.m2/repository
@@ -85,16 +85,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
 
       - name: Restore maven repository cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -114,16 +114,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
 
       - name: Restore maven repository cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -139,14 +139,14 @@ jobs:
           cp --parents ./**/target/*-reports/*.xml unit/
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-results
           path: "*/**/target/*-reports/*.xml"
 
       - name: Parse test results
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
           check_name: Unit tests report
@@ -164,10 +164,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 
@@ -185,22 +185,22 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
 
       - name: Restore maven repository cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Setup Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 
@@ -214,7 +214,7 @@ jobs:
         run: make resolve-cassandra-version
 
       - name: Pull CCM image from the cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: ccm-cache
         with:
           path: ~/.ccm/repository
@@ -228,7 +228,7 @@ jobs:
 
       - name: Save CCM image into the cache
         if: steps.ccm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.ccm/repository
           key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
@@ -248,20 +248,20 @@ jobs:
 
       - name: Upload test results
         if: steps.run-integration-tests.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-${{ matrix.java-version }}-${{ matrix.cassandra-version }}
           path: "*/**/target/*-reports/*.xml"
 
       - name: Upload CCM logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: ccm-log-cassandra-${{ matrix.java-version }}-${{ matrix.cassandra-version }}
           path: /tmp/ccm*/ccm*/node*/logs/*
 
       - name: Parse test results
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
           check_name: Integration tests report for Cassandra ${{ steps.cassandra-version.outputs.value }}
@@ -286,22 +286,22 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
 
       - name: Restore maven repository cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Setup Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 
@@ -313,7 +313,7 @@ jobs:
         run: make resolve-scylla-version
 
       - name: Pull CCM image from the cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: ccm-cache
         with:
           path: ~/.ccm/scylla-repository
@@ -326,7 +326,7 @@ jobs:
         run: make download-scylla
 
       - name: Save CCM image into the cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: steps.ccm-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.ccm/scylla-repository
@@ -346,21 +346,21 @@ jobs:
           cp --parents ./**/target/*-reports/*.xml scylla-${{ matrix.scylla-version }}/
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.run-integration-tests.outcome == 'failure'
         with:
           name: test-results-${{ matrix.java-version }}-${{ matrix.scylla-version }}
           path: "*/**/target/*-reports/*.xml"
 
       - name: Upload CCM logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: ccm-log-scylla-${{ matrix.java-version }}-${{ matrix.scylla-version }}
           path: /tmp/ccm*/ccm*/node*/logs/*
 
       - name: Parse test results
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
           check_name: Integration tests report for Scylla ${{ steps.scylla-version.outputs.value }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,31 @@ sudo ifconfig lo0 alias 127.0.1.1 up
 sudo ifconfig lo0 alias 127.0.1.2 up
 ...
 ```
+
+## Updating GitHub Actions workflows
+
+GitHub Actions workflows in this repository pin all third-party actions to specific commit SHAs
+instead of mutable version tags (e.g. `@v5`). This is a supply chain security measure: tags can be
+moved to point to different commits, but a SHA is immutable.
+
+The format used is:
+
+```yaml
+uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+```
+
+There is no need to update workflow action versions on every release. Only do so when the current
+version has a known vulnerability or when a new feature is needed.
+
+### How to update a pinned action
+
+1. Go to the action's GitHub repository (e.g. `github.com/actions/checkout`).
+2. Navigate to the desired release tag (e.g. `v5.0.2`) via the Tags page.
+3. Copy the full 40-character commit SHA from that tag's commit page.
+4. Verify the commit is not an [impostor commit](https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd):
+   open the commit on GitHub and ensure there is **no** banner saying
+   "This commit does not belong to any branch on this repository".
+5. Replace the SHA and version comment in all workflow files.
+6. Update the repository allowlist under
+   `Settings -> Actions -> General -> Allow or block specified actions and reusable workflows`
+   to include the new SHA.


### PR DESCRIPTION
## Summary

Closes DRIVER-583 / part of DRIVER-515.

Replaces all third-party GitHub Action version tags (e.g. `@v4`, `@v5`) with immutable full commit SHAs across all 6 workflow files on the `scylla-3.x` branch. This reduces the supply chain attack surface: mutable tags can be silently redirected to malicious code, while a pinned SHA is permanent.

## Pinned versions

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/checkout` | v5.0.1 | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` |
| `actions/setup-java` | v5.2.0 | `be666c2fcd27ec809703dec50e508c2fdc7f6654` |
| `actions/setup-python` | v5.6.0 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `actions/setup-python` | v6.2.0 | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `actions/cache` (restore/save) | v4.3.0 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/upload-artifact` | v4.6.2 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `mikepenz/action-junit-report` | v5.6.2 | `3585e9575db828022551b4231f165eb59a0e74e3` |
| `dorny/test-reporter` | v1 | `3eeb9fc888e82e8be2fb356bbeec2750231672bc` |

Note: two actions have different versions across files (docs workflows use older `checkout@v4` / `setup-python@v5` while the tests workflow uses `@v5` / `@v6`). Both are pinned to their respective SHAs without upgrading versions.

## Files changed

- `.github/workflows/docs-pages.yaml`
- `.github/workflows/docs-pr.yaml`
- `.github/workflows/release.yml`
- `.github/workflows/tests@v1.yml`
- `.github/workflows/tests-reports@v1.yml`
- `.github/workflows/tests-reports-4x@v1.yml`
- `CONTRIBUTING.md` — added section explaining how to update pinned actions in the future

## Required follow-up (manual, needs repo admin)

Update `Settings -> Actions -> General -> Allow or block specified actions and reusable workflows` to allowlist the pinned SHAs:

```
actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5,
actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd,
actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654,
actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065,
actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405,
actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830,
actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02,
mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3,
dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc
```

Reference implementation: https://github.com/scylladb/nodejs-rs-driver/pull/430