### PR TITLE
fix: enrich timeout diagnostics

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -412,6 +412,9 @@ abstract class ArrayBackedResultSet implements ResultSet {
             public void register(RequestHandler handler) {}
 
             @Override
+            public void registerReadTimeoutMillis(long readTimeoutMillis) {}
+
+            @Override
             public void onSet(
                 Connection connection,
                 Message.Response response,

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -962,6 +962,9 @@ class Connection {
       throws ConnectionException, BusyConnectionException {
 
     ResponseHandler handler = new ResponseHandler(this, statementReadTimeoutMillis, callback);
+    if (callback instanceof RequestHandler.Callback) {
+      ((RequestHandler.Callback) callback).registerReadTimeoutMillis(handler.readTimeoutMillis);
+    }
     dispatcher.add(handler);
 
     Message.Request request = callback.request().setStreamId(handler.streamId);
@@ -1060,6 +1063,97 @@ class Connection {
 
   public ProtocolFeatureStore getProtocolFeatureStore() {
     return protocolFeatureStore;
+  }
+
+  OperationTimedOutException newTimeoutException(long elapsedTimeoutNanos, int retryCount) {
+    return newTimeoutException(
+        null,
+        factory.getReadTimeoutMillis(),
+        elapsedTimeoutNanos,
+        retryCount,
+        OperationTimedOutException.UNAVAILABLE);
+  }
+
+  OperationTimedOutException newTimeoutException(
+      long configuredTimeoutMs,
+      long elapsedTimeoutNanos,
+      int retryCount,
+      int speculativeExecutionIndex) {
+    return newTimeoutException(
+        null, configuredTimeoutMs, elapsedTimeoutNanos, retryCount, speculativeExecutionIndex);
+  }
+
+  OperationTimedOutException newTimeoutException(
+      String message,
+      long configuredTimeoutMs,
+      long elapsedTimeoutNanos,
+      int retryCount,
+      int speculativeExecutionIndex) {
+    HostConnectionPool pool = ownerPool();
+    ShardingInfo.ConnectionShardingInfo connectionShardingInfo =
+        protocolFeatureStore == null ? null : protocolFeatureStore.getConnectionShardingInfo();
+    ShardingInfo hostShardingInfo =
+        connectionShardingInfo != null
+            ? connectionShardingInfo.shardingInfo
+            : pool != null ? pool.host.getShardingInfo() : null;
+    int connectionShardId =
+        connectionShardingInfo != null ? shardId() : OperationTimedOutException.UNAVAILABLE;
+    int hostShardsCount =
+        hostShardingInfo != null
+            ? hostShardingInfo.getShardsCount()
+            : OperationTimedOutException.UNAVAILABLE;
+    int poolPendingBorrows =
+        pool != null ? pool.pendingBorrowCount.get() : OperationTimedOutException.UNAVAILABLE;
+    int poolPendingBorrowsForShard =
+        pool != null && connectionShardId != OperationTimedOutException.UNAVAILABLE
+            ? pool.pendingBorrowCountForShard(connectionShardId)
+            : OperationTimedOutException.UNAVAILABLE;
+    int poolTotalInFlight =
+        pool != null ? pool.totalInFlight.get() : OperationTimedOutException.UNAVAILABLE;
+    int poolOpenConnectionsForShard =
+        pool != null && connectionShardId != OperationTimedOutException.UNAVAILABLE
+            ? pool.openConnectionCountForShard(connectionShardId)
+            : OperationTimedOutException.UNAVAILABLE;
+    int poolMaxConnectionsPerShard =
+        pool != null ? pool.maxConnectionsPerShard() : OperationTimedOutException.UNAVAILABLE;
+    long elapsedTimeoutMs = TimeUnit.NANOSECONDS.toMillis(elapsedTimeoutNanos);
+
+    if (message == null) {
+      return new OperationTimedOutException(
+          endPoint,
+          configuredTimeoutMs,
+          elapsedTimeoutMs,
+          retryCount,
+          speculativeExecutionIndex,
+          inFlight.get(),
+          connectionShardId,
+          hostShardsCount,
+          poolPendingBorrows,
+          poolPendingBorrowsForShard,
+          poolTotalInFlight,
+          poolOpenConnectionsForShard,
+          poolMaxConnectionsPerShard);
+    }
+    return new OperationTimedOutException(
+        endPoint,
+        message,
+        configuredTimeoutMs,
+        elapsedTimeoutMs,
+        retryCount,
+        speculativeExecutionIndex,
+        inFlight.get(),
+        connectionShardId,
+        hostShardsCount,
+        poolPendingBorrows,
+        poolPendingBorrowsForShard,
+        poolTotalInFlight,
+        poolOpenConnectionsForShard,
+        poolMaxConnectionsPerShard);
+  }
+
+  private HostConnectionPool ownerPool() {
+    Owner owner = ownerRef.get();
+    return owner instanceof HostConnectionPool ? (HostConnectionPool) owner : null;
   }
 
   /**
@@ -1812,6 +1906,11 @@ class Connection {
     @Override
     public void register(RequestHandler handler) {
       // noop, we don't care about the handler here so far
+    }
+
+    @Override
+    public void registerReadTimeoutMillis(long readTimeoutMillis) {
+      // noop, direct connection writes keep the legacy timeout exception shape
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -41,6 +41,7 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet>
   private final ProtocolVersion protocolVersion;
   private final Message.Request request;
   private volatile RequestHandler handler;
+  private volatile long readTimeoutMillis = OperationTimedOutException.UNAVAILABLE;
 
   DefaultResultSetFuture(
       SessionManager session, ProtocolVersion protocolVersion, Message.Request request) {
@@ -52,6 +53,11 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet>
   @Override
   public void register(RequestHandler handler) {
     this.handler = handler;
+  }
+
+  @Override
+  public void registerReadTimeoutMillis(long readTimeoutMillis) {
+    this.readTimeoutMillis = readTimeoutMillis;
   }
 
   @Override
@@ -293,7 +299,9 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet>
     // RequestHandler).
     // So just set an exception for the final result, which should be handled correctly by said
     // internal call.
-    setException(new OperationTimedOutException(connection.endPoint));
+    setException(
+        connection.newTimeoutException(
+            readTimeoutMillis, latency, retryCount, OperationTimedOutException.UNAVAILABLE));
     return true;
   }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -29,6 +29,7 @@ import static com.datastax.driver.core.Connection.State.TRASHED;
 import com.datastax.driver.core.exceptions.AuthenticationException;
 import com.datastax.driver.core.exceptions.BusyPoolException;
 import com.datastax.driver.core.exceptions.ConnectionException;
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.annotations.VisibleForTesting;
@@ -206,6 +207,27 @@ class HostConnectionPool implements Connection.Owner {
   public void tempBlockAdvShardAwareness(long millis) {
     advShardAwarenessBlockedUntil =
         Math.max(System.currentTimeMillis() + millis, advShardAwarenessBlockedUntil);
+  }
+
+  int pendingBorrowCountForShard(int shardId) {
+    if (pendingBorrows == null || shardId < 0 || shardId >= pendingBorrows.length) {
+      return OperationTimedOutException.UNAVAILABLE;
+    }
+    return pendingBorrows[shardId].size();
+  }
+
+  int openConnectionCountForShard(int shardId) {
+    if (connections == null || shardId < 0 || shardId >= connections.length) {
+      return OperationTimedOutException.UNAVAILABLE;
+    }
+    return connections[shardId].size();
+  }
+
+  int maxConnectionsPerShard() {
+    if (connections == null) {
+      return OperationTimedOutException.UNAVAILABLE;
+    }
+    return maxConnectionsPerShard;
   }
 
   private final ConnectionTasksSharedState connectionTasksSharedState =

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -319,6 +319,8 @@ class RequestHandler {
         long latency);
 
     void register(RequestHandler handler);
+
+    void registerReadTimeoutMillis(long readTimeoutMillis);
   }
 
   /**
@@ -943,11 +945,19 @@ class RequestHandler {
                 queryStateRef.get());
             return false;
           }
+          long configuredTimeoutMs =
+              connectionHandler != null
+                  ? connectionHandler.readTimeoutMillis
+                  : OperationTimedOutException.UNAVAILABLE;
+          OperationTimedOutException timeoutException =
+              connection.newTimeoutException(
+                  "Timed out waiting for response to PREPARE message",
+                  configuredTimeoutMs,
+                  latency,
+                  retryCount,
+                  position);
           connection.release();
-          logError(
-              connection.endPoint,
-              new OperationTimedOutException(
-                  connection.endPoint, "Timed out waiting for response to PREPARE message"));
+          logError(connection.endPoint, timeoutException);
           retry(false, null);
           return true;
         }
@@ -1006,25 +1016,13 @@ class RequestHandler {
       }
 
       Host queriedHost = current;
-
-      HostConnectionPool pool = queriedHost == null ? null : manager.pools.get(queriedHost);
       long configuredTimeoutMs =
           connectionHandler != null
               ? connectionHandler.readTimeoutMillis
               : OperationTimedOutException.UNAVAILABLE;
-      int connInFlight = connection.inFlight.get();
-      int poolPendingBorrows =
-          pool != null ? pool.pendingBorrowCount.get() : OperationTimedOutException.UNAVAILABLE;
-      int poolTotalInFlight =
-          pool != null ? pool.totalInFlight.get() : OperationTimedOutException.UNAVAILABLE;
 
       OperationTimedOutException timeoutException =
-          new OperationTimedOutException(
-              connection.endPoint,
-              configuredTimeoutMs,
-              connInFlight,
-              poolPendingBorrows,
-              poolTotalInFlight);
+          connection.newTimeoutException(configuredTimeoutMs, latency, retryCount, position);
 
       try {
         connection.release();

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/OperationTimedOutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/OperationTimedOutException.java
@@ -22,50 +22,110 @@ import com.datastax.driver.core.SocketOptions;
  * Thrown on a client-side timeout, i.e. when the client didn't hear back from the server within
  * {@link SocketOptions#getReadTimeoutMillis()}.
  *
- * <p>When the exception is thrown from the request execution path it carries additional diagnostic
- * fields: the driver-side timeout that was configured for the request, the number of in-flight
- * requests on the connection at the moment of the timeout, and the pool-level pending-borrow queue
- * depth and total in-flight count. These fields are set to {@link #UNAVAILABLE} when the exception
- * was not created through that path (e.g. when re-thrown or copied via legacy constructors).
+ * <p>When the exception is thrown from the request execution path it can carry additional
+ * diagnostic fields: the configured timeout, the measured elapsed timeout, retry and speculative
+ * execution counters, connection shard and load information, and host-pool contention metrics.
+ * These fields are set to {@link #UNAVAILABLE} when the corresponding information was not available
+ * at the time the exception was created.
  */
 public class OperationTimedOutException extends ConnectionException {
 
   private static final long serialVersionUID = 0;
+  private static final String DEFAULT_MESSAGE = "Timed out waiting for server response";
 
   /**
-   * Sentinel value returned by {@link #getConfiguredTimeoutMs()}, {@link #getConnectionInFlight()},
-   * {@link #getPoolPendingBorrows()}, and {@link #getPoolTotalInFlight()} when the corresponding
-   * information was not available at the time the exception was created.
+   * Sentinel value returned by the diagnostic getters when the corresponding information was not
+   * available at the time the exception was created.
    */
   public static final int UNAVAILABLE = -1;
 
   private final long configuredTimeoutMs;
+  private final long elapsedTimeoutMs;
+  private final int retryCount;
+  private final int speculativeExecutionIndex;
   private final int connectionInFlight;
+  private final int connectionShardId;
+  private final int hostShardsCount;
   private final int poolPendingBorrows;
+  private final int poolPendingBorrowsForShard;
   private final int poolTotalInFlight;
+  private final int poolOpenConnectionsForShard;
+  private final int poolMaxConnectionsPerShard;
 
   public OperationTimedOutException(EndPoint endPoint) {
     super(endPoint, "Operation timed out");
     this.configuredTimeoutMs = UNAVAILABLE;
+    this.elapsedTimeoutMs = UNAVAILABLE;
+    this.retryCount = UNAVAILABLE;
+    this.speculativeExecutionIndex = UNAVAILABLE;
     this.connectionInFlight = UNAVAILABLE;
+    this.connectionShardId = UNAVAILABLE;
+    this.hostShardsCount = UNAVAILABLE;
     this.poolPendingBorrows = UNAVAILABLE;
+    this.poolPendingBorrowsForShard = UNAVAILABLE;
     this.poolTotalInFlight = UNAVAILABLE;
+    this.poolOpenConnectionsForShard = UNAVAILABLE;
+    this.poolMaxConnectionsPerShard = UNAVAILABLE;
   }
 
   public OperationTimedOutException(EndPoint endPoint, String msg) {
     super(endPoint, msg);
     this.configuredTimeoutMs = UNAVAILABLE;
+    this.elapsedTimeoutMs = UNAVAILABLE;
+    this.retryCount = UNAVAILABLE;
+    this.speculativeExecutionIndex = UNAVAILABLE;
     this.connectionInFlight = UNAVAILABLE;
+    this.connectionShardId = UNAVAILABLE;
+    this.hostShardsCount = UNAVAILABLE;
     this.poolPendingBorrows = UNAVAILABLE;
+    this.poolPendingBorrowsForShard = UNAVAILABLE;
     this.poolTotalInFlight = UNAVAILABLE;
+    this.poolOpenConnectionsForShard = UNAVAILABLE;
+    this.poolMaxConnectionsPerShard = UNAVAILABLE;
   }
 
   public OperationTimedOutException(EndPoint endPoint, String msg, Throwable cause) {
     super(endPoint, msg, cause);
     this.configuredTimeoutMs = UNAVAILABLE;
+    this.elapsedTimeoutMs = UNAVAILABLE;
+    this.retryCount = UNAVAILABLE;
+    this.speculativeExecutionIndex = UNAVAILABLE;
     this.connectionInFlight = UNAVAILABLE;
+    this.connectionShardId = UNAVAILABLE;
+    this.hostShardsCount = UNAVAILABLE;
     this.poolPendingBorrows = UNAVAILABLE;
+    this.poolPendingBorrowsForShard = UNAVAILABLE;
     this.poolTotalInFlight = UNAVAILABLE;
+    this.poolOpenConnectionsForShard = UNAVAILABLE;
+    this.poolMaxConnectionsPerShard = UNAVAILABLE;
+  }
+
+  /**
+   * Creates an exception with the diagnostic context that was exposed in 3.11.5.14.
+   *
+   * <p>This overload is retained for source and binary compatibility with callers that were
+   * compiled against that release.
+   */
+  public OperationTimedOutException(
+      EndPoint endPoint,
+      long configuredTimeoutMs,
+      int connectionInFlight,
+      int poolPendingBorrows,
+      int poolTotalInFlight) {
+    this(
+        endPoint,
+        configuredTimeoutMs,
+        UNAVAILABLE,
+        UNAVAILABLE,
+        UNAVAILABLE,
+        connectionInFlight,
+        UNAVAILABLE,
+        UNAVAILABLE,
+        poolPendingBorrows,
+        UNAVAILABLE,
+        poolTotalInFlight,
+        UNAVAILABLE,
+        UNAVAILABLE);
   }
 
   /**
@@ -76,32 +136,104 @@ public class OperationTimedOutException extends ConnectionException {
    *     milliseconds. Either the per-statement override ({@link
    *     com.datastax.driver.core.Statement#setReadTimeoutMillis}) or the driver-wide value from
    *     {@link SocketOptions#getReadTimeoutMillis()}.
+   * @param elapsedTimeoutMs the time observed by the driver between the request being written and
+   *     the timeout firing, in milliseconds.
+   * @param retryCount the request-level retry count associated with the timed out execution.
+   * @param speculativeExecutionIndex the index of the speculative execution that timed out, where 0
+   *     is the original execution.
    * @param connectionInFlight the number of in-flight requests on the connection at the time of the
    *     timeout.
+   * @param connectionShardId the shard the connection was pinned to, if known.
+   * @param hostShardsCount the number of shards reported by the host, if known.
    * @param poolPendingBorrows the number of requests waiting to acquire a connection from the pool
    *     at the time of the timeout. A non-zero value indicates pool contention.
+   * @param poolPendingBorrowsForShard the number of requests waiting on the same shard queue, if
+   *     known.
    * @param poolTotalInFlight the total number of in-flight requests across all connections to this
    *     host at the time of the timeout.
+   * @param poolOpenConnectionsForShard the number of open connections on the same shard, if known.
+   * @param poolMaxConnectionsPerShard the configured maximum number of connections for a shard, if
+   *     known.
    */
   public OperationTimedOutException(
       EndPoint endPoint,
       long configuredTimeoutMs,
+      long elapsedTimeoutMs,
+      int retryCount,
+      int speculativeExecutionIndex,
       int connectionInFlight,
+      int connectionShardId,
+      int hostShardsCount,
       int poolPendingBorrows,
-      int poolTotalInFlight) {
-    super(
+      int poolPendingBorrowsForShard,
+      int poolTotalInFlight,
+      int poolOpenConnectionsForShard,
+      int poolMaxConnectionsPerShard) {
+    this(
         endPoint,
-        String.format(
-            "Timed out waiting for server response"
-                + " [configured timeout: %dms,"
-                + " connection in-flight: %d,"
-                + " pool pending borrows: %d,"
-                + " pool total in-flight: %d]",
-            configuredTimeoutMs, connectionInFlight, poolPendingBorrows, poolTotalInFlight));
-    this.configuredTimeoutMs = configuredTimeoutMs;
-    this.connectionInFlight = connectionInFlight;
-    this.poolPendingBorrows = poolPendingBorrows;
-    this.poolTotalInFlight = poolTotalInFlight;
+        DEFAULT_MESSAGE,
+        configuredTimeoutMs,
+        elapsedTimeoutMs,
+        retryCount,
+        speculativeExecutionIndex,
+        connectionInFlight,
+        connectionShardId,
+        hostShardsCount,
+        poolPendingBorrows,
+        poolPendingBorrowsForShard,
+        poolTotalInFlight,
+        poolOpenConnectionsForShard,
+        poolMaxConnectionsPerShard);
+  }
+
+  /**
+   * Same as {@link #OperationTimedOutException(EndPoint, long, long, int, int, int, int, int, int,
+   * int, int, int, int)}, but with a custom message.
+   */
+  public OperationTimedOutException(
+      EndPoint endPoint,
+      String msg,
+      long configuredTimeoutMs,
+      long elapsedTimeoutMs,
+      int retryCount,
+      int speculativeExecutionIndex,
+      int connectionInFlight,
+      int connectionShardId,
+      int hostShardsCount,
+      int poolPendingBorrows,
+      int poolPendingBorrowsForShard,
+      int poolTotalInFlight,
+      int poolOpenConnectionsForShard,
+      int poolMaxConnectionsPerShard) {
+    this(
+        endPoint,
+        buildMessage(
+            msg,
+            configuredTimeoutMs,
+            elapsedTimeoutMs,
+            retryCount,
+            speculativeExecutionIndex,
+            connectionInFlight,
+            connectionShardId,
+            hostShardsCount,
+            poolPendingBorrows,
+            poolPendingBorrowsForShard,
+            poolTotalInFlight,
+            poolOpenConnectionsForShard,
+            poolMaxConnectionsPerShard),
+        null,
+        configuredTimeoutMs,
+        elapsedTimeoutMs,
+        retryCount,
+        speculativeExecutionIndex,
+        connectionInFlight,
+        connectionShardId,
+        hostShardsCount,
+        poolPendingBorrows,
+        poolPendingBorrowsForShard,
+        poolTotalInFlight,
+        poolOpenConnectionsForShard,
+        poolMaxConnectionsPerShard);
   }
 
   /** Private constructor used by {@link #copy()} to preserve all fields and the cause chain. */
@@ -110,14 +242,30 @@ public class OperationTimedOutException extends ConnectionException {
       String msg,
       Throwable cause,
       long configuredTimeoutMs,
+      long elapsedTimeoutMs,
+      int retryCount,
+      int speculativeExecutionIndex,
       int connectionInFlight,
+      int connectionShardId,
+      int hostShardsCount,
       int poolPendingBorrows,
-      int poolTotalInFlight) {
+      int poolPendingBorrowsForShard,
+      int poolTotalInFlight,
+      int poolOpenConnectionsForShard,
+      int poolMaxConnectionsPerShard) {
     super(endPoint, msg, cause);
     this.configuredTimeoutMs = configuredTimeoutMs;
+    this.elapsedTimeoutMs = elapsedTimeoutMs;
+    this.retryCount = retryCount;
+    this.speculativeExecutionIndex = speculativeExecutionIndex;
     this.connectionInFlight = connectionInFlight;
+    this.connectionShardId = connectionShardId;
+    this.hostShardsCount = hostShardsCount;
     this.poolPendingBorrows = poolPendingBorrows;
+    this.poolPendingBorrowsForShard = poolPendingBorrowsForShard;
     this.poolTotalInFlight = poolTotalInFlight;
+    this.poolOpenConnectionsForShard = poolOpenConnectionsForShard;
+    this.poolMaxConnectionsPerShard = poolMaxConnectionsPerShard;
   }
 
   /**
@@ -129,11 +277,49 @@ public class OperationTimedOutException extends ConnectionException {
   }
 
   /**
+   * Returns the elapsed time observed by the driver between request dispatch and timeout firing, in
+   * milliseconds, or {@link #UNAVAILABLE} if not available.
+   */
+  public long getElapsedTimeoutMs() {
+    return elapsedTimeoutMs;
+  }
+
+  /**
+   * Returns the request-level retry count associated with the timed out execution, or {@link
+   * #UNAVAILABLE} if not available.
+   */
+  public int getRetryCount() {
+    return retryCount;
+  }
+
+  /**
+   * Returns the speculative execution index associated with the timed out execution, or {@link
+   * #UNAVAILABLE} if not available. The original execution is index 0.
+   */
+  public int getSpeculativeExecutionIndex() {
+    return speculativeExecutionIndex;
+  }
+
+  /**
    * Returns the number of in-flight requests on the connection at the time of the timeout, or
    * {@link #UNAVAILABLE} if not available.
    */
   public int getConnectionInFlight() {
     return connectionInFlight;
+  }
+
+  /**
+   * Returns the shard of the connection that timed out, or {@link #UNAVAILABLE} if not available.
+   */
+  public int getConnectionShardId() {
+    return connectionShardId;
+  }
+
+  /**
+   * Returns the number of shards reported by the host, or {@link #UNAVAILABLE} if not available.
+   */
+  public int getHostShardsCount() {
+    return hostShardsCount;
   }
 
   /**
@@ -146,11 +332,35 @@ public class OperationTimedOutException extends ConnectionException {
   }
 
   /**
+   * Returns the number of requests waiting on the shard-specific pool queue, or {@link
+   * #UNAVAILABLE} if not available.
+   */
+  public int getPoolPendingBorrowsForShard() {
+    return poolPendingBorrowsForShard;
+  }
+
+  /**
    * Returns the total number of in-flight requests across all connections to the host at the time
    * of the timeout, or {@link #UNAVAILABLE} if not available.
    */
   public int getPoolTotalInFlight() {
     return poolTotalInFlight;
+  }
+
+  /**
+   * Returns the number of open connections on the shard that timed out, or {@link #UNAVAILABLE} if
+   * not available.
+   */
+  public int getPoolOpenConnectionsForShard() {
+    return poolOpenConnectionsForShard;
+  }
+
+  /**
+   * Returns the configured maximum number of connections for a shard, or {@link #UNAVAILABLE} if
+   * not available.
+   */
+  public int getPoolMaxConnectionsPerShard() {
+    return poolMaxConnectionsPerShard;
   }
 
   @Override
@@ -160,8 +370,121 @@ public class OperationTimedOutException extends ConnectionException {
         getRawMessage(),
         this,
         configuredTimeoutMs,
+        elapsedTimeoutMs,
+        retryCount,
+        speculativeExecutionIndex,
         connectionInFlight,
+        connectionShardId,
+        hostShardsCount,
         poolPendingBorrows,
-        poolTotalInFlight);
+        poolPendingBorrowsForShard,
+        poolTotalInFlight,
+        poolOpenConnectionsForShard,
+        poolMaxConnectionsPerShard);
+  }
+
+  private static String buildMessage(
+      String msg,
+      long configuredTimeoutMs,
+      long elapsedTimeoutMs,
+      int retryCount,
+      int speculativeExecutionIndex,
+      int connectionInFlight,
+      int connectionShardId,
+      int hostShardsCount,
+      int poolPendingBorrows,
+      int poolPendingBorrowsForShard,
+      int poolTotalInFlight,
+      int poolOpenConnectionsForShard,
+      int poolMaxConnectionsPerShard) {
+    StringBuilder message = new StringBuilder(msg == null ? DEFAULT_MESSAGE : msg);
+    boolean hasDiagnostics = false;
+    hasDiagnostics =
+        appendDiagnostic(message, hasDiagnostics, "configured timeout", configuredTimeoutMs, "ms");
+    hasDiagnostics =
+        appendDiagnostic(message, hasDiagnostics, "elapsed timeout", elapsedTimeoutMs, "ms");
+    hasDiagnostics = appendDiagnostic(message, hasDiagnostics, "retry count", retryCount, null);
+    hasDiagnostics =
+        appendDiagnostic(
+            message,
+            hasDiagnostics,
+            "speculative execution index",
+            speculativeExecutionIndex,
+            null);
+    hasDiagnostics =
+        appendDiagnostic(message, hasDiagnostics, "connection in-flight", connectionInFlight, null);
+    hasDiagnostics =
+        appendShardDiagnostic(message, hasDiagnostics, connectionShardId, hostShardsCount);
+    if (!isAvailable(connectionShardId)) {
+      hasDiagnostics =
+          appendDiagnostic(message, hasDiagnostics, "host shards count", hostShardsCount, null);
+    }
+    hasDiagnostics =
+        appendDiagnostic(message, hasDiagnostics, "pool pending borrows", poolPendingBorrows, null);
+    hasDiagnostics =
+        appendDiagnostic(
+            message,
+            hasDiagnostics,
+            "pool pending borrows for shard",
+            poolPendingBorrowsForShard,
+            null);
+    hasDiagnostics =
+        appendDiagnostic(message, hasDiagnostics, "pool total in-flight", poolTotalInFlight, null);
+    hasDiagnostics =
+        appendDiagnostic(
+            message,
+            hasDiagnostics,
+            "pool open connections for shard",
+            poolOpenConnectionsForShard,
+            null);
+    hasDiagnostics =
+        appendDiagnostic(
+            message,
+            hasDiagnostics,
+            "pool max connections per shard",
+            poolMaxConnectionsPerShard,
+            null);
+    if (hasDiagnostics) {
+      message.append(']');
+    }
+    return message.toString();
+  }
+
+  private static boolean appendDiagnostic(
+      StringBuilder message, boolean hasDiagnostics, String label, long value, String suffix) {
+    if (!isAvailable(value)) {
+      return hasDiagnostics;
+    }
+    appendSeparator(message, hasDiagnostics);
+    message.append(label).append(": ").append(value);
+    if (suffix != null) {
+      message.append(suffix);
+    }
+    return true;
+  }
+
+  private static boolean appendShardDiagnostic(
+      StringBuilder message, boolean hasDiagnostics, int connectionShardId, int hostShardsCount) {
+    if (!isAvailable(connectionShardId)) {
+      return hasDiagnostics;
+    }
+    appendSeparator(message, hasDiagnostics);
+    message.append("connection shard: ").append(connectionShardId);
+    if (isAvailable(hostShardsCount)) {
+      message.append('/').append(hostShardsCount);
+    }
+    return true;
+  }
+
+  private static void appendSeparator(StringBuilder message, boolean hasDiagnostics) {
+    if (hasDiagnostics) {
+      message.append(", ");
+    } else {
+      message.append(" [");
+    }
+  }
+
+  private static boolean isAvailable(long value) {
+    return value != UNAVAILABLE;
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DefaultResultSetFutureTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DefaultResultSetFutureTest.java
@@ -15,14 +15,18 @@
  */
 package com.datastax.driver.core;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.testng.annotations.Test;
 
 /**
@@ -79,6 +83,43 @@ public class DefaultResultSetFutureTest {
     }
   }
 
+  @Test(groups = "unit")
+  public void should_use_dispatched_timeout_snapshot_for_internal_timeouts() throws Exception {
+    DefaultResultSetFuture future =
+        new DefaultResultSetFuture(
+            null, ProtocolVersion.V4, new Requests.Query("SELECT cluster_name FROM system.local"));
+    Connection connection = allocateInstance(Connection.class);
+    EndPoint endPoint = EndPoints.forAddress("127.0.0.1", 9042);
+
+    setField(connection, "endPoint", endPoint);
+    setField(connection, "inFlight", new AtomicInteger(1));
+    setField(connection, "ownerRef", new AtomicReference<Connection.Owner>());
+    future.registerReadTimeoutMillis(17L);
+
+    future.onTimeout(connection, TimeUnit.MILLISECONDS.toNanos(123), 2);
+
+    try {
+      future.getUninterruptibly();
+      fail("Should have thrown exception");
+    } catch (OperationTimedOutException e) {
+      assertEquals(e.getConfiguredTimeoutMs(), 17L);
+      assertEquals(e.getElapsedTimeoutMs(), 123L);
+      assertEquals(e.getRetryCount(), 2);
+      assertEquals(e.getSpeculativeExecutionIndex(), OperationTimedOutException.UNAVAILABLE);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T allocateInstance(Class<T> clazz) throws Exception {
+    Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+    Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    Object unsafe = unsafeField.get(null);
+    java.lang.reflect.Method allocateInstance =
+        unsafeClass.getMethod("allocateInstance", Class.class);
+    return (T) allocateInstance.invoke(unsafe, clazz);
+  }
+
   /**
    * Creates minimal test objects needed for testing. Uses Unsafe to create instances without
    * invoking constructors.
@@ -122,9 +163,18 @@ public class DefaultResultSetFutureTest {
 
   /** Helper to set a field value using reflection. */
   private void setField(Object obj, String fieldName, Object value) throws Exception {
-    Field field = obj.getClass().getDeclaredField(fieldName);
-    field.setAccessible(true);
-    field.set(obj, value);
+    Class<?> current = obj.getClass();
+    while (current != null) {
+      try {
+        Field field = current.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+        return;
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
   }
 
   /**

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -51,6 +51,7 @@ import com.datastax.driver.core.exceptions.BusyPoolException;
 import com.datastax.driver.core.exceptions.ConnectionException;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -483,6 +484,37 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
       }
     } finally {
       MockRequest.completeAll(requests);
+      cluster.close();
+    }
+  }
+
+  @Test(groups = "short")
+  public void should_keep_legacy_timeout_exception_for_direct_connection_writes() throws Exception {
+    Cluster cluster = createClusterBuilder().build();
+    try {
+      HostConnectionPool pool = createPool(cluster, 1, 1);
+      Connection connection = pool.connections[0].get(0);
+      Connection.Future future = new Connection.Future(new Requests.Query("USE \"slowks\""));
+      future.onTimeout(connection, 0, 0);
+
+      try {
+        Uninterruptibles.getUninterruptibly(future);
+        fail("Should have thrown exception");
+      } catch (ExecutionException e) {
+        assertThat(e.getCause()).isInstanceOf(OperationTimedOutException.class);
+        OperationTimedOutException timeout = (OperationTimedOutException) e.getCause();
+        assertThat(timeout.getMessage())
+            .contains("Operation timed out")
+            .doesNotContain("configured timeout");
+        assertThat(timeout.getConfiguredTimeoutMs())
+            .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+        assertThat(timeout.getElapsedTimeoutMs()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+        assertThat(timeout.getConnectionInFlight())
+            .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+        assertThat(timeout.getPoolTotalInFlight())
+            .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+      }
+    } finally {
       cluster.close();
     }
   }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutDiagnosticsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutDiagnosticsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import static org.testng.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import org.objenesis.ObjenesisStd;
+import org.testng.annotations.Test;
+
+public class HostConnectionPoolTimeoutDiagnosticsTest {
+
+  @Test(groups = "unit")
+  public void should_report_pending_borrow_queue_size_per_shard() throws Exception {
+    HostConnectionPool pool = allocateInstance(HostConnectionPool.class);
+    Queue<Object> pendingBorrows = new ArrayDeque<Object>();
+    for (int i = 0; i < 6; i++) {
+      pendingBorrows.add(new Object());
+    }
+    setField(pool, "pendingBorrows", new Queue[] {pendingBorrows});
+
+    assertEquals(pool.pendingBorrowCountForShard(0), 6);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocateInstance(Class<T> clazz) throws Exception {
+    return (T) new ObjenesisStd().newInstance(clazz);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Class<?> current = target.getClass();
+    while (current != null) {
+      try {
+        Field field = current.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
@@ -15,8 +15,10 @@
  */
 package com.datastax.driver.core;
 
+import static com.datastax.driver.core.Assertions.assertThat;
 import static org.scassandra.http.client.PrimingRequest.queryBuilder;
 import static org.scassandra.http.client.PrimingRequest.then;
+import static org.testng.Assert.fail;
 
 import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import org.testng.annotations.BeforeMethod;
@@ -38,6 +40,35 @@ public class ReadTimeoutTest extends ScassandraTestBase.PerClassCluster {
   @Test(groups = "short", expectedExceptions = OperationTimedOutException.class)
   public void should_use_default_timeout_if_not_overridden_by_statement() {
     session.execute(query);
+  }
+
+  @Test(groups = "short")
+  public void should_include_timeout_diagnostics() {
+    try {
+      session.execute(query);
+      fail("expected an OperationTimedOutException");
+    } catch (OperationTimedOutException e) {
+      assertThat(e.getConfiguredTimeoutMs()).isEqualTo(10);
+      assertThat(e.getElapsedTimeoutMs()).isGreaterThanOrEqualTo(10);
+      assertThat(e.getRetryCount()).isEqualTo(0);
+      assertThat(e.getSpeculativeExecutionIndex()).isEqualTo(0);
+      assertThat(e.getConnectionInFlight()).isGreaterThanOrEqualTo(1);
+      assertThat(e.getPoolPendingBorrows()).isGreaterThanOrEqualTo(0);
+      assertThat(e.getPoolTotalInFlight()).isGreaterThanOrEqualTo(1);
+      assertThat(e.getConnectionShardId()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+      assertThat(e.getHostShardsCount()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+      assertThat(e.getPoolPendingBorrowsForShard())
+          .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+      assertThat(e.getPoolOpenConnectionsForShard())
+          .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+      assertThat(e.getPoolMaxConnectionsPerShard()).isGreaterThanOrEqualTo(1);
+      assertThat(e.getMessage())
+          .contains("Timed out waiting for server response")
+          .contains("configured timeout: 10ms")
+          .contains("elapsed timeout:")
+          .contains("retry count: 0")
+          .contains("speculative execution index: 0");
+    }
   }
 
   @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerPrepareTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerPrepareTimeoutTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.objenesis.ObjenesisStd;
+import org.testng.annotations.Test;
+
+public class RequestHandlerPrepareTimeoutTest {
+
+  @Test(groups = "unit")
+  public void should_capture_prepare_timeout_diagnostics_before_releasing_connection()
+      throws Exception {
+    RequestHandler handler = allocateInstance(RequestHandler.class);
+    setField(handler, "id", "test");
+    setField(
+        handler,
+        "queryPlan",
+        new RequestHandler.QueryPlan(Collections.<Host>emptyList().iterator()));
+    Set<Object> runningExecutions = new CopyOnWriteArraySet<Object>();
+    runningExecutions.add(new Object());
+    setField(handler, "runningExecutions", runningExecutions);
+    setField(handler, "isDone", new AtomicBoolean(false));
+
+    RequestHandler.SpeculativeExecution execution =
+        handler.new SpeculativeExecution(new Requests.Query("SELECT v FROM test WHERE k = ?"), 2);
+
+    Method prepareAndRetry =
+        RequestHandler.SpeculativeExecution.class.getDeclaredMethod(
+            "prepareAndRetry", String.class);
+    prepareAndRetry.setAccessible(true);
+    Connection.ResponseCallback callback =
+        (Connection.ResponseCallback)
+            prepareAndRetry.invoke(execution, "SELECT v FROM test WHERE k = ?");
+
+    EndPoint endPoint = EndPoints.forAddress("127.0.0.1", 9042);
+    RecordingConnection connection = allocateInstance(RecordingConnection.class);
+    connection.calls = new ArrayList<String>();
+    setField(connection, "endPoint", endPoint);
+
+    connection.timeoutException = new OperationTimedOutException(endPoint);
+
+    setField(
+        execution,
+        "queryStateRef",
+        new AtomicReference<RequestHandler.QueryState>(
+            RequestHandler.QueryState.INITIAL.startNext()));
+
+    callback.onTimeout(connection, 123L, 0);
+
+    assertThat(connection.calls).containsExactly("newTimeoutException", "release");
+    assertThat(connection.message).isEqualTo("Timed out waiting for response to PREPARE message");
+    assertThat(connection.configuredTimeoutMs).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(connection.elapsedTimeoutNanos).isEqualTo(123L);
+    assertThat(connection.retryCount).isEqualTo(0);
+    assertThat(connection.speculativeExecutionIndex).isEqualTo(2);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocateInstance(Class<T> clazz) throws Exception {
+    return (T) new ObjenesisStd().newInstance(clazz);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Class<?> current = target.getClass();
+    while (current != null) {
+      try {
+        Field field = current.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+
+  private static class RecordingConnection extends Connection {
+
+    private List<String> calls;
+    private OperationTimedOutException timeoutException;
+    private String message;
+    private long configuredTimeoutMs;
+    private long elapsedTimeoutNanos;
+    private int retryCount;
+    private int speculativeExecutionIndex;
+
+    private RecordingConnection() {
+      super(null, null, null);
+    }
+
+    @Override
+    OperationTimedOutException newTimeoutException(
+        String message,
+        long configuredTimeoutMs,
+        long elapsedTimeoutNanos,
+        int retryCount,
+        int speculativeExecutionIndex) {
+      calls.add("newTimeoutException");
+      this.message = message;
+      this.configuredTimeoutMs = configuredTimeoutMs;
+      this.elapsedTimeoutNanos = elapsedTimeoutNanos;
+      this.retryCount = retryCount;
+      this.speculativeExecutionIndex = speculativeExecutionIndex;
+      return timeoutException;
+    }
+
+    @Override
+    void release() {
+      calls.add("release");
+    }
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/OperationTimedOutExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/OperationTimedOutExceptionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core.exceptions;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+import com.datastax.driver.core.EndPoint;
+import com.datastax.driver.core.EndPoints;
+import org.testng.annotations.Test;
+
+public class OperationTimedOutExceptionTest {
+
+  private final EndPoint endPoint = EndPoints.forAddress("127.0.0.1", 9042);
+
+  @Test(groups = "unit")
+  public void should_preserve_legacy_five_argument_timeout_constructor() {
+    OperationTimedOutException exception = new OperationTimedOutException(endPoint, 10, 5, 7, 11);
+
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "[/127.0.0.1:9042] Timed out waiting for server response"
+                + " [configured timeout: 10ms, connection in-flight: 5,"
+                + " pool pending borrows: 7, pool total in-flight: 11]");
+    assertThat(exception.getConfiguredTimeoutMs()).isEqualTo(10);
+    assertThat(exception.getElapsedTimeoutMs()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getRetryCount()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getSpeculativeExecutionIndex())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getConnectionInFlight()).isEqualTo(5);
+    assertThat(exception.getConnectionShardId()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getHostShardsCount()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolPendingBorrows()).isEqualTo(7);
+    assertThat(exception.getPoolPendingBorrowsForShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolTotalInFlight()).isEqualTo(11);
+    assertThat(exception.getPoolOpenConnectionsForShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolMaxConnectionsPerShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+  }
+
+  @Test(groups = "unit")
+  public void should_store_and_copy_extended_timeout_diagnostics() {
+    OperationTimedOutException exception =
+        new OperationTimedOutException(endPoint, 10, 17, 2, 3, 5, 1, 12, 7, 4, 11, 2, 6);
+
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "[/127.0.0.1:9042] Timed out waiting for server response"
+                + " [configured timeout: 10ms, elapsed timeout: 17ms, retry count: 2,"
+                + " speculative execution index: 3, connection in-flight: 5,"
+                + " connection shard: 1/12, pool pending borrows: 7,"
+                + " pool pending borrows for shard: 4, pool total in-flight: 11,"
+                + " pool open connections for shard: 2, pool max connections per shard: 6]");
+    assertThat(exception.getConfiguredTimeoutMs()).isEqualTo(10);
+    assertThat(exception.getElapsedTimeoutMs()).isEqualTo(17);
+    assertThat(exception.getRetryCount()).isEqualTo(2);
+    assertThat(exception.getSpeculativeExecutionIndex()).isEqualTo(3);
+    assertThat(exception.getConnectionInFlight()).isEqualTo(5);
+    assertThat(exception.getConnectionShardId()).isEqualTo(1);
+    assertThat(exception.getHostShardsCount()).isEqualTo(12);
+    assertThat(exception.getPoolPendingBorrows()).isEqualTo(7);
+    assertThat(exception.getPoolPendingBorrowsForShard()).isEqualTo(4);
+    assertThat(exception.getPoolTotalInFlight()).isEqualTo(11);
+    assertThat(exception.getPoolOpenConnectionsForShard()).isEqualTo(2);
+    assertThat(exception.getPoolMaxConnectionsPerShard()).isEqualTo(6);
+
+    OperationTimedOutException copy = exception.copy();
+    assertThat(copy.getMessage()).isEqualTo(exception.getMessage());
+    assertThat(copy.getConfiguredTimeoutMs()).isEqualTo(exception.getConfiguredTimeoutMs());
+    assertThat(copy.getElapsedTimeoutMs()).isEqualTo(exception.getElapsedTimeoutMs());
+    assertThat(copy.getRetryCount()).isEqualTo(exception.getRetryCount());
+    assertThat(copy.getSpeculativeExecutionIndex())
+        .isEqualTo(exception.getSpeculativeExecutionIndex());
+    assertThat(copy.getConnectionInFlight()).isEqualTo(exception.getConnectionInFlight());
+    assertThat(copy.getConnectionShardId()).isEqualTo(exception.getConnectionShardId());
+    assertThat(copy.getHostShardsCount()).isEqualTo(exception.getHostShardsCount());
+    assertThat(copy.getPoolPendingBorrows()).isEqualTo(exception.getPoolPendingBorrows());
+    assertThat(copy.getPoolPendingBorrowsForShard())
+        .isEqualTo(exception.getPoolPendingBorrowsForShard());
+    assertThat(copy.getPoolTotalInFlight()).isEqualTo(exception.getPoolTotalInFlight());
+    assertThat(copy.getPoolOpenConnectionsForShard())
+        .isEqualTo(exception.getPoolOpenConnectionsForShard());
+    assertThat(copy.getPoolMaxConnectionsPerShard())
+        .isEqualTo(exception.getPoolMaxConnectionsPerShard());
+    assertThat(copy.getCause()).isSameAs(exception);
+  }
+
+  @Test(groups = "unit")
+  public void should_leave_extended_timeout_diagnostics_unavailable_for_legacy_constructors() {
+    OperationTimedOutException exception = new OperationTimedOutException(endPoint);
+
+    assertThat(exception.getConfiguredTimeoutMs())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getElapsedTimeoutMs()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getRetryCount()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getSpeculativeExecutionIndex())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getConnectionInFlight()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getConnectionShardId()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getHostShardsCount()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolPendingBorrows()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolPendingBorrowsForShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolTotalInFlight()).isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolOpenConnectionsForShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+    assertThat(exception.getPoolMaxConnectionsPerShard())
+        .isEqualTo(OperationTimedOutException.UNAVAILABLE);
+  }
+
+  @Test(groups = "unit")
+  public void should_use_default_message_when_custom_message_is_null() {
+    OperationTimedOutException exception =
+        new OperationTimedOutException(endPoint, null, 10, 17, 2, 3, 5, 1, 12, 7, 4, 11, 2, 6);
+
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "[/127.0.0.1:9042] Timed out waiting for server response"
+                + " [configured timeout: 10ms, elapsed timeout: 17ms, retry count: 2,"
+                + " speculative execution index: 3, connection in-flight: 5,"
+                + " connection shard: 1/12, pool pending borrows: 7,"
+                + " pool pending borrows for shard: 4, pool total in-flight: 11,"
+                + " pool open connections for shard: 2, pool max connections per shard: 6]");
+  }
+}


### PR DESCRIPTION
## Summary
- enrich `OperationTimedOutException` with elapsed timeout, retry/speculative execution, and shard/pool diagnostics
- populate those diagnostics from connection and request timeout paths, including PREPARE timeouts
- add unit and read-timeout coverage for the new fields and message formatting

## Testing
- `mvn -pl driver-core -Dtest=OperationTimedOutExceptionTest test`
- `mvn -pl driver-core -Pshort -Dtest=ReadTimeoutTest test`