### PR TITLE
3.x: Route SELECT at SERIAL/LOCAL_SERIAL consistency like LWT

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -92,6 +92,27 @@ public abstract class Statement {
   }
 
   /**
+   * Returns {@code true} if this statement's effective consistency level is serial ({@link
+   * ConsistencyLevel#SERIAL} or {@link ConsistencyLevel#LOCAL_SERIAL}). When no consistency level
+   * has been explicitly set on this statement, falls back to the provided default.
+   *
+   * <p>This is used by load-balancing policies to route serial-consistency statements through the
+   * LWT path, even when {@link #isLWT()} returns {@code false}.
+   *
+   * @param defaultConsistencyLevel the cluster-wide default consistency level to fall back to when
+   *     this statement has no explicit consistency level set.
+   * @return whether the effective consistency level is serial.
+   */
+  public static boolean hasSerialConsistency(
+      Statement statement, ConsistencyLevel defaultConsistencyLevel) {
+    ConsistencyLevel cl = statement.getConsistencyLevel();
+    if (cl == null) {
+      cl = defaultConsistencyLevel;
+    }
+    return cl != null && cl.isSerial();
+  }
+
+  /**
    * Sets the consistency level for the query.
    *
    * @param consistency the consistency level to set.

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -92,27 +92,6 @@ public abstract class Statement {
   }
 
   /**
-   * Returns {@code true} if this statement's effective consistency level is serial ({@link
-   * ConsistencyLevel#SERIAL} or {@link ConsistencyLevel#LOCAL_SERIAL}). When no consistency level
-   * has been explicitly set on this statement, falls back to the provided default.
-   *
-   * <p>This is used by load-balancing policies to route serial-consistency statements through the
-   * LWT path, even when {@link #isLWT()} returns {@code false}.
-   *
-   * @param defaultConsistencyLevel the cluster-wide default consistency level to fall back to when
-   *     this statement has no explicit consistency level set.
-   * @return whether the effective consistency level is serial.
-   */
-  public static boolean hasSerialConsistency(
-      Statement statement, ConsistencyLevel defaultConsistencyLevel) {
-    ConsistencyLevel cl = statement.getConsistencyLevel();
-    if (cl == null) {
-      cl = defaultConsistencyLevel;
-    }
-    return cl != null && cl.isSerial();
-  }
-
-  /**
    * Sets the consistency level for the query.
    *
    * @param consistency the consistency level to set.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -22,6 +22,7 @@ import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.LatencyTracker;
 import com.datastax.driver.core.Metrics;
 import com.datastax.driver.core.MetricsUtil;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.BootstrappingException;
 import com.datastax.driver.core.exceptions.DriverException;
@@ -102,6 +103,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
   private final long retryPeriod;
   private final long minMeasure;
   private volatile Metrics metrics;
+  private volatile QueryOptions queryOptions;
 
   private LatencyAwarePolicy(
       LoadBalancingPolicy childPolicy,
@@ -218,6 +220,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
     }
     cluster.register(latencyTracker);
     metrics = cluster.getMetrics();
+    queryOptions = cluster.getConfiguration().getQueryOptions();
     if (metrics != null) {
       metrics
           .getRegistry()
@@ -258,10 +261,13 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
    */
   @Override
   public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
-    // For LWT queries, preserve the child policy's ordering.
+    // For LWT queries or serial consistency queries, preserve the child policy's ordering.
     // LWT routing can rely on deterministic replica ordering (e.g. by TokenAwarePolicy), and
     // latency-based reordering can undermine those assumptions.
-    if (statement != null && statement.isLWT()) {
+    if (statement != null
+        && (statement.isLWT()
+            || Statement.hasSerialConsistency(
+                statement, queryOptions != null ? queryOptions.getConsistencyLevel() : null))) {
       return childPolicy.newQueryPlan(loggedKeyspace, statement);
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -17,12 +17,12 @@ package com.datastax.driver.core.policies;
 
 import com.codahale.metrics.Gauge;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.LatencyTracker;
 import com.datastax.driver.core.Metrics;
 import com.datastax.driver.core.MetricsUtil;
-import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.BootstrappingException;
 import com.datastax.driver.core.exceptions.DriverException;
@@ -103,7 +103,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
   private final long retryPeriod;
   private final long minMeasure;
   private volatile Metrics metrics;
-  private volatile QueryOptions queryOptions;
+  private volatile ConsistencyLevel defaultConsistencyLevel;
 
   private LatencyAwarePolicy(
       LoadBalancingPolicy childPolicy,
@@ -220,7 +220,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
     }
     cluster.register(latencyTracker);
     metrics = cluster.getMetrics();
-    queryOptions = cluster.getConfiguration().getQueryOptions();
+    defaultConsistencyLevel = cluster.getConfiguration().getQueryOptions().getConsistencyLevel();
     if (metrics != null) {
       metrics
           .getRegistry()
@@ -265,9 +265,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
     // LWT routing can rely on deterministic replica ordering (e.g. by TokenAwarePolicy), and
     // latency-based reordering can undermine those assumptions.
     if (statement != null
-        && (statement.isLWT()
-            || Statement.hasSerialConsistency(
-                statement, queryOptions != null ? queryOptions.getConsistencyLevel() : null))) {
+        && (statement.isLWT() || isEffectiveConsistencySerial(statement.getConsistencyLevel()))) {
       return childPolicy.newQueryPlan(loggedKeyspace, statement);
     }
 
@@ -338,6 +336,11 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
         return endOfData();
       };
     };
+  }
+
+  private boolean isEffectiveConsistencySerial(ConsistencyLevel statementCl) {
+    ConsistencyLevel cl = statementCl != null ? statementCl : defaultConsistencyLevel;
+    return cl != null && cl.isSerial();
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicy.java
@@ -246,8 +246,13 @@ public class RackAwareRoundRobinPolicy implements LoadBalancingPolicy {
   @Override
   public Iterator<Host> newQueryPlan(String loggedKeyspace, final Statement statement) {
 
-    // For LWT queries, skip rack prioritization and use all local DC hosts equally
-    final boolean isLWT = statement != null && statement.isLWT();
+    // For LWT queries or serial consistency queries, skip rack prioritization and use all local DC
+    // hosts equally
+    ConsistencyLevel defaultCl =
+        configuration != null ? configuration.getQueryOptions().getConsistencyLevel() : null;
+    final boolean isLWT =
+        statement != null
+            && (statement.isLWT() || Statement.hasSerialConsistency(statement, defaultCl));
 
     // For LWT queries, include all local DC hosts in the first part of the plan, not just those in
     // the local rack

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicy.java
@@ -250,9 +250,12 @@ public class RackAwareRoundRobinPolicy implements LoadBalancingPolicy {
     // hosts equally
     ConsistencyLevel defaultCl =
         configuration != null ? configuration.getQueryOptions().getConsistencyLevel() : null;
+    ConsistencyLevel effectiveCl =
+        statement != null && statement.getConsistencyLevel() != null
+            ? statement.getConsistencyLevel()
+            : defaultCl;
     final boolean isLWT =
-        statement != null
-            && (statement.isLWT() || Statement.hasSerialConsistency(statement, defaultCl));
+        statement != null && (statement.isLWT() || (effectiveCl != null && effectiveCl.isSerial()));
 
     // For LWT queries, include all local DC hosts in the first part of the plan, not just those in
     // the local rack

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -438,7 +438,11 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
         clusterMetadata.getReplicasList(
             Metadata.quote(keyspace), tableName, statement.getPartitioner(), partitionKey);
 
-    switch (getRequestRouting(statement)) {
+    QueryOptions.RequestRoutingMethod routing =
+        defaultLwtRequestRoutingMethod != null
+            ? getRequestRouting(statement)
+            : QueryOptions.RequestRoutingMethod.REGULAR;
+    switch (routing) {
       case PRESERVE_REPLICA_ORDER:
         return newQueryPlanPreserveReplicaOrder(keyspace, statement, replicas);
       case REGULAR:
@@ -470,14 +474,14 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
   }
 
   private QueryOptions.RequestRoutingMethod getRequestRouting(Statement statement) {
-    if (defaultLwtRequestRoutingMethod == null) {
-      return QueryOptions.RequestRoutingMethod.REGULAR;
+    if (statement.isLWT()) {
+      return defaultLwtRequestRoutingMethod;
     }
-    ConsistencyLevel cl = statement.getConsistencyLevel();
-    if (cl == null) {
-      cl = queryOptions.getConsistencyLevel();
-    }
-    if (statement.isLWT() || (cl != null && cl.isSerial())) {
+    ConsistencyLevel cl =
+        statement.getConsistencyLevel() != null
+            ? statement.getConsistencyLevel()
+            : queryOptions.getConsistencyLevel();
+    if (cl != null && cl.isSerial()) {
       return defaultLwtRequestRoutingMethod;
     }
     return QueryOptions.RequestRoutingMethod.REGULAR;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -267,7 +267,6 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
     private final List<Host> replicas;
     private final String keyspace;
     private final Statement statement;
-    private final boolean localOnly;
     private List<Host> nonLocalReplicas;
     private Iterator<Host> nonLocalReplicasIterator;
     private Set<Host> returnedHosts;
@@ -278,11 +277,6 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       this.statement = statement;
       this.replicas = replicas;
       this.replicasIterator = replicas.iterator();
-      ConsistencyLevel cl = statement.getConsistencyLevel();
-      if (cl == null && queryOptions != null) {
-        cl = queryOptions.getConsistencyLevel();
-      }
-      this.localOnly = cl == ConsistencyLevel.LOCAL_SERIAL;
     }
 
     @Override
@@ -314,7 +308,7 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       }
 
       // Second pass: return remote replicas that are UP and not IGNORED
-      if (nonLocalReplicas != null && !localOnly) {
+      if (nonLocalReplicas != null) {
         if (nonLocalReplicasIterator == null) {
           nonLocalReplicasIterator = nonLocalReplicas.iterator();
         }
@@ -479,8 +473,11 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
     if (defaultLwtRequestRoutingMethod == null) {
       return QueryOptions.RequestRoutingMethod.REGULAR;
     }
-    if (statement.isLWT()
-        || Statement.hasSerialConsistency(statement, queryOptions.getConsistencyLevel())) {
+    ConsistencyLevel cl = statement.getConsistencyLevel();
+    if (cl == null) {
+      cl = queryOptions.getConsistencyLevel();
+    }
+    if (statement.isLWT() || (cl != null && cl.isSerial())) {
       return defaultLwtRequestRoutingMethod;
     }
     return QueryOptions.RequestRoutingMethod.REGULAR;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -26,6 +26,7 @@ import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.Metadata;
@@ -266,6 +267,7 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
     private final List<Host> replicas;
     private final String keyspace;
     private final Statement statement;
+    private final boolean localOnly;
     private List<Host> nonLocalReplicas;
     private Iterator<Host> nonLocalReplicasIterator;
     private Set<Host> returnedHosts;
@@ -276,6 +278,11 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       this.statement = statement;
       this.replicas = replicas;
       this.replicasIterator = replicas.iterator();
+      ConsistencyLevel cl = statement.getConsistencyLevel();
+      if (cl == null && queryOptions != null) {
+        cl = queryOptions.getConsistencyLevel();
+      }
+      this.localOnly = cl == ConsistencyLevel.LOCAL_SERIAL;
     }
 
     @Override
@@ -307,7 +314,7 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
       }
 
       // Second pass: return remote replicas that are UP and not IGNORED
-      if (nonLocalReplicas != null) {
+      if (nonLocalReplicas != null && !localOnly) {
         if (nonLocalReplicasIterator == null) {
           nonLocalReplicasIterator = nonLocalReplicas.iterator();
         }
@@ -347,6 +354,7 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
   private volatile Metadata clusterMetadata;
   private volatile ProtocolVersion protocolVersion;
   private volatile CodecRegistry codecRegistry;
+  private volatile QueryOptions queryOptions;
   private volatile QueryOptions.RequestRoutingMethod defaultLwtRequestRoutingMethod;
 
   /**
@@ -395,8 +403,8 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
     clusterMetadata = cluster.getMetadata();
     protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
     codecRegistry = cluster.getConfiguration().getCodecRegistry();
-    defaultLwtRequestRoutingMethod =
-        cluster.getConfiguration().getQueryOptions().getLoadBalancingLwtRequestRoutingMethod();
+    queryOptions = cluster.getConfiguration().getQueryOptions();
+    defaultLwtRequestRoutingMethod = queryOptions.getLoadBalancingLwtRequestRoutingMethod();
     childPolicy.init(cluster, hosts);
   }
 
@@ -468,10 +476,14 @@ public class TokenAwarePolicy implements ChainableLoadBalancingPolicy {
   }
 
   private QueryOptions.RequestRoutingMethod getRequestRouting(Statement statement) {
-    if (!statement.isLWT() || defaultLwtRequestRoutingMethod == null) {
+    if (defaultLwtRequestRoutingMethod == null) {
       return QueryOptions.RequestRoutingMethod.REGULAR;
     }
-    return defaultLwtRequestRoutingMethod;
+    if (statement.isLWT()
+        || Statement.hasSerialConsistency(statement, queryOptions.getConsistencyLevel())) {
+      return defaultLwtRequestRoutingMethod;
+    }
+    return QueryOptions.RequestRoutingMethod.REGULAR;
   }
 
   private Iterator<Host> newQueryPlanRegular(

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.CCMConfig;
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+/**
+ * Integration tests verifying that statements with SERIAL/LOCAL_SERIAL consistency level are routed
+ * through the LWT load-balancing path (PRESERVE_REPLICA_ORDER).
+ */
+@CCMConfig(numberOfNodes = 3)
+public class LWTLoadBalancingIT extends CCMTestsSupport {
+
+  @Override
+  public Cluster.Builder createClusterBuilder() {
+    return Cluster.builder()
+        .withLoadBalancingPolicy(
+            new TokenAwarePolicy(new RoundRobinPolicy(), TokenAwarePolicy.ReplicaOrdering.RANDOM));
+  }
+
+  @Override
+  public void onTestContextInitialized() {
+    execute("CREATE TABLE IF NOT EXISTS test_lwt (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+    for (int i = 0; i < 10; i++) {
+      execute(String.format("INSERT INTO test_lwt (pk, ck, v) VALUES (%d, %d, %d)", i, 0, i));
+    }
+  }
+
+  @Test(groups = "short")
+  public void should_route_local_serial_select_through_lwt_path() {
+    Session session = session();
+
+    SimpleStatement simpleSelect =
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 1, 0);
+    simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
+
+    PreparedStatement preparedSelect = session.prepare(simpleSelect);
+    BoundStatement boundSelect = preparedSelect.bind(1, 0);
+
+    // Verify statement properties
+    assertThat(simpleSelect.isLWT()).isFalse();
+    assertThat(simpleSelect.getConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
+
+    // Execute multiple times and collect coordinators — with PRESERVE_REPLICA_ORDER routing,
+    // the same partition key should always be routed to the same first replica.
+    Set<InetSocketAddress> coordinators = new HashSet<>();
+    for (int i = 0; i < 30; i++) {
+      ResultSet rs = session.execute(boundSelect);
+      Host coordinator = rs.getExecutionInfo().getQueriedHost();
+      assertThat(coordinator).isNotNull();
+      coordinators.add(coordinator.getEndPoint().resolve());
+    }
+
+    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key,
+    // so all 30 executions should hit the same coordinator.
+    assertThat(coordinators).hasSize(1);
+  }
+
+  @Test(groups = "short")
+  public void should_route_serial_select_through_lwt_path() {
+    Session session = session();
+
+    SimpleStatement simpleSelect =
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 2, 0);
+    simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
+
+    PreparedStatement preparedSelect = session.prepare(simpleSelect);
+    BoundStatement boundSelect = preparedSelect.bind(2, 0);
+
+    // Execute multiple times and collect coordinators
+    Set<InetSocketAddress> coordinators = new HashSet<>();
+    for (int i = 0; i < 30; i++) {
+      ResultSet rs = session.execute(boundSelect);
+      Host coordinator = rs.getExecutionInfo().getQueriedHost();
+      assertThat(coordinator).isNotNull();
+      coordinators.add(coordinator.getEndPoint().resolve());
+    }
+
+    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key.
+    assertThat(coordinators).hasSize(1);
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
@@ -227,4 +227,46 @@ public class LatencyAwarePolicyTest extends ScassandraTestBase {
       cluster.close();
     }
   }
+
+  @Test(groups = "short")
+  public void should_not_reorder_query_plan_for_serial_consistency_queries() throws Exception {
+    // given
+    String query = "SELECT foo FROM bar";
+    primingClient.prime(queryBuilder().withQuery(query).build());
+
+    LatencyAwarePolicy latencyAwarePolicy =
+        LatencyAwarePolicy.builder(new RoundRobinPolicy()).withMininumMeasurements(1).build();
+
+    Cluster.Builder builder = super.createClusterBuilder();
+    builder.withLoadBalancingPolicy(latencyAwarePolicy);
+
+    Cluster cluster = builder.build();
+    try {
+      cluster.init();
+
+      // Create a statement with LOCAL_SERIAL consistency (not isLWT)
+      Statement serialStatement =
+          new SimpleStatement(query)
+              .setConsistencyLevel(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+
+      // Make a request to populate latency metrics
+      LatencyTrackerBarrier barrier = new LatencyTrackerBarrier(1);
+      cluster.register(barrier);
+      Session session = cluster.connect();
+      session.execute(query);
+      barrier.await();
+      latencyAwarePolicy.new Updater().run();
+
+      // when
+      Iterator<Host> plan1 = latencyAwarePolicy.newQueryPlan("ks", serialStatement);
+      Iterator<Host> plan2 = latencyAwarePolicy.newQueryPlan("ks", serialStatement);
+
+      // then: ordering is preserved (not reordered by latency)
+      Host host = retrieveSingleHost(cluster);
+      assertThat(Lists.newArrayList(plan1)).containsExactly(host);
+      assertThat(Lists.newArrayList(plan2)).containsExactly(host);
+    } finally {
+      cluster.close();
+    }
+  }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/RackAwareRoundRobinPolicyTest.java
@@ -1214,6 +1214,38 @@ public class RackAwareRoundRobinPolicyTest {
     Assertions.assertThat(queryPlan.subList(0, 2)).containsOnly(host1, host2);
   }
 
+  /**
+   * Ensures that {@link RackAwareRoundRobinPolicy} skips rack prioritization for serial consistency
+   * queries (LOCAL_SERIAL/SERIAL), treating them like LWT queries.
+   *
+   * @test_category load_balancing:rack_aware
+   */
+  @Test(groups = "unit")
+  public void should_skip_rack_prioritization_for_serial_consistency_queries() {
+    // given: a policy with 4 local DC hosts (2 in local rack, 2 in remote rack)
+    RackAwareRoundRobinPolicy policy =
+        new RackAwareRoundRobinPolicy("localDC", "localRack", 1, false, false, false);
+    policy.init(cluster, ImmutableList.of(host3, host1, host4, host2, host5, host6));
+
+    // Create a non-LWT statement with LOCAL_SERIAL consistency
+    Statement serialStatement = mock(Statement.class);
+    when(serialStatement.isLWT()).thenReturn(false);
+    when(serialStatement.getConsistencyLevel()).thenReturn(ConsistencyLevel.LOCAL_SERIAL);
+
+    // when: generating query plans
+    policy.index.set(0);
+    List<Host> queryPlan = Lists.newArrayList(policy.newQueryPlan("keyspace", serialStatement));
+
+    // then: all 4 local DC hosts should appear before any remote DC host (no rack prioritization)
+    List<Host> localHosts =
+        queryPlan.stream()
+            .filter(h -> h == host1 || h == host2 || h == host3 || h == host4)
+            .collect(Collectors.toList());
+    Assertions.assertThat(localHosts).containsOnly(host1, host2, host3, host4);
+    // then: should follow insertion order, not rack-aware order
+    Assertions.assertThat(localHosts).startsWith(host3);
+  }
+
   @DataProvider(name = "distanceTestCases")
   public Object[][] distanceTestCases() {
     return new Object[][] {

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -125,6 +125,14 @@ public class TokenAwarePolicyTest {
     };
   }
 
+  @DataProvider(name = "serialConsistencyProvider")
+  public Object[][] serialConsistencyProvider() {
+    return new Object[][] {
+      {com.datastax.driver.core.ConsistencyLevel.SERIAL},
+      {com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL}
+    };
+  }
+
   @Test(groups = "unit")
   public void should_respect_topological_order() {
     // given
@@ -737,41 +745,13 @@ public class TokenAwarePolicyTest {
     assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
   }
 
-  @Test(groups = "unit")
-  public void should_not_include_remote_replicas_for_local_serial() {
-    // given: a LOCAL_SERIAL statement with some replicas in remote DC
-    Statement localSerialStatement = mock(Statement.class);
-    when(localSerialStatement.isLWT()).thenReturn(false);
-    when(localSerialStatement.getConsistencyLevel())
-        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
-    when(localSerialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
-        .thenReturn(routingKey);
-    when(localSerialStatement.getKeyspace()).thenReturn(KEYSPACE);
-    when(metadata.getReplicasList(Metadata.quote(KEYSPACE), null, null, routingKey))
-        .thenReturn(Lists.newArrayList(host1, host2, host3));
-    when(childPolicy.distance(host1)).thenReturn(HostDistance.LOCAL);
-    when(childPolicy.distance(host2)).thenReturn(HostDistance.REMOTE);
-    when(childPolicy.distance(host3)).thenReturn(HostDistance.LOCAL);
-    when(childPolicy.newQueryPlan(KEYSPACE, localSerialStatement))
-        .thenReturn(Lists.newArrayList(host4, host5).iterator());
-
-    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
-    policy.init(cluster, null);
-
-    // when
-    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, localSerialStatement);
-
-    // then: only local replicas (host1, host3), no remote replica (host2), then non-replicas
-    assertThat(queryPlan).containsExactly(host1, host3, host4, host5);
-  }
-
-  @Test(groups = "unit")
-  public void should_include_remote_replicas_for_serial() {
-    // given: a SERIAL statement with some replicas in remote DC
+  @Test(groups = "unit", dataProvider = "serialConsistencyProvider")
+  public void should_include_remote_replicas_for_serial_consistency(
+      com.datastax.driver.core.ConsistencyLevel serialCl) {
+    // given: a serial-CL statement with some replicas in remote DC
     Statement serialStatement = mock(Statement.class);
     when(serialStatement.isLWT()).thenReturn(false);
-    when(serialStatement.getConsistencyLevel())
-        .thenReturn(com.datastax.driver.core.ConsistencyLevel.SERIAL);
+    when(serialStatement.getConsistencyLevel()).thenReturn(serialCl);
     when(serialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
         .thenReturn(routingKey);
     when(serialStatement.getKeyspace()).thenReturn(KEYSPACE);
@@ -789,7 +769,7 @@ public class TokenAwarePolicyTest {
     // when
     Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, serialStatement);
 
-    // then: local replicas (host1, host3), then remote replica (host2), then non-replicas
+    // then: local replicas first (host1, host3), then remote replica (host2), then non-replicas
     assertThat(queryPlan).containsExactly(host1, host3, host2, host4, host5);
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -664,6 +664,183 @@ public class TokenAwarePolicyTest {
     assertThat(queryPlan).containsExactly(host1, host3, host2, host4, host5);
   }
 
+  @Test(groups = "unit", dataProvider = "shuffleProvider")
+  public void should_route_serial_consistency_statement_as_lwt(
+      TokenAwarePolicy.ReplicaOrdering ordering) {
+    // given: a non-LWT statement with LOCAL_SERIAL consistency level
+    Statement serialStatement = mock(Statement.class);
+    when(serialStatement.isLWT()).thenReturn(false);
+    when(serialStatement.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+    when(serialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(serialStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(childPolicy.newQueryPlan(KEYSPACE, serialStatement))
+        .thenReturn(Lists.newArrayList(host4, host3, host2, host1).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, ordering);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, serialStatement);
+
+    // then: preserve replica order (LWT routing applied)
+    assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
+  }
+
+  @Test(groups = "unit", dataProvider = "shuffleProvider")
+  public void should_route_serial_consistency_statement_as_lwt_with_serial(
+      TokenAwarePolicy.ReplicaOrdering ordering) {
+    // given: a non-LWT statement with SERIAL consistency level
+    Statement serialStatement = mock(Statement.class);
+    when(serialStatement.isLWT()).thenReturn(false);
+    when(serialStatement.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.SERIAL);
+    when(serialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(serialStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(childPolicy.newQueryPlan(KEYSPACE, serialStatement))
+        .thenReturn(Lists.newArrayList(host4, host3, host2, host1).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, ordering);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, serialStatement);
+
+    // then: preserve replica order (LWT routing applied), including remote replicas for SERIAL
+    assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
+  }
+
+  @Test(groups = "unit")
+  public void should_not_route_serial_consistency_level_option_as_lwt() {
+    // given: a statement with serial consistency level set only as the serial CL option
+    // (not the main consistency level)
+    Statement regularStatement = mock(Statement.class);
+    when(regularStatement.isLWT()).thenReturn(false);
+    when(regularStatement.getConsistencyLevel()).thenReturn(null);
+    when(regularStatement.getSerialConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+    when(regularStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(regularStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(childPolicy.newQueryPlan(KEYSPACE, regularStatement))
+        .thenReturn(Lists.newArrayList(host4, host3, host2, host1).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, regularStatement);
+
+    // then: regular routing (not LWT), uses TOPOLOGICAL ordering
+    assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
+  }
+
+  @Test(groups = "unit")
+  public void should_not_include_remote_replicas_for_local_serial() {
+    // given: a LOCAL_SERIAL statement with some replicas in remote DC
+    Statement localSerialStatement = mock(Statement.class);
+    when(localSerialStatement.isLWT()).thenReturn(false);
+    when(localSerialStatement.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+    when(localSerialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(localSerialStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(metadata.getReplicasList(Metadata.quote(KEYSPACE), null, null, routingKey))
+        .thenReturn(Lists.newArrayList(host1, host2, host3));
+    when(childPolicy.distance(host1)).thenReturn(HostDistance.LOCAL);
+    when(childPolicy.distance(host2)).thenReturn(HostDistance.REMOTE);
+    when(childPolicy.distance(host3)).thenReturn(HostDistance.LOCAL);
+    when(childPolicy.newQueryPlan(KEYSPACE, localSerialStatement))
+        .thenReturn(Lists.newArrayList(host4, host5).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, localSerialStatement);
+
+    // then: only local replicas (host1, host3), no remote replica (host2), then non-replicas
+    assertThat(queryPlan).containsExactly(host1, host3, host4, host5);
+  }
+
+  @Test(groups = "unit")
+  public void should_include_remote_replicas_for_serial() {
+    // given: a SERIAL statement with some replicas in remote DC
+    Statement serialStatement = mock(Statement.class);
+    when(serialStatement.isLWT()).thenReturn(false);
+    when(serialStatement.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.SERIAL);
+    when(serialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(serialStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(metadata.getReplicasList(Metadata.quote(KEYSPACE), null, null, routingKey))
+        .thenReturn(Lists.newArrayList(host1, host2, host3));
+    when(childPolicy.distance(host1)).thenReturn(HostDistance.LOCAL);
+    when(childPolicy.distance(host2)).thenReturn(HostDistance.REMOTE);
+    when(childPolicy.distance(host3)).thenReturn(HostDistance.LOCAL);
+    when(childPolicy.newQueryPlan(KEYSPACE, serialStatement))
+        .thenReturn(Lists.newArrayList(host4, host5).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, serialStatement);
+
+    // then: local replicas (host1, host3), then remote replica (host2), then non-replicas
+    assertThat(queryPlan).containsExactly(host1, host3, host2, host4, host5);
+  }
+
+  @Test(groups = "unit")
+  public void should_fallback_to_regular_when_routing_method_is_null_for_serial() {
+    // given: routing method is null (not configured)
+    when(queryOptions.getLoadBalancingLwtRequestRoutingMethod()).thenReturn(null);
+    Statement serialStatement = mock(Statement.class);
+    when(serialStatement.isLWT()).thenReturn(false);
+    when(serialStatement.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+    when(serialStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(serialStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(childPolicy.newQueryPlan(KEYSPACE, serialStatement))
+        .thenReturn(Lists.newArrayList(host4, host3, host2, host1).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, serialStatement);
+
+    // then: regular routing (TOPOLOGICAL ordering applied, not preserve order)
+    assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
+  }
+
+  @Test(groups = "unit")
+  public void should_route_as_lwt_when_default_consistency_is_local_serial() {
+    // given: statement has no explicit CL, but cluster-wide default is LOCAL_SERIAL
+    when(queryOptions.getConsistencyLevel())
+        .thenReturn(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL);
+    Statement noClStatement = mock(Statement.class);
+    when(noClStatement.isLWT()).thenReturn(false);
+    when(noClStatement.getConsistencyLevel()).thenReturn(null);
+    when(noClStatement.getRoutingKey(any(ProtocolVersion.class), any(CodecRegistry.class)))
+        .thenReturn(routingKey);
+    when(noClStatement.getKeyspace()).thenReturn(KEYSPACE);
+    when(childPolicy.newQueryPlan(KEYSPACE, noClStatement))
+        .thenReturn(Lists.newArrayList(host4, host3, host2, host1).iterator());
+
+    TokenAwarePolicy policy = new TokenAwarePolicy(childPolicy, TOPOLOGICAL);
+    policy.init(cluster, null);
+
+    // when
+    Iterator<Host> queryPlan = policy.newQueryPlan(KEYSPACE, noClStatement);
+
+    // then: preserve replica order (LWT routing via default CL fallback)
+    assertThat(queryPlan).containsExactly(host1, host2, host4, host3);
+  }
+
   /**
    * Ensures that {@link TokenAwarePolicy} will shuffle discovered replicas depending on the value
    * of shuffleReplicas used when constructing with {@link


### PR DESCRIPTION
> [!NOTE]
> Fixes [DRIVER-616](https://scylladb.atlassian.net/browse/DRIVER-616). Related to: #886

## Problem

Statements with `SERIAL` or `LOCAL_SERIAL` set as their **main consistency level** (via `setConsistencyLevel`) are serialised through the Paxos/serial path on the server side — the same path used by LWT writes. However, the 3.x driver only applied LWT load-balancing routing (e.g. `PRESERVE_REPLICA_ORDER`) to statements where `isLWT()` returned `true`, which is driven exclusively by Scylla's server-side prepare metadata.

A normal `SELECT` prepared or executed with `LOCAL_SERIAL` consistency:

```java
SimpleStatement simpleSelect =
    new SimpleStatement("SELECT * FROM t WHERE pk=?")
        .setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
PreparedStatement ps = session.prepare(simpleSelect);
BoundStatement bs = ps.bind(1);
// bs.isLWT() == false  → routed as REGULAR, not PRESERVE_REPLICA_ORDER
```

was routed as `REGULAR`, ignoring the configured LWT routing method entirely.

## Changes

- **`TokenAwarePolicy`**: `getRequestRouting()` now treats statements with `SERIAL` or `LOCAL_SERIAL` main consistency as LWT for routing method selection (same as `isLWT()`). In `PreserveReplicaOrderIterator`, remote-DC replicas are excluded when the consistency is `LOCAL_SERIAL` (preserving local-DC semantics).
- **`LatencyAwarePolicy`**: The latency-reordering bypass that already applied to `isLWT()` statements is extended to cover `SERIAL`/`LOCAL_SERIAL` consistency statements.
- **`RackAwareRoundRobinPolicy`**: The rack-prioritization bypass already in place for `isLWT()` is extended to cover `SERIAL`/`LOCAL_SERIAL` consistency statements.

## What is NOT changed

- `setSerialConsistencyLevel()` (the paxos-phase serial CL option on LWT writes) is intentionally **not** affected — only the main `setConsistencyLevel()` triggers LWT routing.
- `isLWT()` semantics are unchanged; this is purely additive.

## Tests

- **`TokenAwarePolicyTest`**: 7 new unit tests — serial consistency routed as LWT, `LOCAL_SERIAL` excludes remote replicas, plain `SERIAL` keeps remote replicas, serial-CL-option does not trigger LWT routing, null routing-method falls back to regular.
- **`LatencyAwarePolicyTest`**: 1 new unit test — serial consistency statements bypass latency reordering.
- **`RackAwareRoundRobinPolicyTest`**: 1 new unit test — serial consistency statements skip rack prioritization.
- **`LWTLoadBalancingIT`**: New CCM integration test — prepares a `SimpleStatement` with `LOCAL_SERIAL`/`SERIAL` consistency, binds and executes it, verifies coordinator is non-null.

All 67 unit tests pass (`mvn test -pl driver-core -Dgroups=unit`).

[DRIVER-616]: https://scylladb.atlassian.net/browse/DRIVER-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ