### PR TITLE
fix: bump netty to 4.1.133.Final to remediate CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.2.2</hdrhistogram.version>
     <metrics.version>4.2.37</metrics.version>
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in


### PR DESCRIPTION
## Summary

Root fix for CVE-2026-42583, tracked in scylladb/kafka-connect-scylladb#164.

`Lz4FrameDecoder` in `netty-codec` prior to `4.1.133.Final` allocates up to 32 MB per block before LZ4 decompression runs. A peer needs only a 21-byte crafted header to trigger that allocation, enabling remote memory exhaustion (DoS). CVSS 7.5 (HIGH).

## Change

```diff
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
```

One-line change in the root `pom.xml`. All consumers of `java-driver-core` will inherit the fix transitively once a new driver release is published, eliminating the need for downstream `<dependencyManagement>` overrides.

## Follow-up

After this merges and a new release is cut, scylladb/kafka-connect-scylladb will bump `scylladb.version` and remove the temporary BOM override added in Stage 1.
