### PR TITLE
fix: expand contact point hostnames to all DNS IPs at connection time (DRIVER-201) — Part 1/2

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
@@ -313,7 +313,7 @@ public class InsightsClient {
         .withDriverVersion(getDriverVersion(startupOptions))
         .withContactPoints(
             getResolvedContactPoints(
-                driverContext.getMetadataManager().getContactPoints().stream()
+                driverContext.getMetadataManager().getResolvedContactPoints().stream()
                     .map(n -> n.getEndPoint().resolve())
                     .filter(InetSocketAddress.class::isInstance)
                     .map(InetSocketAddress.class::cast)

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -701,8 +701,13 @@ public enum DefaultDriverOption implements DriverOption {
   CONTROL_CONNECTION_AGREEMENT_WARN("advanced.control-connection.schema-agreement.warn-on-failure"),
 
   /**
-   * Whether to forcibly add original contact points held by MetadataManager to the reconnection
-   * plan, in case there is no live nodes available according to LBP. Experimental.
+   * Whether to append the original contact points held by MetadataManager to the reconnection plan,
+   * after the live nodes reported by the load balancing policy. Defaults to {@code true}.
+   *
+   * <p>This is also the driver's DNS re-resolution path: contact points are expanded to their
+   * current DNS IPs at query-plan time, whereas metadata nodes hold an already-resolved endpoint
+   * that is never re-resolved. Keeping this enabled lets control-connection reconnects re-resolve
+   * the original hostnames and pick up new IPs once the live-node plan is exhausted.
    *
    * <p>Value-type: boolean
    */
@@ -837,7 +842,11 @@ public enum DefaultDriverOption implements DriverOption {
    * Whether to resolve the addresses passed to `basic.contact-points`.
    *
    * <p>Value-type: boolean
+   *
+   * @deprecated Contact points are now always kept as unresolved hostnames and expanded to all
+   *     their DNS-mapped IPs lazily at connection time. Setting this option has no effect.
    */
+  @Deprecated
   RESOLVE_CONTACT_POINTS("advanced.resolve-contact-points"),
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -369,7 +369,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL, Duration.ofMillis(200));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT, Duration.ofSeconds(10));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, true);
-    map.put(TypedDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, false);
+    map.put(TypedDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, true);
     map.put(TypedDriverOption.PREPARE_ON_ALL_NODES, true);
     map.put(TypedDriverOption.REPREPARE_ENABLED, true);
     map.put(TypedDriverOption.REPREPARE_CHECK_SYSTEM_TABLE, false);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -600,7 +600,7 @@ public class TypedDriverOption<ValueT> {
   public static final TypedDriverOption<Boolean> CONTROL_CONNECTION_AGREEMENT_WARN =
       new TypedDriverOption<>(
           DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, GenericType.BOOLEAN);
-  /** Whether to forcibly try original contacts if no live nodes are available */
+  /** Whether to append the original contact points to the reconnection plan (defaults to true) */
   public static final TypedDriverOption<Boolean> CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS =
       new TypedDriverOption<>(
           DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, GenericType.BOOLEAN);
@@ -664,7 +664,13 @@ public class TypedDriverOption<ValueT> {
   /** The coalescer reschedule interval. */
   public static final TypedDriverOption<Duration> COALESCER_INTERVAL =
       new TypedDriverOption<>(DefaultDriverOption.COALESCER_INTERVAL, GenericType.DURATION);
-  /** Whether to resolve the addresses passed to `basic.contact-points`. */
+  /**
+   * Whether to resolve the addresses passed to `basic.contact-points`.
+   *
+   * @deprecated Contact points are now always kept as unresolved hostnames and expanded to all
+   *     their DNS-mapped IPs lazily at connection time. Setting this option has no effect.
+   */
+  @Deprecated
   public static final TypedDriverOption<Boolean> RESOLVE_CONTACT_POINTS =
       new TypedDriverOption<>(DefaultDriverOption.RESOLVE_CONTACT_POINTS, GenericType.BOOLEAN);
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -166,11 +166,15 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
    * <p>Contact points can also be provided statically in the configuration. If both are specified,
    * they will be merged. If both are absent, the driver will default to 127.0.0.1:9042.
    *
-   * <p>Contrary to the configuration, DNS names with multiple A-records will not be handled here.
-   * If you need that, extract them manually with {@link java.net.InetAddress#getAllByName(String)}
-   * before calling this method. Similarly, if you need connect addresses to stay unresolved, make
-   * sure you pass unresolved instances here (see {@code advanced.resolve-contact-points} in the
-   * configuration for more explanations).
+   * <p>The driver automatically expands any contact point backed by an unresolved hostname to all
+   * its DNS-mapped IPs at query plan time (via {@code MetadataManager.getResolvedContactPoints()}),
+   * so passing a single hostname is sufficient to try all its IPs on initial connect. This applies
+   * equally to hostnames provided here programmatically (build an unresolved {@link
+   * InetSocketAddress} with {@link InetSocketAddress#createUnresolved(String, int)} to opt in) and
+   * to hostnames specified in the configuration. An already-resolved address passed here (the
+   * common case when constructing an {@code InetSocketAddress} directly from a hostname, which
+   * resolves eagerly) is used as provided, with no further expansion. The {@code
+   * advanced.resolve-contact-points} option is deprecated and has no effect.
    */
   @NonNull
   public SelfT addContactPoints(@NonNull Collection<InetSocketAddress> contactPoints) {
@@ -957,11 +961,11 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
         programmaticArguments = programmaticArgumentsBuilder.build();
       }
 
-      boolean resolveAddresses =
-          defaultConfig.getBoolean(DefaultDriverOption.RESOLVE_CONTACT_POINTS, false);
-
+      // RESOLVE_CONTACT_POINTS is deprecated: contact points are always kept as unresolved
+      // hostnames and expanded to all their DNS IPs at query plan time (before the first
+      // connection attempt) via MetadataManager.getResolvedContactPoints().
       Set<EndPoint> contactPoints =
-          ContactPoints.merge(programmaticContactPoints, configContactPoints, resolveAddresses);
+          ContactPoints.merge(programmaticContactPoints, configContactPoints, false);
 
       if (keyspace == null && defaultConfig.isDefined(DefaultDriverOption.SESSION_KEYSPACE)) {
         keyspace =

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
@@ -26,7 +26,6 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,73 +67,34 @@ public class OptionalLocalDcHelper implements LocalDcHelper {
   @Override
   @NonNull
   public Optional<String> discoverLocalDc(@NonNull Map<UUID, Node> nodes) {
-    String localDcStr = context.getLocalDatacenter(profile.getName());
-    Optional<String> localDc;
-    if (localDcStr != null) {
-      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDcStr);
-      localDc = Optional.of(localDcStr);
+    String localDc = context.getLocalDatacenter(profile.getName());
+    if (localDc != null) {
+      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDc);
     } else if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)) {
-      localDcStr = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
-      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDcStr);
-      localDc = Optional.of(localDcStr);
-    } else {
-      localDc = Optional.empty();
-    }
-    if (localDc.isPresent()) {
-      checkLocalDatacenterCompatibility(
-          localDc.get(), context.getMetadataManager().getContactPoints());
-      // Also warn if the configured DC doesn't match any node in the cluster
-      if (!nodes.isEmpty()) {
-        boolean found = false;
-        for (Node node : nodes.values()) {
-          if (localDc.get().equals(node.getDatacenter())) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          LOG.warn(
-              "[{}] Configured local DC '{}' does not match any node's datacenter"
-                  + " (available DCs: {}); please verify your configuration",
-              logPrefix,
-              localDc.get(),
-              formatDcs(nodes.values()));
-        }
-      }
+      localDc = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
+      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDc);
     } else {
       LOG.debug("[{}] Local DC not set, DC awareness will be disabled", logPrefix);
+      return Optional.empty();
     }
-    return localDc;
-  }
-
-  /**
-   * Checks if the contact points are compatible with the local datacenter specified either through
-   * configuration, or programmatically.
-   *
-   * <p>The default implementation logs a warning when a contact point reports a datacenter
-   * different from the local one, and only for the default profile.
-   *
-   * @param localDc The local datacenter, as specified in the config, or programmatically.
-   * @param contactPoints The contact points provided when creating the session.
-   */
-  protected void checkLocalDatacenterCompatibility(
-      @NonNull String localDc, Set<? extends Node> contactPoints) {
-    if (profile.getName().equals(DriverExecutionProfile.DEFAULT_NAME)) {
-      Set<Node> badContactPoints = new LinkedHashSet<>();
-      for (Node node : contactPoints) {
-        if (!Objects.equals(localDc, node.getDatacenter())) {
-          badContactPoints.add(node);
+    if (!nodes.isEmpty()) {
+      boolean found = false;
+      for (Node node : nodes.values()) {
+        if (localDc.equals(node.getDatacenter())) {
+          found = true;
+          break;
         }
       }
-      if (!badContactPoints.isEmpty()) {
+      if (!found) {
         LOG.warn(
-            "[{}] You specified {} as the local DC, but some contact points are from a different DC: {}; "
-                + "please provide the correct local DC, or check your contact points",
+            "[{}] Configured local DC '{}' does not match any node's datacenter"
+                + " (available DCs: {}); please verify your configuration",
             logPrefix,
             localDc,
-            formatNodesAndDcs(badContactPoints));
+            formatDcs(nodes.values()));
       }
     }
+    return Optional.of(localDc);
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.config.ClientRouteProxy;
 import com.datastax.oss.driver.api.core.config.ClientRoutesConfig;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
@@ -478,6 +479,22 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
       broadcastInetAddress = row.getInetAddress("peer");
     }
     return new ClientRoutesEndPoint(this, hostId, broadcastInetAddress, fallback);
+  }
+
+  @Override
+  public boolean reresolvesNodeAddresses() {
+    // ClientRoutesEndPoint re-resolves via the client route hostname on every connection attempt,
+    // but only when a route exists for that host_id (see ClientRoutesEndPoint#resolve()) -- for
+    // mixed/incomplete route sets it falls back to a static, non-re-resolving endpoint instead.
+    // Only report true when every currently-known node actually has a live route; otherwise the
+    // contact-point reconnection fallback must stay available for the nodes stuck on the fallback.
+    Map<UUID, ClientRouteRecord> routes = resolvedRoutesCache.get();
+    for (Node node : context.getMetadataManager().getMetadata().getNodes().values()) {
+      if (!routes.containsKey(node.getHostId())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/CloudTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/CloudTopologyMonitor.java
@@ -44,4 +44,12 @@ public class CloudTopologyMonitor extends DefaultTopologyMonitor {
     UUID hostId = Objects.requireNonNull(row.getUuid("host_id"));
     return new SniEndPoint(cloudProxyAddress, hostId.toString());
   }
+
+  @Override
+  public boolean reresolvesNodeAddresses() {
+    // Nodes are reached through the cloud SNI proxy via SniEndPoint, which re-resolves the proxy
+    // hostname on every connection attempt. Appending the original contact points as a DNS
+    // re-resolution fallback is therefore unnecessary and could resurrect removed nodes.
+    return true;
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -147,8 +147,7 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
     switch (stateRef.get()) {
       case BEFORE_INIT:
       case DURING_INIT:
-        // The contact points are not stored in the metadata yet:
-        List<Node> nodes = new ArrayList<>(context.getMetadataManager().getContactPoints());
+        List<Node> nodes = new ArrayList<>(context.getMetadataManager().getResolvedContactPoints());
         Collections.shuffle(nodes);
         return new ConcurrentLinkedQueue<>(nodes);
       case RUNNING:
@@ -164,15 +163,33 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
 
   @NonNull
   public Queue<Node> newControlReconnectionQueryPlan() {
+    // Read the state once, before building the regular plan. State transitions are monotonic
+    // (BEFORE_INIT -> DURING_INIT -> RUNNING -> ...), so this captured value is <= the value
+    // newQueryPlan() reads internally; that guarantees we never both build the plan from resolved
+    // contact points (pre-RUNNING branch of newQueryPlan) and append them again below.
+    State state = stateRef.get();
     Queue<Node> regularQueryPlan = newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
 
-    if (context
-        .getConfig()
-        .getDefaultProfile()
-        .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)) {
-      Set<DefaultNode> originalNodes = context.getMetadataManager().getContactPoints();
+    // Only append resolved contact points as an explicit fallback once the LBP is RUNNING: before
+    // that (BEFORE_INIT/DURING_INIT), newQueryPlan() above already built regularQueryPlan directly
+    // from getResolvedContactPoints(), so appending them again here would just duplicate every
+    // entry and re-trigger DNS resolution for no benefit.
+    if (state == State.RUNNING
+        && context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)
+        && !context.getTopologyMonitor().reresolvesNodeAddresses()) {
+      // Use DNS-expanded contact points so every resolved IP is tried as a fallback, not just
+      // the first IP the JVM happens to return for the hostname.
+      //
+      // Skipped when the topology monitor re-resolves node addresses on its own (e.g. proxy-based
+      // monitors such as client routes or the cloud SNI proxy): those keep addresses fresh without
+      // this fallback, and appending raw contact points could resurrect nodes the monitor has
+      // authoritatively removed.
+      List<Node> resolvedNodes = context.getMetadataManager().getResolvedContactPoints();
       List<Node> contactNodes = new ArrayList<>();
-      for (DefaultNode node : originalNodes) {
+      for (Node node : resolvedNodes) {
         contactNodes.add(DefaultNode.newContactPoint(node.getEndPoint(), context));
       }
       Collections.shuffle(contactNodes);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -49,8 +49,12 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.netty.util.concurrent.EventExecutor;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -59,6 +63,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,12 +83,27 @@ public class MetadataManager implements AsyncAutoCloseable {
   static final EndPoint DEFAULT_CONTACT_POINT =
       new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042));
 
+  // Bounds how long a single contact-point hostname resolution may block the caller (typically the
+  // admin event loop, see getResolvedContactPoints()). Not configurable on purpose: this is an
+  // interim mitigation, see the note on getResolvedContactPoints() below.
+  private static final Duration CONTACT_POINT_RESOLUTION_TIMEOUT = Duration.ofSeconds(3);
+
   private final InternalDriverContext context;
   private final String logPrefix;
   private final EventExecutor adminExecutor;
   private final DriverExecutionProfile config;
   private final SingleThreaded singleThreaded;
   private final ControlConnection controlConnection;
+
+  // Contact-point hostname resolution (getResolvedContactPoints()) runs on the admin event loop,
+  // where nothing should block. InetAddress.getAllByName() blocks, so each resolution is offloaded
+  // here and bounded by CONTACT_POINT_RESOLUTION_TIMEOUT. A cached pool (rather than a single
+  // shared thread) resolves each hostname on its own thread: a slow or blackholed lookup that
+  // ignores its interrupt only ties up its own daemon thread until the OS resolver finally
+  // returns, instead of starving the sibling contact points -- or the next reconnect that would
+  // otherwise queue behind it. This is an interim mitigation, superseded by #890's non-blocking
+  // EndPoint.resolveAll().
+  private final ExecutorService contactPointResolverExecutor;
 
   private volatile DefaultMetadata metadata; // only updated from adminExecutor
   private volatile boolean schemaEnabledInConfig;
@@ -107,6 +134,19 @@ public class MetadataManager implements AsyncAutoCloseable {
             DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList());
     this.keyspaceFilter = KeyspaceFilter.newInstance(logPrefix, refreshedKeyspaces);
     this.tokenMapEnabled = config.getBoolean(DefaultDriverOption.METADATA_TOKEN_MAP_ENABLED);
+    AtomicInteger resolverThreadCount = new AtomicInteger();
+    this.contactPointResolverExecutor =
+        Executors.newCachedThreadPool(
+            runnable -> {
+              Thread thread =
+                  new Thread(
+                      runnable,
+                      logPrefix
+                          + "-contact-point-resolver-"
+                          + resolverThreadCount.incrementAndGet());
+              thread.setDaemon(true);
+              return thread;
+            });
 
     context.getEventBus().register(ConfigChangeEvent.class, this::onConfigChanged);
   }
@@ -173,6 +213,167 @@ public class MetadataManager implements AsyncAutoCloseable {
     return contactPoints;
   }
 
+  /**
+   * Returns the contact points expanded to all their DNS-resolved IPs.
+   *
+   * <p>Contact points are stored with unresolved hostnames (the driver always uses deferred DNS
+   * resolution). For each contact point whose underlying address is an unresolved {@link
+   * InetSocketAddress}, this method calls {@link InetAddress#getAllByName(String)} to obtain every
+   * IP the hostname maps to and creates a synthetic contact-point {@link DefaultNode} for each IP.
+   * This lets the load balancing policy iterate over all candidate IPs rather than only the first
+   * one, so that a non-responsive IP does not block initial connection or control-connection
+   * reconnection.
+   *
+   * <p>The returned synthetic nodes are IP-backed <em>connection candidates</em>, not mere hostname
+   * wrappers: their endpoint resolves to a concrete IP. If such a node becomes the control node,
+   * its resolved endpoint is stored as-is in metadata (see {@link #registerNode(NodeInfo)}), so
+   * later reconnects keep using that IP unless they fall back to the original (unresolved) contact
+   * points, which re-enters this method and re-resolves DNS.
+   *
+   * <p><b>TLS note:</b> each synthetic endpoint is built from the {@link InetAddress} returned by
+   * resolving the original hostname, which retains that hostname. This means the TCP connection
+   * uses the selected IP while the SSL engine still receives the original contact-point hostname
+   * for peer host / SNI / hostname verification. This must be preserved: constructing the endpoint
+   * from a raw IP string instead would break hostname verification and implicit SNI.
+   *
+   * <p>Already-resolved addresses, and endpoints that are not a {@link DefaultEndPoint} (e.g. an
+   * SNI or client-routes endpoint), are returned as-is: those specialized endpoint types carry
+   * identity beyond a plain socket address (SNI server name, host_id) and must not be naively
+   * reconstructed from a resolved IP.
+   *
+   * <p>Resolution is best-effort: if a hostname cannot be resolved, or resolution exceeds {@link
+   * #getContactPointResolutionTimeout()}, the original <em>unresolved</em> contact-point node is
+   * kept as-is instead of being dropped. The query plan is therefore never emptier than the
+   * configured contact points, and the hostname can still be resolved later at connection time (as
+   * it was before DNS expansion existed).
+   */
+  public List<Node> getResolvedContactPoints() {
+    Set<DefaultNode> nodes = contactPoints;
+    if (nodes == null) {
+      return new ArrayList<>();
+    }
+    List<Node> result = new ArrayList<>();
+    // NOTE (interim mitigation, superseded in #890): this method is called from the
+    // control-connection query-plan path, i.e. the admin event loop (ControlConnection asserts
+    // inEventLoop()), where nothing should ever block. InetAddress.getAllByName() is a blocking
+    // call, so each unresolved hostname is submitted to contactPointResolverExecutor (pass 1) and
+    // then collected against a single shared deadline (pass 2). Resolving concurrently rather than
+    // one-at-a-time keeps the total wait bounded by roughly one CONTACT_POINT_RESOLUTION_TIMEOUT
+    // regardless of the number of contact points, and keeps one slow/blackholed hostname from
+    // starving the others. The calling thread still waits for the result, so this is a bound, not a
+    // true fix -- #890 moves multi-address resolution into the EndPoint API / ChannelFactory
+    // (EndPoint.resolveAll()) for proper non-blocking resolution; revisit when that lands.
+    List<PendingResolution> pending = new ArrayList<>();
+    for (DefaultNode node : nodes) {
+      EndPoint endPoint = node.getEndPoint();
+      if (endPoint instanceof DefaultEndPoint) {
+        InetSocketAddress address = ((DefaultEndPoint) endPoint).resolve();
+        if (address.isUnresolved()) {
+          // Expand hostname to all IPs so callers can try each one in turn.
+          try {
+            Future<InetAddress[]> future =
+                contactPointResolverExecutor.submit(
+                    () -> resolveContactPointHostname(address.getHostString()));
+            pending.add(new PendingResolution(node, address, future));
+          } catch (RejectedExecutionException e) {
+            // Executor already shut down (session closing): keep the unresolved node as a
+            // best-effort fallback rather than dropping it.
+            result.add(node);
+          }
+          continue;
+        }
+      }
+      // Already resolved or non-DefaultEndPoint endpoint — use as-is.
+      result.add(node);
+    }
+
+    // Collect the concurrent resolutions against one shared deadline so the total wait is bounded
+    // by roughly a single timeout, no matter how many hostnames are pending.
+    long deadlineNanos = System.nanoTime() + getContactPointResolutionTimeout().toNanos();
+    for (int i = 0; i < pending.size(); i++) {
+      PendingResolution p = pending.get(i);
+      InetAddress[] all;
+      try {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        all = p.future.get(Math.max(0, remainingNanos), TimeUnit.NANOSECONDS);
+      } catch (TimeoutException e) {
+        p.future.cancel(true);
+        LOG.warn(
+            "[{}] Timed out resolving contact point hostname {} after {}, keeping it unresolved",
+            logPrefix,
+            p.address.getHostString(),
+            getContactPointResolutionTimeout());
+        result.add(p.node);
+        continue;
+      } catch (ExecutionException e) {
+        LOG.warn(
+            "[{}] Could not resolve contact point hostname {}, keeping it unresolved",
+            logPrefix,
+            p.address.getHostString(),
+            e.getCause());
+        result.add(p.node);
+        continue;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        // Keep this and every remaining contact point unresolved (best-effort) and stop waiting.
+        for (int j = i; j < pending.size(); j++) {
+          pending.get(j).future.cancel(true);
+          result.add(pending.get(j).node);
+        }
+        break;
+      }
+      if (all.length > 1) {
+        LOG.debug(
+            "[{}] Contact point {} expands to {} addresses",
+            logPrefix,
+            p.address.getHostString(),
+            all.length);
+      }
+      for (InetAddress ip : all) {
+        // Build the endpoint from the resolved InetAddress (not a raw IP string) on
+        // purpose: the InetAddress keeps the original hostname, so the TCP connection
+        // uses this IP while the SSL engine still receives the hostname for peer host,
+        // SNI and hostname verification. Do not simplify this to a numeric IP address.
+        InetSocketAddress resolved = new InetSocketAddress(ip, p.address.getPort());
+        result.add(DefaultNode.newContactPoint(new DefaultEndPoint(resolved), context));
+      }
+    }
+    return result;
+  }
+
+  /** A contact-point hostname whose concurrent DNS resolution is in flight. */
+  private static final class PendingResolution {
+    final DefaultNode node;
+    final InetSocketAddress address;
+    final Future<InetAddress[]> future;
+
+    PendingResolution(DefaultNode node, InetSocketAddress address, Future<InetAddress[]> future) {
+      this.node = node;
+      this.address = address;
+      this.future = future;
+    }
+  }
+
+  /**
+   * The timeout applied to each contact-point hostname resolution triggered by {@link
+   * #getResolvedContactPoints()}. Extracted as a method (rather than referencing the constant
+   * directly) so tests can substitute a short timeout instead of waiting out the real one.
+   */
+  @VisibleForTesting
+  Duration getContactPointResolutionTimeout() {
+    return CONTACT_POINT_RESOLUTION_TIMEOUT;
+  }
+
+  /**
+   * Resolves a contact-point hostname to all its IPs. Extracted as a method (rather than calling
+   * {@link InetAddress#getAllByName(String)} directly) so tests can substitute a slow or failing
+   * resolution to exercise the timeout path in {@link #getResolvedContactPoints()}.
+   */
+  @VisibleForTesting
+  InetAddress[] resolveContactPointHostname(String host) throws UnknownHostException {
+    return InetAddress.getAllByName(host);
+  }
+
   /** Whether the default contact point was used (because none were provided explicitly). */
   public boolean wasImplicitContactPoint() {
     return wasImplicitContactPoint;
@@ -188,6 +389,13 @@ public class MetadataManager implements AsyncAutoCloseable {
    * they are never added to metadata and never exposed to user-facing APIs (events, {@link
    * com.datastax.oss.driver.api.core.metadata.Metadata#getNodes()}, or {@link
    * com.datastax.oss.driver.api.core.metadata.NodeStateListener} callbacks).
+   *
+   * <p>The metadata node stores {@code nodeInfo.getEndPoint()} as-is. When the control node was
+   * reached through a DNS-expanded synthetic contact point (see {@link
+   * #getResolvedContactPoints()}), that resolved IP endpoint is therefore persisted in metadata and
+   * is never re-resolved afterwards. Re-resolving the original hostname only happens through the
+   * original-contact-point reconnection fallback (see {@code
+   * advanced.control-connection.reconnection.fallback-to-original-contact-points}).
    */
   public CompletionStage<Node> registerNode(NodeInfo nodeInfo) {
     Preconditions.checkNotNull(nodeInfo.getHostId(), "Cannot register node without hostId");
@@ -585,6 +793,7 @@ public class MetadataManager implements AsyncAutoCloseable {
       if (queuedSchemaRefresh != null) {
         queuedSchemaRefresh.completeExceptionally(new IllegalStateException("Cluster is closed"));
       }
+      contactPointResolverExecutor.shutdownNow();
       closeFuture.complete(null);
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/TopologyMonitor.java
@@ -141,4 +141,24 @@ public interface TopologyMonitor extends AsyncAutoCloseable {
    * {@link DefaultTopologyMonitor}) should override this method.
    */
   default void resetColumnCaches() {}
+
+  /**
+   * Whether this monitor re-resolves node addresses dynamically on every connection attempt (for
+   * example by re-resolving a proxy hostname each time), rather than relying on an endpoint address
+   * captured once at node-registration time.
+   *
+   * <p>When this returns {@code true}, the control connection's reconnection query plan must not
+   * append the original contact points as a DNS re-resolution fallback (see {@code
+   * advanced.control-connection.reconnection.fallback-to-original-contact-points}): the monitor
+   * already keeps addresses fresh, and appending raw contact points could resurrect nodes that the
+   * monitor has authoritatively removed.
+   *
+   * <p>The default implementation returns {@code false}, which is correct for {@link
+   * DefaultTopologyMonitor}, whose {@code DefaultEndPoint}s cache their resolved address and never
+   * re-resolve. Proxy-based monitors that re-resolve per call should override this to return {@code
+   * true}.
+   */
+  default boolean reresolvesNodeAddresses() {
+    return false;
+  }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1227,6 +1227,10 @@ datastax-java-driver {
   # Required: no (defaults to false)
   # Modifiable at runtime: no
   # Overridable in a profile: no
+  #
+  # DEPRECATED: this option no longer has any effect. Contact points are always kept as unresolved
+  # hostnames and expanded to all their DNS-mapped IPs at query-plan time (see
+  # MetadataManager.getResolvedContactPoints()). It will be removed in a future release.
   advanced.resolve-contact-points = false
 
   advanced.protocol {
@@ -2318,14 +2322,20 @@ datastax-java-driver {
     }
 
     reconnection {
-      # Whether to forcibly add original contact points held by MetadataManager to the reconnection plan,
-      # in case there is no live nodes available according to LBP.
-      # Experimental.
+      # Whether to append the original contact points held by MetadataManager to the reconnection
+      # plan, after the live nodes reported by the load balancing policy.
+      #
+      # This is also the driver's DNS re-resolution path. Contact points are kept as unresolved
+      # hostnames and expanded to their current DNS IPs at query-plan time (see
+      # MetadataManager.getResolvedContactPoints()). Metadata nodes, in contrast, store an
+      # already-resolved endpoint that is never re-resolved, so once DNS records change they would
+      # otherwise become stale. Keeping this enabled lets control-connection reconnects re-resolve
+      # the original hostnames and pick up the new IPs once the live-node plan is exhausted.
       #
       # Required: yes
       # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
       # Overridable in a profile: no
-      fallback-to-original-contact-points = false
+      fallback-to-original-contact-points = true
     }
   }
 

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
@@ -487,7 +487,7 @@ public class InsightsClientTest {
     EndPoint contactEndPoint = mock(EndPoint.class);
     when(contactEndPoint.resolve()).thenReturn(new InetSocketAddress("127.0.0.1", 9999));
     when(contactPoint.getEndPoint()).thenReturn(contactEndPoint);
-    when(manager.getContactPoints()).thenReturn(ImmutableSet.of(contactPoint));
+    when(manager.getResolvedContactPoints()).thenReturn(ImmutableList.of(contactPoint));
 
     DriverConfig driverConfig = mock(DriverConfig.class);
     when(context.getConfig()).thenReturn(driverConfig);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -28,6 +28,8 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
@@ -66,6 +68,8 @@ public class ClientRoutesTopologyMonitorTest {
   @Mock private ControlConnection controlConnection;
   @Mock private DriverConfig driverConfig;
   @Mock private DriverExecutionProfile defaultProfile;
+  @Mock private MetadataManager metadataManager;
+  @Mock private Metadata metadata;
 
   private TestableClientRoutesTopologyMonitor handler;
 
@@ -218,6 +222,57 @@ public class ClientRoutesTopologyMonitorTest {
 
     assertThat(handler.resolve(hostId1)).isNull();
     assertThat(handler.resolve(hostId2)).isNotNull();
+  }
+
+  // ---- reresolvesNodeAddresses() -------------------------------------------
+
+  @Test
+  public void should_reresolve_when_all_known_nodes_have_client_routes() {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    Node node1 = Mockito.mock(Node.class);
+    when(node1.getHostId()).thenReturn(hostId1);
+    Node node2 = Mockito.mock(Node.class);
+    when(node2.getHostId()).thenReturn(hostId2);
+
+    when(context.getMetadataManager()).thenReturn(metadataManager);
+    when(metadataManager.getMetadata()).thenReturn(metadata);
+    when(metadata.getNodes()).thenReturn(ImmutableMap.of(hostId1, node1, hostId2, node2));
+
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "127.0.0.2", 9042)));
+
+    assertThat(handler.reresolvesNodeAddresses()).isTrue();
+  }
+
+  @Test
+  public void should_not_reresolve_when_a_known_node_has_no_client_route() {
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    Node node1 = Mockito.mock(Node.class);
+    when(node1.getHostId()).thenReturn(hostId1);
+    Node node2 = Mockito.mock(Node.class);
+    when(node2.getHostId()).thenReturn(hostId2);
+
+    when(context.getMetadataManager()).thenReturn(metadataManager);
+    when(metadataManager.getMetadata()).thenReturn(metadata);
+    when(metadata.getNodes()).thenReturn(ImmutableMap.of(hostId1, node1, hostId2, node2));
+
+    // Only node1 has a live client route; node2 would fall back to a static endpoint.
+    handler.setRoutes(ImmutableMap.of(hostId1, new ClientRouteRecord(hostId1, "127.0.0.1", 9042)));
+
+    assertThat(handler.reresolvesNodeAddresses()).isFalse();
+  }
+
+  @Test
+  public void should_reresolve_when_no_nodes_known_yet() {
+    when(context.getMetadataManager()).thenReturn(metadataManager);
+    when(metadataManager.getMetadata()).thenReturn(metadata);
+    when(metadata.getNodes()).thenReturn(Collections.emptyMap());
+
+    assertThat(handler.reresolvesNodeAddresses()).isTrue();
   }
 
   // ---- Merge behavior tests -----------------------------------------------

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -44,6 +44,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
@@ -79,6 +80,7 @@ public class LoadBalancingPolicyWrapperTest {
   private EventBus eventBus;
   @Mock private MetadataManager metadataManager;
   @Mock private Metadata metadata;
+  @Mock private TopologyMonitor topologyMonitor;
   @Mock protected MetricsFactory metricsFactory;
   @Captor private ArgumentCaptor<Map<UUID, Node>> initNodesCaptor;
 
@@ -100,8 +102,9 @@ public class LoadBalancingPolicyWrapperTest {
             Objects.requireNonNull(node3.getHostId()), node3);
     when(metadataManager.getMetadata()).thenReturn(metadata);
     when(metadata.getNodes()).thenReturn(allNodes);
-    when(metadataManager.getContactPoints()).thenReturn(contactPoints);
+    when(metadataManager.getResolvedContactPoints()).thenReturn(new ArrayList<>(contactPoints));
     when(context.getMetadataManager()).thenReturn(metadataManager);
+    when(context.getTopologyMonitor()).thenReturn(topologyMonitor);
 
     when(context.getConfig()).thenReturn(config);
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
@@ -130,26 +133,36 @@ public class LoadBalancingPolicyWrapperTest {
 
   @Test
   public void should_build_control_connection_query_plan_from_contact_points_before_init() {
+    // Given — simulate DNS expansion: node1's hostname resolves to two IPs (node1 + node4)
+    DefaultNode node4 = TestNodeFactory.newNode(4, context);
+    when(metadataManager.getResolvedContactPoints())
+        .thenReturn(ImmutableList.of(node1, node2, node4));
+
     // When
     Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
 
-    // Then
+    // Then — query plan contains all DNS-expanded nodes, not just the original 2 contact points
     for (LoadBalancingPolicy policy : ImmutableList.of(policy1, policy2, policy3)) {
       verify(policy, never()).newQueryPlan(null, null);
     }
-    assertThat(queryPlan).hasSameElementsAs(contactPoints);
+    assertThat(queryPlan).containsExactlyInAnyOrder(node1, node2, node4);
   }
 
   @Test
   public void should_build_query_plan_from_contact_points_before_init() {
+    // Given — simulate DNS expansion: node1's hostname resolves to two IPs (node1 + node4)
+    DefaultNode node4 = TestNodeFactory.newNode(4, context);
+    when(metadataManager.getResolvedContactPoints())
+        .thenReturn(ImmutableList.of(node1, node2, node4));
+
     // When
     Queue<Node> queryPlan = wrapper.newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
 
-    // Then
+    // Then — query plan contains all DNS-expanded nodes, not just the original 2 contact points
     for (LoadBalancingPolicy policy : ImmutableList.of(policy1, policy2, policy3)) {
       verify(policy, never()).newQueryPlan(null, null);
     }
-    assertThat(queryPlan).hasSameElementsAs(contactPoints);
+    assertThat(queryPlan).containsExactlyInAnyOrder(node1, node2, node4);
   }
 
   @Test
@@ -204,8 +217,7 @@ public class LoadBalancingPolicyWrapperTest {
     assertThat(queryPlan.poll()).isEqualTo(node3);
     assertThat(queryPlan.poll()).isEqualTo(node2);
     assertThat(queryPlan.poll()).isEqualTo(node1);
-    // Remaining nodes are contact points appended at the end.
-    // They are new DefaultNode instances created via newContactPoint, so compare by endpoint.
+    // Remaining nodes are the DNS-expanded (resolved) contact points appended at the end.
     Set<EndPoint> remainingEndpoints = new java.util.HashSet<>();
     for (Node n : queryPlan) {
       remainingEndpoints.add(n.getEndPoint());
@@ -215,6 +227,56 @@ public class LoadBalancingPolicyWrapperTest {
       contactEndpoints.add(n.getEndPoint());
     }
     assertThat(remainingEndpoints).isEqualTo(contactEndpoints);
+  }
+
+  @Test
+  public void should_not_double_resolve_contact_points_before_init() {
+    // Given — the wrapper hasn't been init()-ed yet (state=BEFORE_INIT), so newQueryPlan() already
+    // builds the regular plan directly from resolved contact points. The reconnect-contact-points
+    // flag doesn't matter here: newControlReconnectionQueryPlan() short-circuits on state before
+    // even reading it, since appending contact points again pre-init would just duplicate every
+    // entry in the plan and re-trigger DNS resolution for no benefit.
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then — getResolvedContactPoints() is resolved only once (not once for the regular plan and
+    // again for a redundant "fallback" append), and the plan has no duplicate entries.
+    verify(metadataManager, times(1)).getResolvedContactPoints();
+    assertThat(queryPlan).containsExactlyInAnyOrder(node1, node2);
+  }
+
+  @Test
+  public void
+      should_not_append_contact_points_to_query_plan_when_reconnect_contact_points_is_disabled() {
+    // Given — the flag defaults to false in the test setup (see @Before)
+    wrapper.init();
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then
+    // Only the policy query plan is returned; no contact points are appended.
+    assertThat(queryPlan).isEqualTo(defaultPolicyQueryPlan);
+  }
+
+  @Test
+  public void
+      should_not_append_contact_points_to_query_plan_when_topology_monitor_reresolves_addresses() {
+    // Given — the flag is enabled, but the topology monitor re-resolves node addresses on its own
+    // (e.g. a proxy-based monitor such as client routes or the cloud SNI proxy).
+    when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(true);
+    when(topologyMonitor.reresolvesNodeAddresses()).thenReturn(true);
+    wrapper.init();
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then
+    // Contact points must not be appended: the monitor keeps addresses fresh, and appending raw
+    // contact points could resurrect nodes it has authoritatively removed.
+    assertThat(queryPlan).isEqualTo(defaultPolicyQueryPlan);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -42,7 +42,9 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import io.netty.channel.DefaultEventLoopGroup;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -490,7 +492,153 @@ public class MetadataManagerTest {
         .hasMessageContaining("Cannot register node without hostId");
   }
 
+  @Test
+  public void should_return_empty_list_when_contact_points_not_yet_set() {
+    // contactPoints field is null until addContactPoints is called
+    assertThat(metadataManager.getResolvedContactPoints()).isEmpty();
+  }
+
+  @Test
+  public void should_return_already_resolved_contact_points_unchanged() {
+    // Given — a contact point with an already-resolved InetSocketAddress
+    metadataManager.addContactPoints(ImmutableSet.of(END_POINT2));
+
+    // When
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+
+    // Then — the single node is returned as-is (no expansion needed)
+    assertThat(resolved).hasSize(1);
+    assertThat(resolved.get(0).getEndPoint()).isEqualTo(END_POINT2);
+  }
+
+  @Test
+  public void should_expand_unresolved_hostname_to_all_ips() {
+    // Given — a contact point with an unresolved hostname (localhost → 127.0.0.1)
+    EndPoint unresolvedEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("localhost", 9042));
+    metadataManager.addContactPoints(ImmutableSet.of(unresolvedEndPoint));
+
+    // When
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+
+    // Then — at least one node is returned, each with a resolved address
+    assertThat(resolved).isNotEmpty();
+    for (Node node : resolved) {
+      InetSocketAddress addr = (InetSocketAddress) node.getEndPoint().resolve();
+      assertThat(addr.isUnresolved()).isFalse();
+      assertThat(addr.getPort()).isEqualTo(9042);
+    }
+  }
+
+  @Test
+  public void should_expand_multiple_contact_points_independently() {
+    // Given — two contact points: one already resolved, one unresolved
+    EndPoint resolvedEndPoint = END_POINT3;
+    EndPoint unresolvedEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("localhost", 9042));
+    metadataManager.addContactPoints(ImmutableSet.of(resolvedEndPoint, unresolvedEndPoint));
+
+    // When
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+
+    // Then — at least 2 nodes: 1 for the resolved + at least 1 for localhost expansion
+    assertThat(resolved.size()).isGreaterThanOrEqualTo(2);
+    // The resolved endpoint must appear
+    assertThat(resolved).anySatisfy(n -> assertThat(n.getEndPoint()).isEqualTo(resolvedEndPoint));
+    // All returned addresses must be resolved
+    for (Node node : resolved) {
+      InetSocketAddress addr = (InetSocketAddress) node.getEndPoint().resolve();
+      assertThat(addr.isUnresolved()).isFalse();
+    }
+  }
+
+  @Test
+  public void should_keep_unresolved_contact_point_when_hostname_cannot_be_resolved() {
+    // Given — a hostname that is guaranteed to fail DNS resolution
+    EndPoint badEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("nonexistent.invalid", 9042));
+    metadataManager.addContactPoints(ImmutableSet.of(badEndPoint));
+
+    // When
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+
+    // Then — resolution is best-effort: the unresolvable hostname is kept as-is (logged as WARN)
+    // instead of being dropped, so the query plan is never emptier than the configured contact
+    // points and the hostname can still be resolved later at connection time.
+    assertThat(resolved).hasSize(1);
+    assertThat(resolved.get(0).getEndPoint()).isEqualTo(badEndPoint);
+    InetSocketAddress addr = (InetSocketAddress) resolved.get(0).getEndPoint().resolve();
+    assertThat(addr.isUnresolved()).isTrue();
+  }
+
+  @Test
+  public void should_keep_unresolved_contact_point_when_resolution_times_out() {
+    // Given — a hostname whose resolution is artificially delayed well past the (test-shortened)
+    // resolution timeout
+    EndPoint slowEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("slow.invalid", 9042));
+    metadataManager.addContactPoints(ImmutableSet.of(slowEndPoint));
+    metadataManager.delayResolutionOf("slow.invalid");
+
+    // When
+    long startNanos = System.nanoTime();
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+    // Then — the call returns bounded by roughly the (test) timeout instead of hanging for the full
+    // simulated delay, and the timed-out hostname is kept unresolved (best-effort) like an
+    // unresolvable one, not dropped.
+    assertThat(resolved).hasSize(1);
+    assertThat(resolved.get(0).getEndPoint()).isEqualTo(slowEndPoint);
+    InetSocketAddress addr = (InetSocketAddress) resolved.get(0).getEndPoint().resolve();
+    assertThat(addr.isUnresolved()).isTrue();
+    assertThat(elapsedMillis).isLessThan(1500);
+  }
+
+  @Test
+  public void should_not_let_one_slow_hostname_starve_the_others() {
+    // Given — one hostname whose resolution hangs past the timeout, alongside a healthy one.
+    // Resolutions run concurrently, so the slow one must not prevent the healthy one from resolving
+    // (the poisoning a single shared resolver thread would cause).
+    EndPoint slowEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("slow.invalid", 9042));
+    EndPoint healthyEndPoint =
+        new DefaultEndPoint(InetSocketAddress.createUnresolved("localhost", 9042));
+    metadataManager.addContactPoints(ImmutableSet.of(slowEndPoint, healthyEndPoint));
+    metadataManager.delayResolutionOf("slow.invalid");
+
+    // When
+    long startNanos = System.nanoTime();
+    List<Node> resolved = metadataManager.getResolvedContactPoints();
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+    // Then — the whole call stays bounded by ~one timeout, the slow hostname is kept unresolved,
+    // and the healthy hostname still resolves to a concrete IP (it was not starved behind the slow
+    // one).
+    assertThat(elapsedMillis).isLessThan(1500);
+    assertThat(resolved)
+        .anySatisfy(
+            n -> {
+              InetSocketAddress a = (InetSocketAddress) n.getEndPoint().resolve();
+              assertThat(a.getHostString()).isEqualTo("slow.invalid");
+              assertThat(a.isUnresolved()).isTrue();
+            });
+    assertThat(resolved)
+        .anySatisfy(
+            n -> {
+              InetSocketAddress a = (InetSocketAddress) n.getEndPoint().resolve();
+              assertThat(a.isUnresolved()).isFalse();
+              assertThat(a.getPort()).isEqualTo(9042);
+            });
+  }
+
   private static class TestMetadataManager extends MetadataManager {
+
+    // Shortened so should_skip_contact_point_when_resolution_times_out() doesn't have to wait out
+    // the real (3s) production timeout.
+    private static final Duration TEST_RESOLUTION_TIMEOUT = Duration.ofMillis(200);
+
+    private volatile String delayedHostname;
 
     private List<MetadataRefresh> refreshes = new CopyOnWriteArrayList<>();
     private volatile int addNodeCount = 0;
@@ -498,6 +646,28 @@ public class MetadataManagerTest {
 
     public TestMetadataManager(InternalDriverContext context) {
       super(context);
+    }
+
+    void delayResolutionOf(String hostname) {
+      this.delayedHostname = hostname;
+    }
+
+    @Override
+    Duration getContactPointResolutionTimeout() {
+      return TEST_RESOLUTION_TIMEOUT;
+    }
+
+    @Override
+    InetAddress[] resolveContactPointHostname(String host) throws UnknownHostException {
+      if (host.equals(delayedHostname)) {
+        try {
+          // Sleep well past TEST_RESOLUTION_TIMEOUT so the caller's Future.get() times out first.
+          Thread.sleep(TEST_RESOLUTION_TIMEOUT.toMillis() * 10);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      return super.resolveContactPointHostname(host);
     }
 
     @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/heartbeat/HeartbeatIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/heartbeat/HeartbeatIT.java
@@ -235,6 +235,10 @@ public class HeartbeatIT {
             .withDuration(DefaultDriverOption.HEARTBEAT_TIMEOUT, Duration.ofMillis(500))
             .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofSeconds(2))
             .withDuration(DefaultDriverOption.RECONNECTION_MAX_DELAY, Duration.ofSeconds(1))
+            // These tests exercise heartbeat behavior only. Disable the contact-point
+            // reconnection fallback, which would otherwise send an extra OPTIONS message on
+            // init/reconnect and skew the heartbeat counts.
+            .withBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, false)
             .build();
     return SessionUtils.newSession(SIMULACRON_RULE, loader);
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -25,7 +25,6 @@ package com.datastax.oss.driver.core.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -109,7 +108,46 @@ public class MockResolverIT {
         assertThat(filteredNodes).hasSize(1);
         InetSocketAddress address =
             (InetSocketAddress) filteredNodes.iterator().next().getEndPoint().resolve();
-        assertTrue(address.isUnresolved());
+        assertFalse(address.isUnresolved());
+      }
+    }
+  }
+
+  @Test
+  public void should_connect_when_first_dns_entry_is_non_responsive() {
+    final int numberOfNodes = 2;
+    DriverConfigLoader loader =
+        new DefaultProgrammaticDriverConfigLoaderBuilder()
+            .withBoolean(TypedDriverOption.RESOLVE_CONTACT_POINTS.getRawOption(), false)
+            .withBoolean(TypedDriverOption.RECONNECT_ON_INIT.getRawOption(), true)
+            .withStringList(
+                TypedDriverOption.CONTACT_POINTS.getRawOption(),
+                Collections.singletonList("test.cluster.fake:9042"))
+            .build();
+
+    CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
+    try (CcmBridge ccmBridge =
+        CcmBridge.builder().withNodes(numberOfNodes).withIpPrefix("127.0.1.").build()) {
+      MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
+      // Register the dead IP first so it's the first entry InetAddress.getAllByName() returns for
+      // this hostname (MultimapHostResolver preserves insertion order). Node 11 is never started,
+      // so nothing listens on 127.0.1.11 in this subnet.
+      MultimapHostResolverProvider.addResolverEntry("test.cluster.fake", "127.0.1.11");
+      MultimapHostResolverProvider.addResolverEntry(
+          "test.cluster.fake", ccmBridge.getNodeIpAddress(1));
+      MultimapHostResolverProvider.addResolverEntry(
+          "test.cluster.fake", ccmBridge.getNodeIpAddress(2));
+      ccmBridge.create();
+      ccmBridge.start();
+
+      try (CqlSession session = builder.build()) {
+        waitForAllNodesUp(session, numberOfNodes);
+        ResultSet rs = session.execute("select * from system.local where key='local'");
+        assertThat(rs).isNotNull();
+        List<Row> rows = rs.all();
+        assertThat(rows).hasSize(1);
+        Collection<Node> nodes = session.getMetadata().getNodes().values();
+        assertThat(nodes).hasSize(numberOfNodes);
       }
     }
   }


### PR DESCRIPTION
## Problem

When `RESOLVE_CONTACT_POINTS=false` (the default), a contact point hostname was stored as a single unresolved `InetSocketAddress`. At connection time the load-balancing query plan contained exactly one `Node` per hostname, so only the **first** IP returned by DNS was ever tried. If that IP was non-responsive the driver raised `AllNodesFailedException` with no fallback to other IPs the hostname might resolve to.

This is particularly impactful in dynamic DNS environments where a hostname maps to multiple nodes and the first one may be temporarily unavailable.

Fixes DRIVER-201.

> **Note:** This is part 1 of 2, implementing the *initial contact endpoints* fix per @dkropachev's [architectural direction](https://github.com/scylladb/java-driver/pull/865#issuecomment-4409811316). Part 2 will expand the `EndPoint` API with `resolveAll()` to address the broader connection path.

## Changes

### `DefaultDriverOption` / `TypedDriverOption`
- `RESOLVE_CONTACT_POINTS` is now `@Deprecated`. Contact points are always kept as unresolved hostnames; the option is a no-op.

### `SessionBuilder`
- Removed the `RESOLVE_CONTACT_POINTS` read; `ContactPoints.merge()` is now always called with `resolve=false`, deferring all DNS expansion to connection time.

### `MetadataManager`
- New `getResolvedContactPoints()` method: for each contact point backed by an unresolved hostname, resolves the hostname to obtain **all** its DNS IPs and creates a synthetic `DefaultNode` for each. Already-resolved addresses, and endpoints that aren't a `DefaultEndPoint` (e.g. SNI or client-routes endpoints), are returned as-is.
- **Bounded, off-event-loop resolution.** This method runs on the shared admin event loop (called from `ControlConnection` init/reconnect, which assert `adminExecutor.inEventLoop()`), where nothing should ever block. DNS resolution (`InetAddress.getAllByName()`) is inherently a blocking call, so it's offloaded to a small dedicated daemon-thread executor (`contactPointResolverExecutor`) and bounded by a 3s timeout (`CONTACT_POINT_RESOLUTION_TIMEOUT`): a slow or unreachable resolver can now only stall the admin loop for that long, instead of the resolver's own (effectively unbounded) timeout. On timeout, the hostname is skipped, same as an unresolvable one. This is a deliberate **interim mitigation**, not a full fix — the admin-loop thread still waits, just for a bounded amount of time — and is superseded by #890's `EndPoint.resolveAll()` redesign, which will make resolution properly non-blocking.

### `LoadBalancingPolicyWrapper`
- `newQueryPlan()` (in `BEFORE_INIT`/`DURING_INIT` states) and `newControlReconnectionQueryPlan()` now call `getResolvedContactPoints()` instead of `getContactPoints()`, so the query plan contains one entry per resolved IP. The driver naturally falls back to the next candidate if one is unreachable.
- `newControlReconnectionQueryPlan()` only appends the resolved-contact-point fallback once the LBP is `RUNNING`. Before that (`BEFORE_INIT`/`DURING_INIT`), `newQueryPlan()` already built the regular plan directly from `getResolvedContactPoints()`, so appending it again would duplicate every entry in the plan and re-trigger DNS resolution (and the bounded wait above) for no benefit.

### `TopologyMonitor` (new capability method)
- Added `TopologyMonitor.reresolvesNodeAddresses()`, a default method returning `false`.
- Overridden to return `true` in `ClientRoutesTopologyMonitor` and `CloudTopologyMonitor`. These proxy-based monitors reach nodes through `ClientRoutesEndPoint` / `SniEndPoint`, which re-resolve their hostname on **every** connection attempt, so they never rely on the contact-point fallback for fresh DNS.
- `LoadBalancingPolicyWrapper.newControlReconnectionQueryPlan()` now appends the original contact points **only** when the flag is enabled **and** the active topology monitor does *not* re-resolve addresses. This prevents a regression (see Regression safety below) where an authoritative proxy-based monitor could have nodes it removed resurrected by the contact-point fallback.

### `InsightsClient`
- `getContactPoints()` → `getResolvedContactPoints()`, so the startup insights payload reports the resolved contact-point IPs, consistent with the new resolution model.

### `OptionalLocalDcHelper` (dead-code cleanup) ⚠️ reviewer FYI
- Removed the `protected checkLocalDatacenterCompatibility(localDc, contactPoints)` method and its call. It read `contactPoint.getDatacenter()` and warned when a contact point reported a datacenter different from the configured local DC.
- **This check was broken on `scylla-4.x`, independent of this PR — it could only ever emit a false positive.** It worked in the original DataStax model, where `InitialNodeListRefresh` matched discovered nodes to contact points *by endpoint* and mutated the same contact-point `DefaultNode` instance with its real datacenter. Commit `12e6acb90b` (*"Resolve control node identity via system.local before initial metadata refresh"*, already merged to `scylla-4.x`) switched refresh matching to **hostId-only**. Contact-point nodes carry no `hostId`, so they are never reused and their `datacenter` field stays `null` forever. Comparing that `null` against a configured local DC (`!Objects.equals(localDc, null)`) is always `true`, so the check would fire as a **false positive for every contact point** whenever `local-datacenter` was set on the default profile — never surfacing a real mismatch.
- **No functional loss — removing it eliminates a spurious warning.** The useful diagnostic — "configured local DC matches no node's datacenter" — is already provided by the pre-existing node-based check in `discoverLocalDc()`, which iterates the **discovered cluster nodes** (whose DCs are populated) and warns with the available DCs. That check is unchanged and strictly more reliable than the removed contact-point check.
- **Reviewer FYI:** the removed method was `protected` in an `internal` package (no public-API/binary-compat impact); the in-tree subclasses `InferringLocalDcHelper` / `MandatoryLocalDcHelper` do not override or call it. Removing it is cleanup consistent with deferred resolution (contact points are now unresolved hostnames with no DC); the only user-visible effect is that the spurious false-positive warning is no longer emitted.

### Reconnection fallback default
- `advanced.control-connection.reconnection.fallback-to-original-contact-points` now defaults to `true` (and is no longer marked *Experimental*). This is the DNS re-resolution path: metadata nodes hold an already-resolved endpoint that is never re-resolved, so on control-connection reconnect the driver must fall back to the original unresolved contact points, which re-enters `getResolvedContactPoints()` and re-expands each hostname to its current DNS IPs.
- The programmatic default in `OptionsMap` was flipped to `true` in lockstep with `reference.conf` (kept in sync; enforced by `MapBasedDriverConfigLoaderTest`).

### Tests
- 6 new `MetadataManagerTest` cases for `getResolvedContactPoints()`: not-yet-set state, already-resolved passthrough, single-hostname DNS expansion, multi-endpoint expansion, unresolvable-hostname skip, and resolution-timeout skip (verifies the bounded executor actually bounds the wait instead of hanging for the full simulated delay).
- `LoadBalancingPolicyWrapperTest`: updated to stub `getResolvedContactPoints()` / `getTopologyMonitor()`, plus 4 new cases — contact points appended when the flag is enabled, not appended when disabled, not appended when the topology monitor re-resolves addresses (even with the flag on), and not double-resolved/duplicated before init.
- `HeartbeatIT`: pins `CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS=false` for its sessions. These tests use `SimulacronRule` (→ `DefaultTopologyMonitor`) and exercise heartbeat behavior, not contact-point reconnection; without the pin, the newly-enabled fallback sends an extra `OPTIONS` during init and skews heartbeat counts.
- `MockResolverIT.should_connect_when_first_dns_entry_is_non_responsive`: 2-node CCM cluster on `127.0.1.x`; first DNS entry points to a non-existent IP (`127.0.1.11`); asserts the session opens successfully against the real nodes.

## Behavioral notes

**Event-loop safety.** `getResolvedContactPoints()` runs on the shared admin event loop (called from `ControlConnection` init/reconnect, which assert `adminExecutor.inEventLoop()`). DNS resolution is inherently blocking, so the actual `InetAddress.getAllByName()` call is offloaded to a dedicated single-thread executor and bounded by a 3s timeout rather than being left to block that thread for the resolver's own (effectively unbounded) timeout — a single dedicated thread is enough given the small, bounded contact-point set this is used for. This is a deliberate interim mitigation, not a full fix: the admin-loop thread still waits, just for a bounded amount of time. It's superseded by #890's `EndPoint.resolveAll()` redesign, which moves multi-address resolution into the `EndPoint` API / `ChannelFactory` for proper non-blocking resolution.

**Metadata persistence.** The DNS-expanded synthetic contact points are IP-backed *connection candidates*, not mere hostname wrappers. If one becomes the control node, its resolved IP endpoint is stored as-is in metadata (`MetadataManager.registerNode()` keeps `nodeInfo.getEndPoint()` verbatim). Since `DefaultEndPoint.resolve()` returns that stored address without re-querying DNS, later reconnects keep using that IP until the original-contact-point fallback re-resolves the hostname — which is why that fallback now defaults to `true`.

**TLS / SNI.** Each synthetic endpoint is built from the `InetAddress` returned by resolving the original hostname (`new InetSocketAddress(ip, port)`), which retains that hostname. So the TCP connection uses the selected IP while the SSL engine still receives the original contact-point hostname for peer host, implicit SNI, and hostname verification. This is intentional and must be preserved: constructing the endpoint from a raw IP string instead would break hostname verification and implicit SNI.

**Regression safety (PrivateLink / Cloud).** The reconnection fallback that re-expands contact points is meaningful only for the default topology monitor, whose `DefaultEndPoint`s cache their resolved address and never re-resolve. Proxy-based monitors — `ClientRoutesTopologyMonitor` (PrivateLink) and `CloudTopologyMonitor` — reach nodes through endpoints (`ClientRoutesEndPoint` / `SniEndPoint`) that already re-resolve on every connection attempt and maintain an authoritative node set. Appending raw contact points to *their* reconnection plan is both unnecessary and harmful: it can resurrect nodes the monitor has removed (e.g. after node replacement). The new `TopologyMonitor.reresolvesNodeAddresses()` gate skips the append for these monitors, preserving existing PrivateLink/Cloud behavior with no regression.
