### PR TITLE
ci: validate matrix patches before release (scylla-3.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
         description: 'target-tag: tag or branch name to release. Use to re-release tagged releases'
         default: scylla-3.x
 
+      matrix-branch:
+        type: string
+        description: 'matrix-branch: scylla-java-driver-matrix branch to use for patch validation'
+        default: master
+
 jobs:
   release:
     name: Release
@@ -61,6 +66,29 @@ jobs:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
         run: |
           make release-prepare
+
+      - name: Validate matrix patches
+        run: |
+          RELEASE_TAG=$(grep '^scm.tag=' release.properties | cut -d= -f2)
+          echo "Release tag: ${RELEASE_TAG}"
+
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            echo "::error::Could not determine release tag from release.properties"
+            exit 1
+          fi
+
+          git clone --depth 1 --branch "${{ inputs.matrix-branch }}" \
+            https://github.com/scylladb/scylla-java-driver-matrix.git /tmp/matrix
+
+          pip install --quiet -r /tmp/matrix/scripts/requirements.txt
+
+          echo "=== Validating scylla driver patches for ${RELEASE_TAG} ==="
+          python3 /tmp/matrix/main.py . \
+            --versions "${RELEASE_TAG}" \
+            --driver-type scylla \
+            --patch-only
+
+          echo "Matrix patches apply cleanly to ${RELEASE_TAG}"
 
       - name: Perform release
         if: inputs.dry-run == false


### PR DESCRIPTION
Closes scylladb/scylla-java-driver-matrix#145

## What

Adds a **"Validate matrix patches"** step to the release workflow, inserted between `Prepare release` (which creates the tag locally via `mvn release:prepare`) and `Perform release` (which publishes to Maven Central).

The step clones `scylla-java-driver-matrix` at the specified branch and runs `--patch-only` mode against the newly created local tag. If patches fail to apply, the release workflow aborts before anything is published or pushed.

## Why

Today, a broken or missing matrix patch is only discovered after the tag is on GitHub and the artifact is on Maven Central — too late for a clean abort. This change makes patch compatibility a hard gate before publication.

## Changes

**`.github/workflows/release.yml`:**
- Add `matrix-branch` input (type: string, default: `master`) — allows pointing to a non-merged matrix branch if patches need updating before the matrix PR merges
- Add "Validate matrix patches" step after "Prepare release":
  1. Extracts the release tag from `release.properties` (`scm.tag=X.Y.Z.W`)
  2. Clones `scylladb/scylla-java-driver-matrix` at the specified branch
  3. Runs `python3 main.py . --versions {tag} --driver-type scylla --patch-only`
  4. Fails the workflow if patches don't apply

## Release flow with this change

```
1. mvn release:prepare          → creates tag locally (e.g., 3.11.5.16)
2. Validate matrix patches      → clone matrix, run --patch-only
   ├── patches apply cleanly    → continue
   └── patches FAIL             → release ABORTS (nothing published, no tag pushed)
3. mvn release:perform          → publish to Maven Central
4. git push --follow-tags       → push tag to GitHub
```

## Testing

Use `dry-run: true` — the "Validate matrix patches" step has no `if` condition so it runs in both normal and dry-run mode. This allows testing the validation without publishing or pushing anything.

## Dependency

Requires `scylladb/scylla-java-driver-matrix#146` (`--patch-only` mode) to be merged into matrix `master` before this workflow runs in production. During the interim, the `matrix-branch` input can point to the feature branch.