### PR TITLE
fix: replace SimpleStrategy with NetworkTopologyStrategy in integration tests (3.x)

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -64,7 +64,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
       String keyspace = (String) objects[0];
       execute(
           String.format(
-              "create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+              "create keyspace %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
               keyspace),
           String.format("create table %s.foo(k int, v int, primary key (k, v))", keyspace));
       for (int v = 1; v <= 100; v++)

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -119,7 +119,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
     Cluster cluster = register(createClusterBuilder().build());
     Session session = cluster.connect();
     session.execute(
-        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
     session.execute("create type ControlConnectionTest_ks.foo (i int)");
     cluster.close();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -63,7 +63,7 @@ public class MetadataTest extends CCMTestsSupport {
     session.execute(
         "CREATE KEYSPACE "
             + keyspace
-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
     Metadata metadata = cluster.getMetadata();
 
     // Capture all Token data.

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
@@ -482,7 +482,7 @@ public class PreparedStatementInvalidationTest extends CCMTestsSupport {
             .init();
     Session session = cluster.connect();
     session.execute(
-        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }");
+        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1' }");
     session.execute("USE cql4_loopholes_test");
     return session;
   }

--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
@@ -95,7 +95,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
     session()
         .execute(
-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
+            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
     session()
         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -24,9 +24,13 @@ package com.datastax.driver.core;
 import static com.datastax.driver.core.Assertions.assertThat;
 
 import com.datastax.driver.core.utils.Bytes;
+import com.google.common.base.Throwables;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 @CCMConfig(
@@ -35,6 +39,36 @@ import org.testng.annotations.Test;
     config = "initial_token:1",
     clusterProvider = "createClusterBuilderNoDebouncing")
 public class SingleTokenIntegrationTest extends CCMTestsSupport {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SingleTokenIntegrationTest.class);
+
+  /**
+   * Override to create the keyspace with tablets disabled when running against Scylla. This test
+   * exercises token-range and token-map based replica lookup (getReplicasList with table == null).
+   * With tablets enabled (the default on modern Scylla), replica placement is controlled by the
+   * tablet map and getReplicasList returns an empty list when the table is unknown, breaking the
+   * test assertions. Cassandra does not support the tablets property.
+   */
+  @Override
+  protected void initTestKeyspace() {
+    try {
+      keyspace = TestUtils.generateIdentifier("ks_");
+      LOGGER.debug("Using keyspace " + keyspace);
+      boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
+      session()
+          .execute(
+              String.format(
+                  "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+                      + " 'datacenter1': 1}"
+                      + (isScylla ? " AND tablets = {'enabled': false}" : ""),
+                  keyspace));
+      useKeyspace(keyspace);
+    } catch (Exception e) {
+      errorOut();
+      LOGGER.error("Could not create test keyspace", e);
+      Throwables.propagate(e);
+    }
+  }
 
   /** JAVA-684: Empty TokenRange returned in a one token cluster */
   @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
@@ -8,7 +8,7 @@ public class StatementPagesTest extends CCMTestsSupport {
   @Override
   public void onTestContextInitialized() {
     execute(
-        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
     execute("CREATE TABLE IF NOT EXISTS ks.t (pk int, ck int, v int, PRIMARY KEY(pk, ck))");
 
     for (int i = 0; i < 50; i++) {

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -86,7 +86,7 @@ public abstract class TestUtils {
   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
 
   public static final String CREATE_KEYSPACE_SIMPLE_FORMAT =
-      "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }";
+      "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : %d }";
   public static final String CREATE_KEYSPACE_GENERIC_FORMAT =
       "CREATE KEYSPACE %s WITH replication = { 'class' : '%s', %s }";
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.testng.annotations.Test;
 
@@ -75,12 +76,19 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
   public void onTestContextInitialized() {
     ks1 = TestUtils.generateIdentifier("ks_");
     ks2 = TestUtils.generateIdentifier("ks_");
+    // Disable tablets on ks1 when running against Scylla. With tablets enabled (the default on
+    // modern Scylla), replica placement is controlled by the tablet map rather than the token map,
+    // so getReplicasList(ks, null, null, key) returns an empty list and the assertions fail.
+    // Cassandra does not support the tablets property, so the clause is omitted there.
+    boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
     execute(
         String.format(
-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+                + " 'datacenter1': 1}"
+                + (isScylla ? " AND tablets = {'enabled': false}" : ""),
             ks1),
         String.format(
-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
+            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}",
             ks2),
         String.format("USE %s", ks1),
         "CREATE TABLE foo(i int primary key)",

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -100,7 +100,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE test_tuple_type "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE test_tuple_type");
     session()
         .execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<tuple<ascii, int, boolean>>)");
@@ -169,7 +169,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE test_tuple_type_varying_lengths "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE test_tuple_type_varying_lengths");
 
     // programmatically create the table with tuples of said sizes
@@ -226,7 +226,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE test_tuple_subtypes "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE test_tuple_subtypes");
 
     // programmatically create the table with a tuple of all datatypes
@@ -294,7 +294,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE test_tuple_non_primitive_subtypes "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE test_tuple_non_primitive_subtypes");
 
     ArrayList<String> values = new ArrayList<String>();
@@ -471,7 +471,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE test_nested_tuples "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE test_nested_tuples");
 
     // create a table with multiple sizes of nested tuples
@@ -519,7 +519,7 @@ public class TupleTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE testTuplesWithNulls "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
     session().execute("USE testTuplesWithNulls");
 
     // create UDT

--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
@@ -34,7 +34,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
 
   private static final String EXPECTED_SCHEMA =
       String.format(
-          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;\n"
+          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '1' } AND DURABLE_WRITES = true;\n"
               + "\n"
               + "CREATE TYPE %s.g (\n"
               + "    f1 int\n"
@@ -89,7 +89,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
 
          Topological sort order should be : gh,FE,D,CB,A
          */
-        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'}",
         String.format("CREATE TYPE %s.h (f1 int)", KEYSPACE),
         String.format("CREATE TYPE %s.g (f1 int)", KEYSPACE),
         String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", KEYSPACE),

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -150,7 +150,7 @@ public class UserTypesTest extends CCMTestsSupport {
             "CREATE KEYSPACE "
                 + otherKeyspaceName
                 + " "
-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
+                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
 
     KeyspaceMetadata otherKeyspace = cluster().getMetadata().getKeyspace(otherKeyspaceName);
     assertThat(otherKeyspace.getUserType(quote("\"User Address\""))).isNull();

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -22,7 +22,6 @@
 package com.datastax.driver.core.policies;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
 import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
 import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.NEUTRAL;
 import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.RANDOM;
@@ -980,7 +979,16 @@ public class TokenAwarePolicyTest {
       Session session = cluster.connect();
 
       String ks = TestUtils.generateIdentifier("ks_");
-      session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, 1));
+      // Use NTS with tablets explicitly disabled. When tablets are enabled (the default on modern
+      // Scylla), replica placement is controlled by the tablet map rather than the token map.
+      // The 3.x driver's tablet-aware getReplicas() path would then route to a different node than
+      // the hardcoded expectation (token 4881097376275569167 → node 1), causing a flaky failure.
+      // Disabling tablets forces deterministic token-map-based replica placement.
+      session.execute(
+          String.format(
+              "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy',"
+                  + " 'datacenter1' : 1 } AND tablets = {'enabled': false}",
+              ks));
       session.execute("USE " + ks);
       session.execute("CREATE TABLE composite (k1 int, k2 int, i int, PRIMARY KEY ((k1, k2)))");
 


### PR DESCRIPTION
## Problem

Since scylladb/scylladb#25342, `SimpleStrategy` throws `InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication` when tablets are globally enabled (default on Scylla 6.0+/2024.2+). This causes widespread integration test failures on modern Scylla.

The root cause in 3.x is `TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT`, which is used by `CCMTestsSupport.initTestKeyspace()` — the default keyspace setup for virtually all integration tests — as well as several other test classes.

## Fix

Replace `SimpleStrategy` with `NetworkTopologyStrategy` (`datacenter1`, the default CCM DC name in 3.x) across all 3.x integration tests:

- `TestUtils.java` — `CREATE_KEYSPACE_SIMPLE_FORMAT` constant (fixes all callers: `CCMTestsSupport`, `AbstractPoliciesTest`, `CaseSensitivityTest`, `LargeDataTest`, `SchemaChangesCCTest`, `SchemaRefreshDebouncerTest`)
- `AsyncQueryTest`, `ControlConnectionTest`, `MetadataTest`, `PreparedStatementInvalidationTest`, `ShardAwarenessTest`, `StatementPagesTest`, `TokenIntegrationTest`, `TupleTest`, `UnresolvedUserTypeTest`, `UserTypesTest` — inline CQL statements
- `TokenAwarePolicyTest` — create keyspace with `AND tablets = {'enabled': false}` to disable tablets for the composite-key routing test; with NTS + tablets enabled, the 3.x driver routes via the tablet map instead of the token map, breaking the hardcoded expectation that token `4881097376275569167` for composite key `(1,2)` maps to node 1

## Companion PRs

- **4.x driver**: scylladb/java-driver#875 (branch `scylla-4.x`)
- **Matrix patches**: scylladb/scylla-java-driver-matrix#141