### PR TITLE
fix: replace SimpleStrategy with NetworkTopologyStrategy in integration tests (4.x)

### DIFF
--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseProxyAuthenticationIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/auth/DseProxyAuthenticationIT.java
@@ -71,7 +71,7 @@ public class DseProxyAuthenticationIT {
             session.execute(
                 "CREATE ROLE IF NOT EXISTS steve WITH PASSWORD = 'fakePasswordForSteve' AND LOGIN = TRUE");
             session.execute(
-                "CREATE KEYSPACE IF NOT EXISTS aliceks WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'1'}");
+                "CREATE KEYSPACE IF NOT EXISTS aliceks WITH REPLICATION = {'class':'NetworkTopologyStrategy', 'dc1':'1'}");
             session.execute(
                 "CREATE TABLE IF NOT EXISTS aliceks.alicetable (key text PRIMARY KEY, value text)");
             session.execute(

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/KeyspaceGraphMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/metadata/schema/KeyspaceGraphMetadataIT.java
@@ -51,7 +51,7 @@ public class KeyspaceGraphMetadataIT {
     CqlSession session = SESSION_RULE.session();
     session.execute(
         "CREATE KEYSPACE keyspace_metadata_it_graph_engine "
-            + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
+            + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
             + "AND graph_engine = 'Core'");
     Metadata metadata = session.getMetadata();
     assertThat(metadata.getKeyspace("keyspace_metadata_it_graph_engine"))
@@ -66,7 +66,7 @@ public class KeyspaceGraphMetadataIT {
     CqlSession session = SESSION_RULE.session();
     session.execute(
         "CREATE KEYSPACE keyspace_metadata_it_graph_engine_alter "
-            + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
     assertThat(session.getMetadata().getKeyspace("keyspace_metadata_it_graph_engine_alter"))
         .hasValueSatisfying(
             keyspaceMetadata ->
@@ -89,7 +89,7 @@ public class KeyspaceGraphMetadataIT {
             () ->
                 session.execute(
                     "CREATE KEYSPACE keyspace_metadata_it_graph_engine_classic "
-                        + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
+                        + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
                         + "AND graph_engine = 'Classic'"))
         .hasMessageContaining("Invalid/unknown graph engine name 'Classic'");
   }
@@ -99,7 +99,7 @@ public class KeyspaceGraphMetadataIT {
     CqlSession session = SESSION_RULE.session();
     session.execute(
         "CREATE KEYSPACE keyspace_metadata_it_graph_engine_core "
-            + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
+            + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
             + "AND graph_engine = 'Core'");
     Metadata metadata = session.getMetadata();
     assertThat(metadata.getKeyspace("keyspace_metadata_it_graph_engine_core"))

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
@@ -375,7 +375,7 @@ public class SimpleStatementCcmIT {
     SESSION_RULE
         .session()
         .execute(
-            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
 
     SESSION_RULE
         .session()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
@@ -72,7 +72,8 @@ public class LWTLoadBalancingIT {
     session.execute(
         "CREATE KEYSPACE "
             + keyspace.asCql(false)
-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
+            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}"
+            + " AND tablets = {'enabled': false}");
     session.execute("USE " + keyspace.asCql(false));
     session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
@@ -99,16 +99,15 @@ public class SchemaChangesIT {
         null,
         String.format(
             "CREATE KEYSPACE %s "
-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
             newKeyspaceId),
         metadata -> metadata.getKeyspace(newKeyspaceId),
         keyspace -> {
           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
           assertThat(keyspace.isDurableWrites()).isTrue();
           assertThat(keyspace.getReplication())
-              .hasSize(2)
-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
-              .containsEntry("replication_factor", "1");
+              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
+              .containsEntry("dc1", "1");
         },
         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
         newKeyspaceId);
@@ -121,7 +120,7 @@ public class SchemaChangesIT {
         ImmutableList.of(
             String.format(
                 "CREATE KEYSPACE %s "
-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 newKeyspaceId.asCql(true))),
         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
         metadata -> metadata.getKeyspace(newKeyspaceId),
@@ -136,11 +135,11 @@ public class SchemaChangesIT {
         ImmutableList.of(
             String.format(
                 "CREATE KEYSPACE %s "
-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 newKeyspaceId.asCql(true))),
         String.format(
             "ALTER KEYSPACE %s "
-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
+                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
                 + "AND durable_writes = 'false'",
             newKeyspaceId.asCql(true)),
         metadata -> metadata.getKeyspace(newKeyspaceId),

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
@@ -56,10 +56,10 @@ public abstract class TokenITBase {
     for (String statement :
         ImmutableList.of(
             String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 KS1.asCql(false)),
             String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
+                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
                 KS2.asCql(false)),
 
             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
     session.execute(
         SimpleStatement.builder(
                 String.format(
-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     DEFAULT_KEYSPACE))
             .setExecutionProfile(SESSION_RULE.slowProfile())
             .build());

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
         ImmutableList.of(
             "CREATE TABLE foo(k int PRIMARY KEY)",
             String.format(
-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 OTHER_KEYSPACE.asCql(false)),
             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
       session.execute(

--- a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+++ b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
@@ -69,7 +69,7 @@ public class MailboxServiceImpl implements MailboxService {
   protected void createSchema() {
     session.execute("DROP KEYSPACE IF EXISTS test_osgi");
     session.execute(
-        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
+        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}");
     session.execute(
         "CREATE TABLE "
             + keyspace


### PR DESCRIPTION
## Problem

ScyllaDB PR [scylladb/scylladb#25342](https://github.com/scylladb/scylladb/pull/25342) changed `ks_prop_defs::as_ks_metadata()` so that when tablets are globally enabled (the default on recent ScyllaDB), `initial_tablets = 0` is set for **all** replication strategies. Each strategy then validates tablet support, and `SimpleStrategy` throws:

```
InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication
```

This caused Jenkins build [#1989](https://jenkins.scylladb.com/job/scylla-master/job/driver-tests/job/java-driver-matrix-test/1989/) to regress across all 4.x driver versions:

| Driver | Errors |
|---|---|
| datastax 4.19.2 | +89 errors |
| datastax 4.19.1 | +97 errors |
| scylla 4.19.0.8 | +84 errors |
| scylla 4.18.1.0 | +105 errors |

The majority of failures cascaded from `SessionUtils.createKeyspace()` being called by `SessionRule.before()` — a single method failure causes entire test classes to be skipped.

## Fix

Replace `SimpleStrategy` with `NetworkTopologyStrategy` (`datacenter1`) in all integration test keyspace creation statements. NTS supports tablets and is the correct strategy for single-DC test clusters.

## Files changed

- `test-infra/.../SessionUtils.java` — central `createKeyspace()` used by `SessionRule` (fixes the majority of failures)
- `integration-tests/.../SchemaChangesIT.java` — 3 CREATE + 1 ALTER CQL strings + updated assertion (NTS replication map uses `datacenter1` key instead of `replication_factor`)
- `integration-tests/.../TokenITBase.java` — 2 CREATE KEYSPACE (RF=1 and RF=2)
- `integration-tests/.../SimpleStatementCcmIT.java` — 1 CREATE KEYSPACE
- `integration-tests/.../LWTLoadBalancingIT.java` — 1 CREATE KEYSPACE (RF=3)
- `integration-tests/.../DefaultKeyspaceIT.java` — 1 CREATE KEYSPACE (mapper test)
- `integration-tests/.../QueryKeyspaceAndTableIT.java` — 1 CREATE KEYSPACE (mapper test)
- `osgi-tests/.../MailboxServiceImpl.java` — 1 CREATE KEYSPACE