### PR TITLE
Drop Java 8 support

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Set up JDK 8.0
+      - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Install uv

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Set up JDK 8.0
+      - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
 
       - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
           RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
         run: make checkout-one-commit-before
 
-      - name: Set up Java
+      - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
           server-id: central
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8]
+        java-version: [11, 17]
       fail-fast: false
 
     steps:
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8]
+        java-version: [11, 17]
       fail-fast: false
 
     steps:
@@ -109,14 +109,14 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8]
+        java-version: [11, 17]
       fail-fast: false
 
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
@@ -142,14 +142,14 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.java-version }}
           path: "*/**/target/*-reports/*.xml"
 
       - name: Parse test results
         uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
-          check_name: Unit tests report
+          check_name: Unit tests report (JDK ${{ matrix.java-version }})
           require_tests: true
           report_paths: "*/**/target/*-reports/*.xml"
           follow_symlink: true
@@ -180,7 +180,7 @@ jobs:
     strategy:
       matrix:
         cassandra-version: [3-LATEST, 4-LATEST]
-        java-version: [8]
+        java-version: [11, 17]
         test-group: [parallelizable, serial, isolated]
       fail-fast: false
 
@@ -278,7 +278,7 @@ jobs:
         uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
-          check_name: Integration tests report for Cassandra ${{ steps.cassandra-version.outputs.value }} (${{ matrix.test-group }})
+          check_name: Integration tests report for Cassandra ${{ steps.cassandra-version.outputs.value }} (${{ matrix.test-group }}, JDK ${{ matrix.java-version }})
           require_tests: true
           report_paths: "*/**/target/*-reports/*.xml"
           follow_symlink: true
@@ -295,7 +295,7 @@ jobs:
     strategy:
       matrix:
         scylla-version: [LTS-LATEST, LTS-PRIOR, LATEST]
-        java-version: [8]
+        java-version: [11, 17]
         test-group: [parallelizable, serial, isolated]
       fail-fast: false
 
@@ -391,7 +391,7 @@ jobs:
         uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
-          check_name: Integration tests report for Scylla ${{ steps.scylla-version.outputs.value }} (${{ matrix.test-group }})
+          check_name: Integration tests report for Scylla ${{ steps.scylla-version.outputs.value }} (${{ matrix.test-group }}, JDK ${{ matrix.java-version }})
           require_tests: true
           report_paths: "*/**/target/*-reports/*.xml"
           follow_symlink: true

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -115,6 +117,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -182,6 +186,11 @@ jobs:
         cassandra-version: [3-LATEST, 4-LATEST]
         java-version: [11, 17]
         test-group: [parallelizable, serial, isolated]
+        exclude:
+          - cassandra-version: 3-LATEST
+            java-version: 17
+          - cassandra-version: 4-LATEST
+            java-version: 11
       fail-fast: false
 
     steps:
@@ -212,6 +221,7 @@ jobs:
         id: cassandra-version
         env:
           CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
+          GET_VERSION_VERSION: 0.4.5
           GH_TOKEN: ${{ github.token }}
         run: make resolve-cassandra-version
 
@@ -226,6 +236,7 @@ jobs:
         if: steps.ccm-cache.outputs.cache-hit != 'true'
         env:
           CASSANDRA_VERSION_RESOLVED: ${{ steps.cassandra-version.outputs.value }}
+          GET_VERSION_VERSION: 0.4.5
         run: make download-cassandra
 
       - name: Save CCM image into the cache
@@ -249,6 +260,7 @@ jobs:
         env:
           CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
           CASSANDRA_VERSION_RESOLVED: ${{ steps.cassandra-version.outputs.value }}
+          GET_VERSION_VERSION: 0.4.5
           GH_TOKEN: ${{ github.token }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
         run: make test-integration-cassandra
@@ -297,6 +309,13 @@ jobs:
         scylla-version: [LTS-LATEST, LTS-PRIOR, LATEST]
         java-version: [11, 17]
         test-group: [parallelizable, serial, isolated]
+        exclude:
+          - scylla-version: LTS-PRIOR
+            java-version: 17
+          - scylla-version: LTS-LATEST
+            java-version: 17
+          - scylla-version: LATEST
+            java-version: 11
       fail-fast: false
 
     steps:

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,11 @@
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED

--- a/LICENSE_binary
+++ b/LICENSE_binary
@@ -222,7 +222,7 @@ Copyright (C) 2018 Christian Stein
 This product includes software developed by Christian Stein
 see ci/install-jdk.sh
 
-This product bundles Java Native Runtime - POSIX 3.1.15,
+This product bundles Java Native Runtime - POSIX 3.1.22,
 which is available under the Eclipse Public License version 2.0.
 see licenses/jnr-posix.txt
 
@@ -234,14 +234,14 @@ This product bundles ASM 9.2: a very small and fast Java bytecode manipulation f
 which is available under the 3-Clause BSD License.
 see licenses/asm.txt
 
-This product bundles HdrHistogram 2.1.12: A High Dynamic Range (HDR) Histogram,
+This product bundles HdrHistogram 2.2.2: A High Dynamic Range (HDR) Histogram,
 which is available under the 2-Clause BSD License.
 see licenses/HdrHistogram.txt
 
-This product bundles The Simple Logging Facade for Java (SLF4J) API 1.7.26,
+This product bundles The Simple Logging Facade for Java (SLF4J) API 2.0.18,
 which is available under the MIT License.
 see licenses/slf4j-api.txt
 
-This product bundles Reactive Streams 1.0.3,
+This product bundles Reactive Streams 1.0.4,
 which is available under the MIT License.
 see licenses/reactive-streams.txt

--- a/README-dev.md
+++ b/README-dev.md
@@ -6,7 +6,7 @@ To build the documentation of this project, you need a UNIX-based operating syst
 
 You also need the following software installed to generate the reference documentation of the driver:
 
-- Java JDK 8 or higher
+- Java JDK 11 or higher
 - Maven
 
 Once you have installed the above software, you can build and preview the documentation by following the steps outlined in the `Quickstart guide <https://sphinx-theme.scylladb.com/stable/getting-started/quickstart.html>`_.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ builder](manual/query_builder/), [mapper](manual/mapper)).
 
 The driver is compatible with Scylla and Apache Cassandra® 2.1 and higher.
 
-It requires Java 8 or higher.
+It requires Java 11 or higher.
 
 ## Migrating from previous versions
 

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -280,6 +280,9 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/core/src/main/java/com/datastax/dse/driver/api/core/data/time/DateRangePrecision.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/data/time/DateRangePrecision.java
@@ -131,9 +131,9 @@ public enum DateRangePrecision {
   private final ChronoUnit roundingUnit;
   // The formatter is only used for formatting (parsing is done with  DateRangeUtil.parseCalendar to
   // be exactly the same as DSE's).
-  // If that ever were to change, note that DateTimeFormatters with a time zone have a parsing bug
-  // in Java 8: the formatter's zone will always be used, even if the input string specifies one
-  // explicitly.
+  // If that ever were to change, note that DateTimeFormatters with a time zone had a parsing bug
+  // on older JDKs: the formatter's zone would always be used, even if the input string specified
+  // one explicitly.
   // See https://stackoverflow.com/questions/41999421
   private final DateTimeFormatter formatter;
 

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphSON2SerdeTP.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphSON2SerdeTP.java
@@ -403,7 +403,7 @@ public class GraphSON2SerdeTP {
 
       private static final long serialVersionUID = 1L;
 
-      protected ObjectGraphNodeGraphSON2Serializer() {
+      ObjectGraphNodeGraphSON2Serializer() {
         super(ObjectGraphNode.class);
       }
 

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
@@ -64,7 +64,6 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,7 +113,7 @@ public class InsightsClient {
     DataCentersFinder dataCentersFinder = new DataCentersFinder();
     return new InsightsClient(
         driverContext,
-        () -> new Date().getTime(),
+        System::currentTimeMillis,
         insightsConfiguration,
         new PlatformInfoFinder(),
         new ReconnectionPolicyInfoFinder(),

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/PackageUtil.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/PackageUtil.java
@@ -18,9 +18,6 @@
 package com.datastax.dse.driver.internal.core.insights;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
-import com.datastax.oss.driver.shaded.guava.common.base.Joiner;
-import java.util.Arrays;
-import java.util.regex.Pattern;
 
 class PackageUtil {
   static final String DEFAULT_SPECULATIVE_EXECUTION_PACKAGE =
@@ -28,8 +25,6 @@ class PackageUtil {
   static final String DEFAULT_LOAD_BALANCING_PACKAGE =
       "com.datastax.oss.driver.internal.core.loadbalancing";
   static final String DEFAULT_AUTH_PROVIDER_PACKAGE = "com.datastax.oss.driver.internal.core.auth";
-  private static final Pattern PACKAGE_SPLIT_REGEX = Pattern.compile("\\.");
-  private static final Joiner DOT_JOINER = Joiner.on(".");
 
   static String getNamespace(Class<?> tClass) {
     String namespace = "";
@@ -61,18 +56,14 @@ class PackageUtil {
 
   @VisibleForTesting
   static String getClassName(String classSetting) {
-    String[] split = PACKAGE_SPLIT_REGEX.split(classSetting);
-    if (split.length == 0) {
-      return "";
-    }
-    return split[split.length - 1];
+    int lastDot = classSetting.lastIndexOf('.');
+    return lastDot < 0 ? classSetting : classSetting.substring(lastDot + 1);
   }
 
   @VisibleForTesting
   static String getFullPackageOrDefault(String classSetting, String defaultValue) {
-    String[] split = PACKAGE_SPLIT_REGEX.split(classSetting);
-    if (split.length <= 1) return defaultValue;
-    return DOT_JOINER.join(Arrays.copyOf(split, split.length - 1));
+    int lastDot = classSetting.lastIndexOf('.');
+    return lastDot < 0 ? defaultValue : classSetting.substring(0, lastDot);
   }
 
   static class ClassSettingDetails {

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/PlatformInfoFinder.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/PlatformInfoFinder.java
@@ -24,6 +24,7 @@ import com.datastax.dse.driver.internal.core.insights.schema.InsightsPlatformInf
 import com.datastax.dse.driver.internal.core.insights.schema.InsightsPlatformInfo.CPUS;
 import com.datastax.oss.driver.internal.core.os.Native;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,11 +38,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 class PlatformInfoFinder {
   private static final String MAVEN_IGNORE_LINE = "The following files have been resolved:";
-  private static final Pattern DEPENDENCY_SPLIT_REGEX = Pattern.compile(":");
+  private static final Splitter DEPENDENCY_SPLITTER = Splitter.on(':');
   static final String UNVERIFIED_RUNTIME_VERSION = "UNVERIFIED";
   private final Function<DependencyFromFile, URL> propertiesUrlProvider;
 
@@ -197,11 +197,13 @@ class PlatformInfoFinder {
   }
 
   private DependencyFromFile extractDependencyFromLine(String line) {
-    String[] split = DEPENDENCY_SPLIT_REGEX.split(line);
-    if (split.length == 6) { // case for i.e.: com.github.jnr:jffi:jar:native:1.2.16:compile
-      return new DependencyFromFile(split[0], split[1], split[4], checkIsOptional(split[5]));
+    List<String> split = DEPENDENCY_SPLITTER.splitToList(line);
+    if (split.size() == 6) { // case for i.e.: com.github.jnr:jffi:jar:native:1.2.16:compile
+      return new DependencyFromFile(
+          split.get(0), split.get(1), split.get(4), checkIsOptional(split.get(5)));
     } else { // case for normal: org.ow2.asm:asm:jar:5.0.3:compile
-      return new DependencyFromFile(split[0], split[1], split[3], checkIsOptional(split[4]));
+      return new DependencyFromFile(
+          split.get(0), split.get(1), split.get(3), checkIsOptional(split.get(4)));
     }
   }
 

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/schema/InsightMetadata.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/schema/InsightMetadata.java
@@ -68,7 +68,7 @@ public class InsightMetadata {
     }
     InsightMetadata that = (InsightMetadata) o;
     return Objects.equals(name, that.name)
-        && Objects.equals(timestamp, that.timestamp)
+        && timestamp == that.timestamp
         && Objects.equals(tags, that.tags)
         && insightType == that.insightType
         && Objects.equals(insightMappingId, that.insightMappingId);

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/metadata/schema/DefaultDseAggregateMetadata.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/metadata/schema/DefaultDseAggregateMetadata.java
@@ -64,7 +64,6 @@ public class DefaultDseAggregateMetadata extends DefaultAggregateMetadata
   }
 
   @Override
-  @Nullable
   public Optional<Boolean> getDeterministic() {
     return Optional.ofNullable(deterministic);
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
@@ -43,7 +43,8 @@ import net.jcip.annotations.Immutable;
  *
  * Examples:
  *
- * <table summary="examples">
+ * <table>
+ *   <caption>Examples</caption>
  *   <tr><th>Create statement</th><th>Case-sensitive?</th><th>CQL id</th><th>Internal id</th></tr>
  *   <tr><td>CREATE TABLE t(foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>
  *   <tr><td>CREATE TABLE t(Foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -49,25 +49,26 @@ public interface DriverContext extends AttachmentPoint {
   @NonNull
   String getSessionName();
 
-  /** @return The driver's configuration; never {@code null}. */
+  /** Returns the driver's configuration; never {@code null}. */
   @NonNull
   DriverConfig getConfig();
 
-  /** @return The driver's configuration loader; never {@code null}. */
+  /** Returns the driver's configuration loader; never {@code null}. */
   @NonNull
   DriverConfigLoader getConfigLoader();
 
   /**
-   * @return The driver's load balancing policies, keyed by profile name; the returned map is
-   *     guaranteed to never be {@code null} and to always contain an entry for the {@value
-   *     DriverExecutionProfile#DEFAULT_NAME} profile.
+   * Returns the driver's load balancing policies, keyed by profile name; the returned map is
+   * guaranteed to never be {@code null} and to always contain an entry for the {@value
+   * DriverExecutionProfile#DEFAULT_NAME} profile.
    */
   @NonNull
   Map<String, LoadBalancingPolicy> getLoadBalancingPolicies();
 
   /**
+   * Returns the driver's load balancing policy for the given profile; never {@code null}.
+   *
    * @param profileName the profile name; never {@code null}.
-   * @return The driver's load balancing policy for the given profile; never {@code null}.
    */
   @NonNull
   default LoadBalancingPolicy getLoadBalancingPolicy(@NonNull String profileName) {
@@ -79,16 +80,17 @@ public interface DriverContext extends AttachmentPoint {
   }
 
   /**
-   * @return The driver's retry policies, keyed by profile name; the returned map is guaranteed to
-   *     never be {@code null} and to always contain an entry for the {@value
-   *     DriverExecutionProfile#DEFAULT_NAME} profile.
+   * Returns the driver's retry policies, keyed by profile name; the returned map is guaranteed to
+   * never be {@code null} and to always contain an entry for the {@value
+   * DriverExecutionProfile#DEFAULT_NAME} profile.
    */
   @NonNull
   Map<String, RetryPolicy> getRetryPolicies();
 
   /**
+   * Returns the driver's retry policy for the given profile; never {@code null}.
+   *
    * @param profileName the profile name; never {@code null}.
-   * @return The driver's retry policy for the given profile; never {@code null}.
    */
   @NonNull
   default RetryPolicy getRetryPolicy(@NonNull String profileName) {
@@ -97,16 +99,17 @@ public interface DriverContext extends AttachmentPoint {
   }
 
   /**
-   * @return The driver's speculative execution policies, keyed by profile name; the returned map is
-   *     guaranteed to never be {@code null} and to always contain an entry for the {@value
-   *     DriverExecutionProfile#DEFAULT_NAME} profile.
+   * Returns the driver's speculative execution policies, keyed by profile name; the returned map is
+   * guaranteed to never be {@code null} and to always contain an entry for the {@value
+   * DriverExecutionProfile#DEFAULT_NAME} profile.
    */
   @NonNull
   Map<String, SpeculativeExecutionPolicy> getSpeculativeExecutionPolicies();
 
   /**
+   * Returns the driver's speculative execution policy for the given profile; never {@code null}.
+   *
    * @param profileName the profile name; never {@code null}.
-   * @return The driver's speculative execution policy for the given profile; never {@code null}.
    */
   @NonNull
   default SpeculativeExecutionPolicy getSpeculativeExecutionPolicy(@NonNull String profileName) {
@@ -116,27 +119,27 @@ public interface DriverContext extends AttachmentPoint {
         : getSpeculativeExecutionPolicies().get(DriverExecutionProfile.DEFAULT_NAME);
   }
 
-  /** @return The driver's timestamp generator; never {@code null}. */
+  /** Returns the driver's timestamp generator; never {@code null}. */
   @NonNull
   TimestampGenerator getTimestampGenerator();
 
-  /** @return The driver's reconnection policy; never {@code null}. */
+  /** Returns the driver's reconnection policy; never {@code null}. */
   @NonNull
   ReconnectionPolicy getReconnectionPolicy();
 
-  /** @return The driver's address translator; never {@code null}. */
+  /** Returns the driver's address translator; never {@code null}. */
   @NonNull
   AddressTranslator getAddressTranslator();
 
-  /** @return The authentication provider, if authentication was configured. */
+  /** Returns the authentication provider, if authentication was configured. */
   @NonNull
   Optional<AuthProvider> getAuthProvider();
 
-  /** @return The SSL engine factory, if SSL was configured. */
+  /** Returns the SSL engine factory, if SSL was configured. */
   @NonNull
   Optional<SslEngineFactory> getSslEngineFactory();
 
-  /** @return The driver's request tracker; never {@code null}. */
+  /** Returns the driver's request tracker; never {@code null}. */
   @NonNull
   RequestTracker getRequestTracker();
 
@@ -144,15 +147,15 @@ public interface DriverContext extends AttachmentPoint {
   @NonNull
   Optional<RequestIdGenerator> getRequestIdGenerator();
 
-  /** @return The driver's request throttler; never {@code null}. */
+  /** Returns the driver's request throttler; never {@code null}. */
   @NonNull
   RequestThrottler getRequestThrottler();
 
-  /** @return The driver's node state listener; never {@code null}. */
+  /** Returns the driver's node state listener; never {@code null}. */
   @NonNull
   NodeStateListener getNodeStateListener();
 
-  /** @return The driver's schema change listener; never {@code null}. */
+  /** Returns the driver's schema change listener; never {@code null}. */
   @NonNull
   SchemaChangeListener getSchemaChangeListener();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -80,7 +80,7 @@ public class CqlVector<T> implements Iterable<T>, Serializable {
    * Create a new CqlVector instance from the specified string representation.
    *
    * @param str a String representation of a CqlVector
-   * @param subtypeCodec
+   * @param subtypeCodec the codec used to parse individual vector elements
    * @return a new CqlVector built from the String representation
    */
   public static <V> CqlVector<V> from(@NonNull String str, @NonNull TypeCodec<V> subtypeCodec) {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/token/Partitioner.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/token/Partitioner.java
@@ -18,7 +18,7 @@ package com.datastax.oss.driver.api.core.metadata.token;
 
 import java.nio.ByteBuffer;
 
-/** Allows to hash partition key to a @code{Token}. */
+/** Allows to hash partition key to a {@code Token}. */
 public interface Partitioner {
   Token hash(ByteBuffer partitionKey);
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
@@ -42,6 +42,7 @@ public interface Metrics {
    *     (Dropwizard Metrics manual)</a>
    * @leaks-private-api
    */
+  @SuppressWarnings("InvalidBlockTag")
   @NonNull
   MetricRegistry getRegistry();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/paging/OffsetPager.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/paging/OffsetPager.java
@@ -46,7 +46,7 @@ import net.jcip.annotations.ThreadSafe;
  * a reasonable trade-off if the cardinality stays low. This class provides a way to emulate this
  * behavior on the client side.
  *
- * <h3>Performance considerations</h3>
+ * <h2>Performance considerations</h2>
  *
  * For each page that you want to retrieve:
  *
@@ -71,7 +71,7 @@ import net.jcip.annotations.ThreadSafe;
  * OffsetPager.Page&lt;Row&gt; page5 = pager.getPage(rs, 5);
  * </pre>
  *
- * <h3>Establishing application-level guardrails</h3>
+ * <h2>Establishing application-level guardrails</h2>
  *
  * Linear performance should be fine for the values typically encountered in real-world
  * applications: for example, if the page size is 25 and users never go past page 10, the worst case
@@ -81,7 +81,7 @@ import net.jcip.annotations.ThreadSafe;
  * maximum, so that an attacker can't inject a large value that could potentially fetch millions of
  * rows.
  *
- * <h3>Relation with protocol-level paging</h3>
+ * <h2>Relation with protocol-level paging</h2>
  *
  * Protocol-level paging refers to the ability to split large response into multiple network chunks:
  * see {@link Statement#setPageSize(int)} and {@code basic.request.page-size} in the configuration.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/retry/RetryVerdict.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/retry/RetryVerdict.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * where, and a method that allows the original request to be modified before the retry.
  */
 @FunctionalInterface
+@SuppressWarnings("ClassInitializationDeadlock")
 public interface RetryVerdict {
 
   /** A retry verdict that retries the same request on the same node. */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
@@ -57,6 +57,7 @@ public interface CodecRegistry {
    * but any attempt to {@linkplain MutableCodecRegistry#register(TypeCodec) register new codecs}
    * will throw {@link UnsupportedOperationException}.
    */
+  @SuppressWarnings("ClassInitializationDeadlock")
   CodecRegistry DEFAULT =
       new DefaultCodecRegistry("default") {
         @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
@@ -370,6 +370,7 @@ public class GenericType<T> {
    *
    * @leaks-private-api
    */
+  @SuppressWarnings("InvalidBlockTag")
   @NonNull
   public TypeToken<T> __getToken() {
     return token;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
  * the domain name of the target instance. Then it performs a forward DNS lookup of the domain name;
  * the EC2 DNS does the private/public switch automatically based on location.
  */
+@SuppressWarnings("BanJNDI")
 public class Ec2MultiRegionAddressTranslator implements AddressTranslator {
 
   private static final Logger LOG = LoggerFactory.getLogger(Ec2MultiRegionAddressTranslator.class);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
@@ -61,8 +61,12 @@ public class SubnetAddressTranslator implements AddressTranslator {
             .getDefaultProfile()
             .getBoolean(ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES, false);
     this.subnetAddresses =
-        context.getConfig().getDefaultProfile().getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)
-            .entrySet().stream()
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)
+            .entrySet()
+            .stream()
             .map(
                 e -> {
                   // Quoted and/or containing forward slashes map keys in reference.conf are read to

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -410,8 +410,7 @@ public class ChannelFactory {
         ChannelPipeline pipeline = channel.pipeline();
         context
             .getSslHandlerFactory()
-            .map(f -> f.newSslHandler(channel, endPoint))
-            .map(h -> pipeline.addLast(SSL_HANDLER_NAME, h));
+            .ifPresent(f -> pipeline.addLast(SSL_HANDLER_NAME, f.newSslHandler(channel, endPoint)));
 
         // Only add meter handlers on the pipeline if metrics are enabled.
         SessionMetricUpdater sessionMetricUpdater = context.getMetricsFactory().getSessionUpdater();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultTraceEvent.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultTraceEvent.java
@@ -78,6 +78,7 @@ public class DefaultTraceEvent implements TraceEvent {
   }
 
   @Override
+  @SuppressWarnings("JavaUtilDate")
   public String toString() {
     return String.format("%s on %s[%s] at %s", activity, source, threadName, new Date(timestamp));
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -331,10 +331,6 @@ public class DefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy impleme
       this.newest = OptionalLong.empty();
     }
 
-    private NodeResponseRateSample(long oldestSample) {
-      this(oldestSample, nanoTime());
-    }
-
     private NodeResponseRateSample(long oldestSample, long newestSample) {
       this.oldest = oldestSample;
       this.newest = OptionalLong.of(newestSample);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -55,8 +55,8 @@ import org.slf4j.LoggerFactory;
 public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
   private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesTopologyMonitor.class);
 
-  private static final String SELECT_ROUTES_COLUMNS =
-      "SELECT host_id, address, port, tls_port, connection_id FROM %s";
+  private static final String SELECT_ROUTES_PREFIX =
+      "SELECT host_id, address, port, tls_port, connection_id FROM ";
 
   /** Disables result-set paging, matching the convention used by {@link DefaultTopologyMonitor}. */
   private static final int NO_PAGING = -1;
@@ -508,8 +508,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
     boolean hasConnectionIds = !connectionIds.isEmpty();
     boolean hasHostIds = eventHostIds != null && !eventHostIds.isEmpty();
 
-    StringBuilder stmt =
-        new StringBuilder(String.format(SELECT_ROUTES_COLUMNS, config.getTableName()));
+    StringBuilder stmt = new StringBuilder(SELECT_ROUTES_PREFIX).append(config.getTableName());
 
     if (hasConnectionIds) {
       // Prepared statements cannot be used here because AdminRequestHandler only supports

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTabletMap.java
@@ -33,11 +33,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Thread-safety notes: This class uses ConcurrentMap and ConcurrentSkipListSet underneath. It is
  * safe to have multiple threads accessing it. However, multiple modifications i.e. multiple calls
- * of {@link DefaultTabletMap#addTablet(CqlIdentifier, CqlIdentifier, Tablet) will race with each
+ * of {@link DefaultTabletMap#addTablet(CqlIdentifier, CqlIdentifier, Tablet)} will race with each
  * other. This may result in unexpected state of this structure when used in a vacuum. For example
- * it may end up containing overlapping tablet ranges.</p> <p>In actual use by the driver {@link
- * MetadataManager} solves this by running modifications sequentially. It schedules them on {@link
- * MetadataManager#adminExecutor}}'s thread.
+ * it may end up containing overlapping tablet ranges.
+ *
+ * <p>In actual use by the driver {@link MetadataManager} solves this by running modifications
+ * sequentially. It schedules them on the {@link MetadataManager#adminExecutor} thread.
  */
 @Beta
 public class DefaultTabletMap implements TabletMap {
@@ -209,7 +210,7 @@ public class DefaultTabletMap implements TabletMap {
      * firstToken} and unspecified other fields. Used for lookup of sorted collections of proper
      * {@link DefaultTablet}.
      *
-     * @param lastToken
+     * @param lastToken the upper bound of the tablet range
      * @return New {@link DefaultTablet} object
      */
     public static DefaultTablet malformedTablet(long lastToken) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/PartitionerFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/PartitionerFactory.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Returns correct Partitioner to use for given query, for example @code{CDCTokenFactory} for
+ * Returns correct Partitioner to use for given query, for example {@code CDCTokenFactory} for
  * queries to CDC log table.
  */
 public class PartitionerFactory {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ScriptBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ScriptBuilder.java
@@ -19,7 +19,6 @@ package com.datastax.oss.driver.internal.core.metadata.schema;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.Describable;
-import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import java.util.function.Consumer;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -42,7 +41,7 @@ public class ScriptBuilder {
 
   public ScriptBuilder append(String s) {
     if (pretty && isAtLineStart && indent > 0) {
-      builder.append(Strings.repeat(" ", indent * INDENT_SIZE));
+      builder.append(" ".repeat(indent * INDENT_SIZE));
     }
     isAtLineStart = false;
     builder.append(s);
@@ -65,7 +64,7 @@ public class ScriptBuilder {
   }
 
   public ScriptBuilder forceNewLine(int count) {
-    builder.append(Strings.repeat("\n", count));
+    builder.append("\n".repeat(count));
     isAtLineStart = true;
     return this;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RawColumn.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RawColumn.java
@@ -27,7 +27,6 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
-import com.datastax.oss.driver.shaded.guava.common.primitives.Ints;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,7 +127,7 @@ public class RawColumn implements Comparable<RawColumn> {
     // First, order by kind. Then order partition key and clustering columns by position. For
     // other kinds, order by column name.
     if (!this.kind.equals(that.kind)) {
-      return Ints.compare(rank(this.kind), rank(that.kind));
+      return Integer.compare(rank(this.kind), rank(that.kind));
     } else if (kind.equals(KIND_PARTITION_KEY) || kind.equals(KIND_CLUSTERING_COLUMN)) {
       return Integer.compare(this.position, that.position);
     } else {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/RuleBasedKeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/RuleBasedKeyspaceFilter.java
@@ -79,9 +79,9 @@ class RuleBasedKeyspaceFilter implements KeyspaceFilter {
           exactExcludes.add(name);
         }
       } else if ((matcher = REGEX_INCLUDE.matcher(spec)).matches()) {
-        compile(matcher.group(1)).map(regexIncludes::add);
+        compile(matcher.group(1)).ifPresent(regexIncludes::add);
       } else if ((matcher = REGEX_EXCLUDE.matcher(spec)).matches()) {
-        compile(matcher.group(1)).map(regexExcludes::add);
+        compile(matcher.group(1)).ifPresent(regexExcludes::add);
       } else {
         LOG.warn(
             "[{}] Error while parsing {}: invalid element '{}', skipping",

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/RandomTokenFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/RandomTokenFactory.java
@@ -43,8 +43,7 @@ public class RandomTokenFactory implements TokenFactory {
     prototype = createMessageDigest();
     boolean supportsClone;
     try {
-      prototype.clone();
-      supportsClone = true;
+      supportsClone = prototype.clone() instanceof MessageDigest;
     } catch (CloneNotSupportedException e) {
       supportsClone = false;
     }
@@ -104,7 +103,8 @@ public class RandomTokenFactory implements TokenFactory {
     if (supportsClone) {
       try {
         return (MessageDigest) prototype.clone();
-      } catch (CloneNotSupportedException ignored) {
+      } catch (CloneNotSupportedException e) {
+        return createMessageDigest();
       }
     }
     return createMessageDigest();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/TokenLong64.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/TokenLong64.java
@@ -18,7 +18,6 @@ package com.datastax.oss.driver.internal.core.metadata.token;
 
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
-import com.datastax.oss.driver.shaded.guava.common.primitives.Longs;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.jcip.annotations.Immutable;
 
@@ -57,6 +56,6 @@ public abstract class TokenLong64 implements Token {
     Preconditions.checkArgument(
         other instanceof TokenLong64, "Cannot compare with non-64-bit-integer token");
     TokenLong64 that = (TokenLong64) other;
-    return Longs.compare(this.value, that.value);
+    return Long.compare(this.value, that.value);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ssl/ReloadingKeyManagerFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ssl/ReloadingKeyManagerFactory.java
@@ -71,7 +71,7 @@ public class ReloadingKeyManagerFactory extends KeyManagerFactory implements Aut
    * @param keystorePassword the keystore password
    * @param reloadInterval the duration between reload attempts. Set to {@link Optional#empty()} to
    *     disable scheduled reloading.
-   * @return
+   * @return a reloading key manager factory backed by the given keystore
    */
   static ReloadingKeyManagerFactory create(
       Path keystorePath, String keystorePassword, Optional<Duration> reloadInterval)

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/OptionalCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/OptionalCodec.java
@@ -52,14 +52,14 @@ public class OptionalCodec<T> extends MappingCodec<T, Optional<T>> {
     return false;
   }
 
-  @Nullable
   @Override
   protected Optional<T> innerToOuter(@Nullable T value) {
-    return Optional.ofNullable(isAbsent(value) ? null : value);
+    return isAbsent(value) ? Optional.empty() : Optional.of(value);
   }
 
   @Nullable
   @Override
+  @SuppressWarnings("NullableOptional")
   protected T outerToInner(@Nullable Optional<T> value) {
     return value != null && value.isPresent() ? value.get() : null;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/enums/EnumOrdinalCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/enums/EnumOrdinalCodec.java
@@ -54,6 +54,7 @@ public class EnumOrdinalCodec<EnumT extends Enum<EnumT>> extends MappingCodec<In
 
   @Nullable
   @Override
+  @SuppressWarnings("EnumOrdinal")
   protected Integer outerToInner(@Nullable EnumT value) {
     return value == null ? null : value.ordinal();
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CodecRegistryConstants.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CodecRegistryConstants.java
@@ -19,6 +19,7 @@ package com.datastax.oss.driver.internal.core.type.codec.registry;
 
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
@@ -31,7 +32,12 @@ public class CodecRegistryConstants {
    * <p>This is exposed in case you want to call {@link
    * DefaultCodecRegistry#DefaultCodecRegistry(String, int, BiFunction, int, BiConsumer,
    * TypeCodec[])} but only customize the caching options.
+   *
+   * @deprecated use {@link #getPrimitiveCodecs()} instead. This array remains public for binary
+   *     compatibility and will be made non-public in a future release.
    */
+  @Deprecated
+  @SuppressWarnings("MutablePublicArray")
   public static final TypeCodec<?>[] PRIMITIVE_CODECS =
       new TypeCodec<?>[] {
         // Must be declared before AsciiCodec so it gets chosen when CQL type not available
@@ -57,4 +63,12 @@ public class CodecRegistryConstants {
         TypeCodecs.COUNTER,
         TypeCodecs.ASCII
       };
+
+  /**
+   * Returns the driver's default primitive codecs (map all primitive CQL types to their "natural"
+   * Java equivalent).
+   */
+  public static List<TypeCodec<?>> getPrimitiveCodecs() {
+    return List.of(PRIMITIVE_CODECS);
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/QueryPlan.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/collection/QueryPlan.java
@@ -52,6 +52,7 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public interface QueryPlan extends Queue<Node> {
 
+  @SuppressWarnings("ClassInitializationDeadlock")
   QueryPlan EMPTY = new EmptyQueryPlan();
 
   /**

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphSupportCheckerTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphSupportCheckerTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.dse.driver.DseTestDataProviders;
@@ -250,7 +250,7 @@ public class GraphSupportCheckerTest {
                 graphStatement, executionProfile, mock(InternalDriverContext.class));
 
     assertThat(inferredProtocol).isEqualTo(graphProtocol);
-    verifyZeroInteractions(executionProfile);
+    verifyNoInteractions(executionProfile);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
@@ -109,7 +109,7 @@ public class InsightsClientTest {
     OS os = new OS("linux", "1.2", "x64");
     CPUS cpus = new CPUS(8, "intel i7");
     Map<String, RuntimeAndCompileTimeVersions> javaDeps =
-        ImmutableMap.of("version", new RuntimeAndCompileTimeVersions("1.8.0", "1.8.0", false));
+        ImmutableMap.of("version", new RuntimeAndCompileTimeVersions("11.0.0", "11.0.0", false));
     Map<String, Map<String, RuntimeAndCompileTimeVersions>> runtimeInfo =
         ImmutableMap.of("java", javaDeps);
     InsightsPlatformInfo insightsPlatformInfo = new InsightsPlatformInfo(os, cpus, runtimeInfo);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/CompletionStageAssert.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/CompletionStageAssert.java
@@ -69,6 +69,7 @@ public class CompletionStageAssert<V>
     return isFailed(f -> {});
   }
 
+  @SuppressWarnings("EmptyCatch")
   public CompletionStageAssert<V> isCancelled() {
     boolean cancelled = false;
     try {
@@ -83,6 +84,7 @@ public class CompletionStageAssert<V>
     return this;
   }
 
+  @SuppressWarnings("EmptyCatch")
   public CompletionStageAssert<V> isNotCancelled() {
     boolean cancelled = false;
     try {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
@@ -73,8 +73,7 @@ public class ContactPointsTest {
     Set<EndPoint> endPoints =
         ContactPoints.merge(Collections.emptySet(), ImmutableList.of("127.0.0.1:9042"), true);
 
-    assertThat(endPoints)
-        .containsExactly(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042)));
+    assertThat(endPoints).containsExactly(new DefaultEndPoint(socketAddress("127.0.0.1", 9042)));
   }
 
   @Test
@@ -85,8 +84,8 @@ public class ContactPointsTest {
 
     assertThat(endPoints)
         .containsExactly(
-            new DefaultEndPoint(new InetSocketAddress("::1", 9042)),
-            new DefaultEndPoint(new InetSocketAddress("::2", 9042)));
+            new DefaultEndPoint(socketAddress("::1", 9042)),
+            new DefaultEndPoint(socketAddress("::2", 9042)));
   }
 
   @Test
@@ -139,26 +138,25 @@ public class ContactPointsTest {
   public void should_merge_programmatic_and_configuration() {
     Set<EndPoint> endPoints =
         ContactPoints.merge(
-            ImmutableSet.of(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042))),
+            ImmutableSet.of(new DefaultEndPoint(socketAddress("127.0.0.1", 9042))),
             ImmutableList.of("127.0.0.2:9042"),
             true);
 
     assertThat(endPoints)
         .containsOnly(
-            new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042)),
-            new DefaultEndPoint(new InetSocketAddress("127.0.0.2", 9042)));
+            new DefaultEndPoint(socketAddress("127.0.0.1", 9042)),
+            new DefaultEndPoint(socketAddress("127.0.0.2", 9042)));
   }
 
   @Test
   public void should_warn_if_duplicate_between_programmatic_and_configuration() {
     Set<EndPoint> endPoints =
         ContactPoints.merge(
-            ImmutableSet.of(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042))),
+            ImmutableSet.of(new DefaultEndPoint(socketAddress("127.0.0.1", 9042))),
             ImmutableList.of("127.0.0.1:9042"),
             true);
 
-    assertThat(endPoints)
-        .containsOnly(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042)));
+    assertThat(endPoints).containsOnly(new DefaultEndPoint(socketAddress("127.0.0.1", 9042)));
     assertLog(Level.WARN, "Duplicate contact point /127.0.0.1:9042");
   }
 
@@ -168,9 +166,31 @@ public class ContactPointsTest {
         ContactPoints.merge(
             Collections.emptySet(), ImmutableList.of("127.0.0.1:9042", "127.0.0.1:9042"), true);
 
-    assertThat(endPoints)
-        .containsOnly(new DefaultEndPoint(new InetSocketAddress("127.0.0.1", 9042)));
+    assertThat(endPoints).containsOnly(new DefaultEndPoint(socketAddress("127.0.0.1", 9042)));
     assertLog(Level.WARN, "Duplicate contact point /127.0.0.1:9042");
+  }
+
+  private static InetSocketAddress socketAddress(String host, int port) {
+    try {
+      switch (host) {
+        case "127.0.0.1":
+          return new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), port);
+        case "127.0.0.2":
+          return new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 2}), port);
+        case "::1":
+          return new InetSocketAddress(
+              InetAddress.getByAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+              port);
+        case "::2":
+          return new InetSocketAddress(
+              InetAddress.getByAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}),
+              port);
+        default:
+          return new InetSocketAddress(InetAddress.getByName(host), port);
+      }
+    } catch (UnknownHostException e) {
+      throw new AssertionError(e);
+    }
   }
 
   private void assertLog(Level level, String message) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
@@ -42,6 +42,7 @@ public class FixedHostNameAddressTranslatorTest {
         new FixedHostNameAddressTranslator(defaultDriverContext);
     InetSocketAddress address = new InetSocketAddress("192.0.2.5", 6061);
 
-    assertThat(translator.translate(address)).isEqualTo(new InetSocketAddress("myaddress", 6061));
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("myaddress", 6061));
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
@@ -122,7 +122,7 @@ public class MockChannelFactoryHelper {
 
     public Builder(ChannelFactory channelFactory) {
       assertThat(MockUtil.isMock(channelFactory)).as("expected a mock").isTrue();
-      verifyZeroInteractions(channelFactory);
+      verifyNoInteractions(channelFactory);
       this.channelFactory = channelFactory;
     }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/AccessibleByIdTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/AccessibleByIdTestBase.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -83,7 +83,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.setBytesUnsafe(FIELD0_ID, Bytes.fromHexString("0x00000001"));
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(FIELD0_ID)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -97,7 +97,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.setToNull(FIELD0_ID);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(FIELD0_ID)).isNull();
   }
 
@@ -144,7 +144,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.set(FIELD0_ID, "1", intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).encode("1", ProtocolVersion.DEFAULT);
     assertThat(t.getBytesUnsafe(FIELD0_ID)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
@@ -189,7 +189,7 @@ public abstract class AccessibleByIdTestBase<
     ByteBuffer bytes = t.getBytesUnsafe(FIELD0_ID);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(bytes).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -203,7 +203,7 @@ public abstract class AccessibleByIdTestBase<
     boolean isNull = t.isNull(FIELD0_ID);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(isNull).isTrue();
   }
 
@@ -253,7 +253,7 @@ public abstract class AccessibleByIdTestBase<
     String s = t.get(FIELD0_ID, intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).decode(any(ByteBuffer.class), eq(ProtocolVersion.DEFAULT));
     assertThat(s).isEqualTo("1");
   }
@@ -295,7 +295,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.setBytesUnsafe(FIELD0_NAME, Bytes.fromHexString("0x00000001"));
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(FIELD0_NAME)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -309,7 +309,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.setToNull(FIELD0_NAME);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(FIELD0_NAME)).isNull();
   }
 
@@ -356,7 +356,7 @@ public abstract class AccessibleByIdTestBase<
     t = t.set(FIELD0_NAME, "1", intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).encode("1", ProtocolVersion.DEFAULT);
     assertThat(t.getBytesUnsafe(FIELD0_NAME)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
@@ -401,7 +401,7 @@ public abstract class AccessibleByIdTestBase<
     ByteBuffer bytes = t.getBytesUnsafe(FIELD0_NAME);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(bytes).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -415,7 +415,7 @@ public abstract class AccessibleByIdTestBase<
     boolean isNull = t.isNull(FIELD0_NAME);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(isNull).isTrue();
   }
 
@@ -465,7 +465,7 @@ public abstract class AccessibleByIdTestBase<
     String s = t.get(FIELD0_NAME, intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).decode(any(ByteBuffer.class), eq(ProtocolVersion.DEFAULT));
     assertThat(s).isEqualTo("1");
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/AccessibleByIndexTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/AccessibleByIndexTestBase.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
@@ -121,7 +121,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     t = t.setBytesUnsafe(0, Bytes.fromHexString("0x00000001"));
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(0)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -135,7 +135,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     t = t.setToNull(0);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(t.getBytesUnsafe(0)).isNull();
   }
 
@@ -182,7 +182,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     t = t.set(0, "1", intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).encode("1", ProtocolVersion.DEFAULT);
     assertThat(t.getBytesUnsafe(0)).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
@@ -273,7 +273,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     ByteBuffer bytes = t.getBytesUnsafe(0);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(bytes).isEqualTo(Bytes.fromHexString("0x00000001"));
   }
 
@@ -287,7 +287,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     boolean isNull = t.isNull(0);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     assertThat(isNull).isTrue();
   }
 
@@ -337,7 +337,7 @@ public abstract class AccessibleByIndexTestBase<T extends GettableByIndex & Sett
     String s = t.get(0, intToStringCodec);
 
     // Then
-    verifyZeroInteractions(codecRegistry);
+    verifyNoInteractions(codecRegistry);
     verify(intToStringCodec).decode(any(ByteBuffer.class), eq(ProtocolVersion.DEFAULT));
     assertThat(s).isEqualTo("1");
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -389,9 +389,9 @@ public class MetadataManagerTest {
     CompletionStage<MetadataManager.RefreshSchemaResult> result2 =
         metadataManager.refreshSchema("bar", true, true);
 
-    // Now complete the agreement check - first refresh will fail at newInstance(),
-    // and onSchemaRefreshComplete should drain the queued second refresh
-    agreementFuture.complete(true);
+    // Now complete the agreement check on the admin event loop - first refresh will fail at
+    // newInstance(), and onSchemaRefreshComplete should drain the queued second refresh.
+    adminEventLoopGroup.next().execute(() -> agreementFuture.complete(true));
 
     // Then both requests should complete (not hang forever)
     waitForPendingAdminTasks(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -124,7 +124,7 @@ public class MockChannelPoolFactoryHelper {
 
     private Builder(ChannelPoolFactory channelPoolFactory) {
       assertThat(MockUtil.isMock(channelPoolFactory)).as("expected a mock").isTrue();
-      verifyZeroInteractions(channelPoolFactory);
+      verifyNoInteractions(channelPoolFactory);
       this.channelPoolFactory = channelPoolFactory;
     }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TupleCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TupleCodecTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
@@ -104,7 +104,7 @@ public class TupleCodecTest extends CodecTestBase<TupleValue> {
 
     verify(intCodec).encodePrimitive(1, ProtocolVersion.DEFAULT);
     // null values are handled directly in the tuple codec, without calling the child codec:
-    verifyZeroInteractions(doubleCodec);
+    verifyNoInteractions(doubleCodec);
     verify(textCodec).encode("a", ProtocolVersion.DEFAULT);
   }
 
@@ -122,7 +122,7 @@ public class TupleCodecTest extends CodecTestBase<TupleValue> {
     assertThat(tuple.getString(2)).isEqualTo("a");
 
     verify(intCodec).decodePrimitive(Bytes.fromHexString("0x00000001"), ProtocolVersion.DEFAULT);
-    verifyZeroInteractions(doubleCodec);
+    verifyNoInteractions(doubleCodec);
     verify(textCodec).decode(Bytes.fromHexString("0x61"), ProtocolVersion.DEFAULT);
   }
 
@@ -141,9 +141,9 @@ public class TupleCodecTest extends CodecTestBase<TupleValue> {
     assertThat(tuple.isNull(1)).isTrue();
     assertThat(tuple.isNull(2)).isTrue();
 
-    verifyZeroInteractions(intCodec);
-    verifyZeroInteractions(doubleCodec);
-    verifyZeroInteractions(textCodec);
+    verifyNoInteractions(intCodec);
+    verifyNoInteractions(doubleCodec);
+    verifyNoInteractions(textCodec);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodecTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -113,7 +113,7 @@ public class UdtCodecTest extends CodecTestBase<UdtValue> {
 
     verify(intCodec).encodePrimitive(1, ProtocolVersion.DEFAULT);
     // null values are handled directly in the udt codec, without calling the child codec:
-    verifyZeroInteractions(doubleCodec);
+    verifyNoInteractions(doubleCodec);
     verify(textCodec).encode("a", ProtocolVersion.DEFAULT);
   }
 
@@ -131,7 +131,7 @@ public class UdtCodecTest extends CodecTestBase<UdtValue> {
     assertThat(udt.getString(2)).isEqualTo("a");
 
     verify(intCodec).decodePrimitive(Bytes.fromHexString("0x00000001"), ProtocolVersion.DEFAULT);
-    verifyZeroInteractions(doubleCodec);
+    verifyNoInteractions(doubleCodec);
     verify(textCodec).decode(Bytes.fromHexString("0x61"), ProtocolVersion.DEFAULT);
   }
 
@@ -165,9 +165,9 @@ public class UdtCodecTest extends CodecTestBase<UdtValue> {
     assertThat(udt.isNull(1)).isTrue();
     assertThat(udt.isNull(2)).isTrue();
 
-    verifyZeroInteractions(intCodec);
-    verifyZeroInteractions(doubleCodec);
-    verifyZeroInteractions(textCodec);
+    verifyNoInteractions(intCodec);
+    verifyNoInteractions(doubleCodec);
+    verifyNoInteractions(textCodec);
   }
 
   @Test
@@ -178,9 +178,9 @@ public class UdtCodecTest extends CodecTestBase<UdtValue> {
     assertThat(udt.isNull(1)).isTrue();
     assertThat(udt.isNull(2)).isTrue();
 
-    verifyZeroInteractions(intCodec);
-    verifyZeroInteractions(doubleCodec);
-    verifyZeroInteractions(textCodec);
+    verifyNoInteractions(intCodec);
+    verifyNoInteractions(doubleCodec);
+    verifyNoInteractions(textCodec);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTest.java
@@ -22,7 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.data.TupleValue;
@@ -80,7 +81,7 @@ public class CachingCodecRegistryTest {
     Class<?> javaClass = (Class<?>) javaType.__getToken().getType();
     assertThat(registry.codecFor(cqlType, javaClass)).isSameAs(codec);
     // Primitive mappings never hit the cache
-    verifyZeroInteractions(mockCache);
+    verifyNoInteractions(mockCache);
   }
 
   @Test
@@ -90,7 +91,7 @@ public class CachingCodecRegistryTest {
   public void should_find_primitive_codecs_for_value(Object value, TypeCodec<?> codec) {
     TestCachingCodecRegistry registry = new TestCachingCodecRegistry(mockCache);
     assertThat(registry.codecFor(value)).isEqualTo(codec);
-    verifyZeroInteractions(mockCache);
+    verifyNoInteractions(mockCache);
   }
 
   @Test
@@ -101,7 +102,7 @@ public class CachingCodecRegistryTest {
       DataType cqlType, Object value, TypeCodec<?> codec) {
     TestCachingCodecRegistry registry = new TestCachingCodecRegistry(mockCache);
     assertThat(registry.codecFor(cqlType, value)).isEqualTo(codec);
-    verifyZeroInteractions(mockCache);
+    verifyNoInteractions(mockCache);
   }
 
   @Test
@@ -123,7 +124,7 @@ public class CachingCodecRegistryTest {
     assertThat(registry.codecFor(DataTypes.INT)).isSameAs(TypeCodecs.INT);
     assertThat(registry.codecFor("123")).isSameAs(TypeCodecs.TEXT);
 
-    verifyZeroInteractions(mockCache);
+    verifyNoMoreInteractions(mockCache);
   }
 
   @Test
@@ -144,7 +145,7 @@ public class CachingCodecRegistryTest {
     // The search by CQL type only still returns the built-in codec
     assertThat(registry.codecFor(DataTypes.TEXT)).isSameAs(TypeCodecs.TEXT);
 
-    verifyZeroInteractions(mockCache);
+    verifyNoMoreInteractions(mockCache);
   }
 
   @Test
@@ -521,7 +522,7 @@ public class CachingCodecRegistryTest {
     assertThat(registry.codecFor(DataTypes.INT)).isSameAs(TypeCodecs.INT);
     assertThat(registry.codecFor("123")).isSameAs(TypeCodecs.TEXT);
 
-    verifyZeroInteractions(mockCache);
+    verifyNoMoreInteractions(mockCache);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/util/VIntCodingTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/util/VIntCodingTest.java
@@ -41,7 +41,7 @@ public class VIntCodingTest {
       -1,
       1
     };
-  };
+  }
 
   private static final long[] LONGS =
       new long[] {

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -116,6 +116,26 @@
               <windowtitle>Java driver for Scylla and Apache Cassandra(R) ${project.version} API</windowtitle>
               <additionalDependencies>
                 <additionalDependency>
+                  <groupId>com.github.stephenc.jcip</groupId>
+                  <artifactId>jcip-annotations</artifactId>
+                  <version>1.0-1</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>com.github.spotbugs</groupId>
+                  <artifactId>spotbugs-annotations</artifactId>
+                  <version>4.9.8</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>com.esri.geometry</groupId>
+                  <artifactId>esri-geometry-api</artifactId>
+                  <version>${esri.version}</version>
+                </additionalDependency>
+                <additionalDependency>
                   <groupId>at.yawk.lz4</groupId>
                   <artifactId>lz4-java</artifactId>
                   <version>${lz4.version}</version>
@@ -134,6 +154,11 @@
                   <groupId>org.apache.tinkerpop</groupId>
                   <artifactId>tinkergraph-gremlin</artifactId>
                   <version>${tinkerpop.version}</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>org.javatuples</groupId>
+                  <artifactId>javatuples</artifactId>
+                  <version>1.2</version>
                 </additionalDependency>
               </additionalDependencies>
             </configuration>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,6 +33,9 @@
   <artifactId>java-driver-examples</artifactId>
   <name>Java driver for Scylla and Apache Cassandra(R) - examples.</name>
   <description>A collection of examples to demonstrate Java Driver for Scylla and Apache Cassandra(R).</description>
+  <properties>
+    <api.plumber.skip>true</api.plumber.skip>
+  </properties>
   <dependencies>
     <!-- driver dependencies -->
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>at.favre.lib</groupId>
       <artifactId>bcrypt</artifactId>
-      <version>0.8.0</version>
+      <version>0.10.2</version>
     </dependency>
     <!-- Reactor (reactive framework) -->
     <dependency>
@@ -148,8 +148,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <annotationProcessorPaths>
             <path>
               <groupId>com.scylladb</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -155,6 +155,11 @@
           <target>11</target>
           <annotationProcessorPaths>
             <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.31.0</version>
+            </path>
+            <path>
               <groupId>com.scylladb</groupId>
               <artifactId>java-driver-mapper-processor</artifactId>
               <version>${project.version}</version>

--- a/examples/src/main/java/com/datastax/oss/driver/examples/paging/ForwardPagingRestUi.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/paging/ForwardPagingRestUi.java
@@ -119,7 +119,7 @@ public class ForwardPagingRestUi {
         int videoid = i * 100 + j;
         session.execute(
             prepare.bind(
-                i, "user " + i, Instant.ofEpochMilli(j * 100000), videoid, "video " + videoid));
+                i, "user " + i, Instant.ofEpochMilli(j * 100000L), videoid, "video " + videoid));
       }
     }
   }

--- a/examples/src/main/java/com/datastax/oss/driver/examples/paging/RandomPagingRestUi.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/paging/RandomPagingRestUi.java
@@ -129,7 +129,7 @@ public class RandomPagingRestUi {
         int videoid = i * 100 + j;
         session.execute(
             prepare.bind(
-                i, "user " + i, Instant.ofEpochMilli(j * 100000), videoid, "video " + videoid));
+                i, "user " + i, Instant.ofEpochMilli(j * 100000L), videoid, "video " + videoid));
       }
     }
   }

--- a/faq/README.md
+++ b/faq/README.md
@@ -106,7 +106,7 @@ available.
 
 ### I want to set a date on a bound statement, where did `setTimestamp()` go?
 
-The driver now uses Java 8's improved date and time API. CQL type `timestamp` is mapped to
+The driver now uses the JDK's improved date and time API. CQL type `timestamp` is mapped to
 `java.time.Instant`, and the corresponding getter and setter are `getInstant` and `setInstant`.
 
 See [Temporal types](../manual/core/temporal_types/) for more details.

--- a/guava-shaded/pom.xml
+++ b/guava-shaded/pom.xml
@@ -58,32 +58,6 @@
   <build>
     <plugins>
       <plugin>
-        <!--
-          Do not attempt to recompile the module if we are not running JVM 1.8.
-          Having additional Java source files and having to shade Guava will break
-          in CI environment, when we run 'mvn verify' on newer JVM and assume that
-          all classes have been compiled with JVM 1.8.
-        -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.12</version>
-        <executions>
-          <execution>
-            <id>regex-property</id>
-            <goals>
-              <goal>regex-property</goal>
-            </goals>
-            <configuration>
-              <name>maven.main.skip</name>
-              <value>${java.version}</value>
-              <regex>^(?!1.8).+</regex>
-              <replacement>true</replacement>
-              <failIfNoMatch>false</failIfNoMatch>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -159,6 +133,7 @@
                   <artifactId>java-driver-guava-shaded</artifactId>
                   <version>${project.version}</version>
                   <type>jar</type>
+                  <excludes>**/module-info.class</excludes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/guava-shaded/src/assembly/shaded-jar.xml
+++ b/guava-shaded/src/assembly/shaded-jar.xml
@@ -38,6 +38,7 @@
       <directory>${project.build.outputDirectory}</directory>
       <excludes>
         <exclude>META-INF/maven/com.scylladb/java-driver-guava-shaded/pom.xml</exclude>
+        <exclude>**/module-info.class</exclude>
       </excludes>
       <outputDirectory/>
     </fileSet>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -232,6 +232,42 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <compilerArg>-processor</compilerArg>
+            <compilerArg>com.datastax.oss.driver.internal.mapper.processor.MapperProcessor,com.datastax.oss.driver.internal.gremlin.PatchedGremlinDslProcessor</compilerArg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.31.0</version>
+            </path>
+            <path>
+              <groupId>com.scylladb</groupId>
+              <artifactId>java-driver-test-infra</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
+              <groupId>com.scylladb</groupId>
+              <artifactId>java-driver-mapper-processor</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
+              <groupId>com.scylladb</groupId>
+              <artifactId>java-driver-mapper-runtime</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
+              <groupId>org.apache.tinkerpop</groupId>
+              <artifactId>gremlin-core</artifactId>
+              <version>${tinkerpop.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/config/DriverExecutionProfileReloadIT.java
@@ -125,8 +125,8 @@ public class DriverExecutionProfileReloadIT {
 
       // Bump up request timeout to 10 seconds and trigger a manual reload.
       configSource.set("basic.request.timeout = 10s");
-      session.getContext().getConfigLoader().reload();
-      waitForConfigChange(session, 500, TimeUnit.MILLISECONDS);
+      waitForConfigChange(
+          session, () -> session.getContext().getConfigLoader().reload(), 3, TimeUnit.SECONDS);
 
       // Execute again, should not timeout.
       session.execute(query);
@@ -217,11 +217,17 @@ public class DriverExecutionProfileReloadIT {
   }
 
   private void waitForConfigChange(CqlSession session, long timeout, TimeUnit unit) {
+    waitForConfigChange(session, () -> {}, timeout, unit);
+  }
+
+  private void waitForConfigChange(
+      CqlSession session, Runnable trigger, long timeout, TimeUnit unit) {
     CountDownLatch latch = new CountDownLatch(1);
     ((InternalDriverContext) session.getContext())
         .getEventBus()
         .register(ConfigChangeEvent.class, (e) -> latch.countDown());
     try {
+      trigger.run();
       boolean success = latch.await(timeout, unit);
       assertThat(success).isTrue();
     } catch (InterruptedException e) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeStateIT.java
@@ -81,12 +81,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
 import org.mockito.InOrder;
-import org.mockito.junit.MockitoJUnitRunner;
 
 @Category(ParallelizableTests.class)
-@RunWith(MockitoJUnitRunner.class)
 public class NodeStateIT {
 
   private SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
@@ -213,10 +210,13 @@ public class NodeStateIT {
     simulacron.cluster().closeConnection(report.getConnections().get(0), CloseType.DISCONNECT);
 
     await()
-        .alias("Reconnection started")
+        .alias("Regular node stayed up after one connection closed")
         .pollInterval(500, TimeUnit.MILLISECONDS)
         .untilAsserted(
-            () -> assertThat(metadataRegularNode).isUp().hasOpenConnections(1).isReconnecting());
+            () -> {
+              assertThat(metadataRegularNode).isUp();
+              assertThat(metadataRegularNode.getOpenConnections()).isBetween(1, 2);
+            });
     inOrder.verify(nodeStateListener, never()).onDown(metadataRegularNode);
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ListenersIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ListenersIT.java
@@ -42,19 +42,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 @Category(ParallelizableTests.class)
-@RunWith(MockitoJUnitRunner.class)
 public class ListenersIT {
 
   @ClassRule
@@ -70,6 +70,18 @@ public class ListenersIT {
 
   @Captor private ArgumentCaptor<Node> nodeCaptor1;
   @Captor private ArgumentCaptor<Node> nodeCaptor2;
+
+  private AutoCloseable mocks;
+
+  @Before
+  public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void teardown() throws Exception {
+    mocks.close();
+  }
 
   @Test
   @Ignore(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ssl/DefaultSslEngineFactoryIT.java
@@ -117,7 +117,7 @@ public class DefaultSslEngineFactoryIT {
       countNoLookups++;
       return super.hostNoLookup(addr);
     }
-  };
+  }
 
   @Test
   public void should_respect_config_for_san_resolution() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/tracker/RequestLoggerIT.java
@@ -59,16 +59,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.verification.Timeout;
 import org.slf4j.LoggerFactory;
 
-@RunWith(MockitoJUnitRunner.class)
 @Category(ParallelizableTests.class)
 public class RequestLoggerIT {
   private static final Pattern LOG_PREFIX_PER_REQUEST = Pattern.compile("\\[s\\d*\\|\\d*]");
@@ -192,9 +190,11 @@ public class RequestLoggerIT {
   @Mock private Appender<ILoggingEvent> appender;
   private Logger logger;
   private Level oldLevel;
+  private AutoCloseable mocks;
 
   @Before
   public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
     logger = (Logger) LoggerFactory.getLogger(RequestLogger.class);
     oldLevel = logger.getLevel();
     logger.setLevel(Level.INFO);
@@ -202,9 +202,14 @@ public class RequestLoggerIT {
   }
 
   @After
-  public void teardown() {
-    logger.detachAppender(appender);
-    logger.setLevel(oldLevel);
+  public void teardown() throws Exception {
+    if (logger != null) {
+      logger.detachAppender(appender);
+      logger.setLevel(oldLevel);
+    }
+    if (mocks != null) {
+      mocks.close();
+    }
   }
 
   @Test

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -185,7 +185,7 @@ datastax-java-driver {
 
 DNS is resolved at connection time (not at route discovery time). The driver delegates to
 `InetAddress.getByName()`, which is a blocking call that uses the JVM's built-in DNS cache
-(30 s default TTL in Java 8+). Because this runs on Netty I/O threads, slow or unresponsive
+(30 s default TTL in the JDK). Because this runs on Netty I/O threads, slow or unresponsive
 DNS can block connection establishment and impact driver throughput. To mitigate this, configure
 the JVM DNS cache TTL via the `networkaddress.cache.ttl` security property (e.g. in
 `$JAVA_HOME/conf/security/java.security` or programmatically with

--- a/manual/core/async/README.md
+++ b/manual/core/async/README.md
@@ -21,7 +21,7 @@ under the License.
 
 ### Quick overview
 
-Async driver methods return Java 8's [CompletionStage].
+Async driver methods return the JDK's [CompletionStage].
 
 * don't call synchronous methods from asynchronous callbacks (the driver detects that and throws).
 * callbacks execute on I/O threads: consider providing your own executor for expensive computations.
@@ -224,6 +224,6 @@ even when iterating through the results of a request. `session.executeAsync` ret
 This greatly simplifies asynchronous paging; see the [paging](../paging/#asynchronous-paging)
 documentation for more details and an example. 
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
 
 [AsyncResultSet]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html

--- a/manual/core/custom_codecs/README.md
+++ b/manual/core/custom_codecs/README.md
@@ -698,17 +698,17 @@ private static String formatRow(Row row) {
 [MappingCodec]:     https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/type/codec/MappingCodec.html
 [SessionBuilder.addTypeCodecs]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/session/SessionBuilder.html#addTypeCodecs-com.datastax.oss.driver.api.core.type.codec.TypeCodec...-
 
-[Enums]: https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html
-[Enum.name()]: https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html#name--
-[Enum.ordinal()]: https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html#ordinal--
-[java.nio.ByteBuffer]: https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html
-[java.util.List]: https://docs.oracle.com/javase/8/docs/api/java/util/List.html
-[java.util.Optional]: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
-[Optional.empty()]: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#empty--
-[java.time.Instant]: https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html
-[java.time.ZonedDateTime]: https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html
-[java.time.LocalDateTime]: https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html
-[java.time.ZoneId]: https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html
+[Enums]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Enum.html
+[Enum.name()]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Enum.html#name--
+[Enum.ordinal()]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Enum.html#ordinal--
+[java.nio.ByteBuffer]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/ByteBuffer.html
+[java.util.List]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/List.html
+[java.util.Optional]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html
+[Optional.empty()]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html#empty--
+[java.time.Instant]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html
+[java.time.ZonedDateTime]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZonedDateTime.html
+[java.time.LocalDateTime]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/LocalDateTime.html
+[java.time.ZoneId]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
 
 [ExtraTypeCodecs]:                           https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html
 [ExtraTypeCodecs.BLOB_TO_ARRAY]:             https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.html#BLOB_TO_ARRAY

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -134,7 +134,7 @@ $ find . -type f
 ##### Project descriptor
 
 `pom.xml` is the [Project Object Model][maven_pom] that describes your application. We declare the
-dependencies, and tell Maven that we're going to use Java 8:
+dependencies, and tell Maven that we're going to use Java 11:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -165,8 +165,8 @@ dependencies, and tell Maven that we're going to use Java 8:
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
     </plugins>
@@ -281,7 +281,7 @@ version '1.0.0-SNAPSHOT'
 
 apply plugin: 'java'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 
 repositories {
     mavenCentral()

--- a/manual/core/metadata/schema/README.md
+++ b/manual/core/metadata/schema/README.md
@@ -352,4 +352,4 @@ take a look at the [Performance](../../performance/#schema-updates) page for a f
 [DseAggregateMetadata]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadata.html
 
 [JAVA-750]: https://datastax-oss.atlassian.net/browse/JAVA-750
-[java.util.regex.Pattern]: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+[java.util.regex.Pattern]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html

--- a/manual/core/paging/README.md
+++ b/manual/core/paging/README.md
@@ -279,6 +279,6 @@ and offset paging.
 [OffsetPager]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/paging/OffsetPager.html
 [PagingState]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/PagingState.html
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
 
 [driver examples]: https://github.com/datastax/java-driver/tree/4.x/examples/src/main/java/com/datastax/oss/driver/examples/paging

--- a/manual/mapper/config/README.md
+++ b/manual/mapper/config/README.md
@@ -52,8 +52,8 @@ configuration (make sure you use version 3.5 or higher):
       <artifactId>maven-compiler-plugin</artifactId>
       <version>3.8.1</version>
       <configuration>
-        <source>1.8</source> <!-- (or higher) -->
-        <target>1.8</target> <!-- (or higher) -->
+        <source>11</source> <!-- (or higher) -->
+        <target>11</target> <!-- (or higher) -->
         <annotationProcessorPaths>
           <path>
             <groupId>com.scylladb</groupId>
@@ -65,7 +65,7 @@ configuration (make sure you use version 3.5 or higher):
           <path>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.26</version>
+            <version>2.0.18</version>
           </path>
         </annotationProcessorPaths>
       </configuration>

--- a/manual/mapper/daos/delete/README.md
+++ b/manual/mapper/daos/delete/README.md
@@ -181,5 +181,5 @@ entity class and the [naming strategy](../../entities/#naming-strategy)).
 [ReactiveResultSet]:      https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
 
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/getentity/README.md
+++ b/manual/mapper/daos/getentity/README.md
@@ -159,7 +159,6 @@ If the return type doesn't match the parameter type (for example [PagingIterable
 [Row]:                       https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/Row.html
 [UdtValue]:                  https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/data/UdtValue.html
 
-[Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
-
+[Stream]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html
 
 

--- a/manual/mapper/daos/increment/README.md
+++ b/manual/mapper/daos/increment/README.md
@@ -101,5 +101,5 @@ entity class and the naming convention).
 [@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
 [@CqlName]:             https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
 
-[CompletionStage]:   https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
+[CompletionStage]:   https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/insert/README.md
+++ b/manual/mapper/daos/insert/README.md
@@ -135,6 +135,6 @@ entity class and the [naming strategy](../../entities/#naming-strategy)).
 [BoundStatement]:               https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/BoundStatement.html
 [ReactiveResultSet]:            https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
-[Optional]: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html
+[Optional]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html

--- a/manual/mapper/daos/query/README.md
+++ b/manual/mapper/daos/query/README.md
@@ -145,7 +145,7 @@ Then:
 [ReactiveResultSet]:         https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
 [MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
-[Optional]: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
-[Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html
+[Optional]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html
+[Stream]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html

--- a/manual/mapper/daos/select/README.md
+++ b/manual/mapper/daos/select/README.md
@@ -194,7 +194,7 @@ entity class and the [naming strategy](../../entities/#naming-strategy)).
 [PagingIterable.spliterator]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/PagingIterable.html#spliterator--
 [MappedReactiveResultSet]:   https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/mapper/reactive/MappedReactiveResultSet.html
 
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
-[Optional]: https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html
-[Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
+[CompletionStage]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html
+[Optional]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html
+[Stream]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html

--- a/manual/mapper/daos/update/README.md
+++ b/manual/mapper/daos/update/README.md
@@ -166,9 +166,9 @@ entity class and the naming convention).
 [@Update]:          https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/Update.html
 
 [AsyncResultSet]:       https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[Boolean]:              https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/Boolean.html
-[CompletionStage]:      https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]:    https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
+[Boolean]:              https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Boolean.html
+[CompletionStage]:      https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html
+[CompletableFuture]:    https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html
 [ResultSet]:            https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/ResultSet.html
 [BoundStatement]:       https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/BoundStatement.html
 [ReactiveResultSet]:    https://docs.datastax.com/en/drivers/java/4.17/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
@@ -20,7 +20,6 @@ package com.datastax.oss.driver.internal.mapper.processor;
 import com.datastax.oss.driver.api.mapper.annotations.Dao;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
-import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.datastax.oss.driver.shaded.guava.common.base.Throwables;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.lang.annotation.Annotation;
@@ -167,7 +166,7 @@ public class MapperProcessor extends AbstractProcessor {
     if (amountSpec != null) {
       try {
         int amount = Integer.parseInt(amountSpec);
-        return Strings.repeat(tabs ? "\t" : " ", amount);
+        return (tabs ? "\t" : " ").repeat(amount);
       } catch (NumberFormatException e) {
         messager.warn(
             "Could not parse %s: expected a number, got '%s'. Defaulting to %s.",

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
@@ -92,7 +92,7 @@ public class MapperProcessor extends AbstractProcessor {
         roundEnvironment, Dao.class, ElementKind.INTERFACE, generatorFactory::newDaoImplementation);
     processAnnotatedTypes(
         roundEnvironment, Mapper.class, ElementKind.INTERFACE, generatorFactory::newMapper);
-    return true;
+    return false;
   }
 
   protected ProcessorContext buildContext(

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeKind.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeKind.java
@@ -40,7 +40,7 @@ public interface DaoReturnTypeKind {
    * @param helperFieldName the name of the helper for entity conversions (might not get used for
    *     certain kinds, in that case it's ok to pass null).
    * @param methodElement the return type of the method (in case the result must be cast).
-   * @param typeParameters
+   * @param typeParameters the type parameters declared on the DAO method.
    */
   void addExecuteStatement(
       CodeBlock.Builder methodBuilder,

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/Classes.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/Classes.java
@@ -106,7 +106,7 @@ public class Classes {
   }
 
   /**
-   * Whether a type mirror is a parameterized Java 8 future ({@code CompletionStage or
+   * Whether a type mirror is a parameterized future such as {@code CompletionStage} or {@code
    * CompletableFuture}.
    */
   public boolean isFuture(DeclaredType declaredType) {

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
@@ -47,7 +47,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method can operate either on an entity instance, or on a primary key (partition key +
  * clustering columns).
@@ -77,7 +77,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -127,7 +127,7 @@ import java.util.function.UnaryOperator;
  * practical purpose for that since those queries always return {@code wasApplied = true} and an
  * empty result set.
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/GetEntity.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/GetEntity.java
@@ -55,7 +55,7 @@ import java.lang.annotation.Target;
  * <p>It does not perform a query. Instead, those methods are intended for cases where you already
  * have a query result, and just need the conversion logic.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method must have a single parameter. The following types are allowed:
  *
@@ -69,7 +69,7 @@ import java.lang.annotation.Target;
  * The data must match the target entity: the generated code will try to extract every mapped
  * property, and fail if one is missing.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
@@ -58,7 +58,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The entity class must be specified with {@link #entityClass()}.
  *
@@ -92,12 +92,12 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>The method can return {@code void}, a void {@link CompletionStage} or {@link
  * CompletableFuture}, or a {@link ReactiveResultSet}.
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
@@ -48,7 +48,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The first parameter must be the entity to insert.
  *
@@ -66,7 +66,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -122,7 +122,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
@@ -55,7 +55,7 @@ import java.util.function.UnaryOperator;
  *
  * This is the equivalent of what was called "accessor methods" in the driver 3 mapper.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The query string provided in {@link #value()} will typically contain CQL placeholders. The
  * method's parameters must match those placeholders: same name and a compatible Java type.
@@ -70,7 +70,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -100,7 +100,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * To avoid hard-coding the keyspace and table name, the query string supports 3 additional
  * placeholders: {@code ${keyspaceId}}, {@code ${tableId}} and {@code ${qualifiedTableId}}. They get

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
@@ -48,7 +48,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * If {@link #customWhereClause()} is empty, the mapper defaults to a selection by primary key
  * (partition key + clustering columns). The method's parameters must match the types of the primary
@@ -87,7 +87,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>In all cases, the method can return:
  *
@@ -132,7 +132,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
@@ -51,7 +51,7 @@ import java.lang.annotation.Target;
  * It does not perform a query. Instead, those methods are intended for cases where you will execute
  * the query yourself, and just need the conversion logic.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method must have two parameters: one is the entity instance, the other must be a subtype of
  * {@link SettableByName} (the most likely candidates are {@link BoundStatement}, {@link
@@ -60,7 +60,7 @@ import java.lang.annotation.Target;
  *
  * <p>The order of the parameters does not matter.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can either be void, or return the exact same type as its settable parameter.
  *

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
@@ -49,7 +49,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * <p>The first parameter must be an entity instance. All of its non-PK properties will be
  * interpreted as values to update.
@@ -88,7 +88,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>The method can return:
  *
@@ -135,7 +135,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerMetricUpdater.java
+++ b/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerMetricUpdater.java
@@ -55,14 +55,14 @@ public abstract class MicrometerMetricUpdater<MetricT> extends AbstractMetricUpd
   @Override
   public void incrementCounter(MetricT metric, @Nullable String profileName, long amount) {
     if (isEnabled(metric, profileName)) {
-      getOrCreateCounterFor(metric).increment(amount);
+      getOrCreateCounterFor(metric).increment((double) amount);
     }
   }
 
   @Override
   public void updateHistogram(MetricT metric, @Nullable String profileName, long value) {
     if (isEnabled(metric, profileName)) {
-      getOrCreateDistributionSummaryFor(metric).record(value);
+      getOrCreateDistributionSummaryFor(metric).record((double) value);
     }
   }
 
@@ -70,7 +70,7 @@ public abstract class MicrometerMetricUpdater<MetricT> extends AbstractMetricUpd
   public void markMeter(MetricT metric, @Nullable String profileName, long amount) {
     if (isEnabled(metric, profileName)) {
       // There is no meter type in Micrometer, so use a counter
-      getOrCreateCounterFor(metric).increment(amount);
+      getOrCreateCounterFor(metric).increment((double) amount);
     }
   }
 

--- a/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
+++ b/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
@@ -132,6 +132,9 @@ public class MicrometerSessionMetricUpdaterTest {
     when(context.getMetricIdGenerator()).thenReturn(generator);
     when(profile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
         .thenReturn(Duration.ofHours(1));
+    when(profile.getDuration(lowest)).thenReturn(Duration.ofMillis(10));
+    when(profile.getDuration(highest)).thenReturn(Duration.ofSeconds(1));
+    when(profile.getInt(digits)).thenReturn(5);
     when(profile.isDefined(sla)).thenReturn(false);
     when(profile.getDurationList(sla))
         .thenReturn(Arrays.asList(Duration.ofMillis(100), Duration.ofMillis(500)));

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -33,6 +33,9 @@
   <artifactId>java-driver-osgi-tests</artifactId>
   <packaging>jar</packaging>
   <name>Java driver for Scylla and Apache Cassandra(R) - OSGi tests</name>
+  <properties>
+    <api.plumber.skip>true</api.plumber.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.scylladb</groupId>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -166,6 +166,23 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>com.scylladb</groupId>
+              <artifactId>java-driver-mapper-processor</artifactId>
+              <version>${project.version}</version>
+            </path>
+            <path>
+              <groupId>com.scylladb</groupId>
+              <artifactId>java-driver-mapper-runtime</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.servicemix.tooling</groupId>
         <artifactId>depends-maven-plugin</artifactId>
         <version>1.5.0</version>

--- a/performance/duration-test.yaml
+++ b/performance/duration-test.yaml
@@ -47,7 +47,7 @@ ensemble:
     configuration_manager:
       - name: ctool
         properties:
-          java.version: openjdk8
+          java.version: openjdk11
           product.install.type: tarball
           product.type: {{server_type}}
           product.version: {{server_version}}
@@ -69,7 +69,7 @@ ensemble:
     configuration_manager:
       - name: ctool
         properties:
-          java.version: openjdk8
+          java.version: openjdk11
           install.maven: true
       - name: java_driver
         properties:

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <release.autopublish>false</release.autopublish>
     <pushChanges>false</pushChanges>
     <mockitoopens.argline/>
+    <api.plumber.skip>false</api.plumber.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -717,8 +718,7 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>11</release>
           <compilerArgs combine.children="override">
             <compilerArg>-XDcompilePolicy=simple</compilerArg>
             <compilerArg>--should-stop=ifError=FLOW</compilerArg>
@@ -879,6 +879,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </goals>
             <phase>process-classes</phase>
             <configuration>
+              <skip>${api.plumber.skip}</skip>
               <doclet>com.datastax.oss.doclet.ApiPlumber</doclet>
               <docletArtifact>
                 <groupId>com.datastax.oss</groupId>
@@ -1081,6 +1082,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
+    </profile>
+    <profile>
+      <!-- ApiPlumber uses the legacy com.sun.javadoc doclet API removed in JDK 13. -->
+      <id>skip-api-plumber-on-jdk-13</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <api.plumber.skip>true</api.plumber.skip>
+      </properties>
     </profile>
     <profile>
       <!-- workarounds for running tests with JDK14 -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <config.version>1.4.5</config.version>
+    <config.version>1.4.8</config.version>
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.2.2</hdrhistogram.version>
-    <metrics.version>4.2.37</metrics.version>
+    <metrics.version>4.2.38</metrics.version>
     <netty.version>4.1.133.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
@@ -66,26 +66,26 @@
     -->
     <tinkerpop.version>3.5.6</tinkerpop.version>
     <!-- when changing version also update version in LICENSE_binary  -->
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <!-- when changing version also update version in LICENSE_binary  -->
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <json.version>20250517</json.version>
-    <jackson.version>2.21.1</jackson.version>
-    <jackson-databind.version>2.20.0</jackson-databind.version>
+    <jackson.version>2.21.3</jackson.version>
+    <jackson-databind.version>2.21.3</jackson-databind.version>
     <legacy-jackson.version>1.9.12</legacy-jackson.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.10.8</snappy.version>
-    <lz4.version>1.10.1</lz4.version>
+    <lz4.version>1.11.0</lz4.version>
     <!-- test dependencies -->
     <assertj.version>3.27.7</assertj.version>
-    <commons-exec.version>1.5.0</commons-exec.version>
+    <commons-exec.version>1.6.0</commons-exec.version>
     <junit.version>4.13.2</junit.version>
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.5.32</logback.version>
     <osgi.version>6.0.0</osgi.version>
     <felix.version>7.0.5</felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>
     <pax-url.version>2.6.17</pax-url.version>
-    <simulacron.version>0.13.0.0</simulacron.version>
+    <simulacron.version>0.14.0.0</simulacron.version>
     <jsr353-api.version>1.1.4</jsr353-api.version>
     <jersey.version>2.47</jersey.version>
     <hk2.version>2.6.1</hk2.version>
@@ -94,7 +94,7 @@
     <rxjava.version>2.2.21</rxjava.version>
     <awaitility.version>4.3.0</awaitility.version>
     <apacheds.version>2.0.0-M19</apacheds.version>
-    <surefire.version>3.5.4</surefire.version>
+    <surefire.version>3.5.5</surefire.version>
     <graalapi.version>22.0.0.2</graalapi.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
@@ -182,7 +182,7 @@
         <!-- Version of Guava used in shaded module and for integration tests. -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.3.1-jre</version>
+        <version>33.6.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.typesafe</groupId>
@@ -213,7 +213,7 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <!-- when changing version also update jnr-* and asm versions in LICENSE_binary  -->
-        <version>3.1.20</version>
+        <version>3.1.22</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.9.6</version>
+        <version>4.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.squareup</groupId>
@@ -306,12 +306,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.17.7</version>
+        <version>1.18.8-jdk5</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.28.2</version>
+        <version>5.23.0</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
@@ -441,7 +441,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>7.5.1</version>
+        <version>7.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.server</groupId>
@@ -553,7 +553,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.15.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -563,7 +563,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.9</version>
+          <version>2.13</version>
         </plugin>
         <plugin>
           <groupId>au.com.acegi</groupId>
@@ -580,17 +580,17 @@
         </plugin>
         <plugin>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.7.1</version>
+          <version>3.8.0</version>
         </plugin>
         <!-- See console.scala in the submodules -->
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.9.6</version>
+          <version>4.9.10</version>
           <configuration>
             <scalaVersion>2.11</scalaVersion>
             <args>
@@ -601,7 +601,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
@@ -609,7 +609,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-gpg-plugin</artifactId>
@@ -617,7 +617,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -641,12 +641,12 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.10.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.13</version>
+          <version>0.8.14</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -687,7 +687,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -705,7 +705,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -717,33 +717,24 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <compilerArgs combine.children="override">
-            <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
-            <compilerArg>-Xep:PreferJavaTimeOverload:OFF</compilerArg>
-            <compilerArg>-Xep:AnnotateFormatMethod:OFF</compilerArg>
-            <compilerArg>-Xep:WildcardImport:WARN</compilerArg>
-            <compilerArg>-XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
+            <compilerArg>-XDcompilePolicy=simple</compilerArg>
+            <compilerArg>--should-stop=ifError=FLOW</compilerArg>
+            <compilerArg>-Xplugin:ErrorProne -Xep:FutureReturnValueIgnored:OFF -Xep:PreferJavaTimeOverload:OFF -Xep:AnnotateFormatMethod:OFF -Xep:WildcardImport:WARN -Xep:MissingSummary:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:InlineMeSuggester:OFF -Xep:AddressSelection:OFF -XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.31.0</version>
+            </path>
+          </annotationProcessorPaths>
           <showWarnings>true</showWarnings>
           <failOnWarning>true</failOnWarning>
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.6</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.4</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>com.coveo</groupId>
@@ -842,6 +833,7 @@
           <verbose>false</verbose>
           <quiet>true</quiet>
           <doclint>all,-missing</doclint>
+          <legacyMode>true</legacyMode>
           <excludePackageNames>com.datastax.*.driver.internal*</excludePackageNames>
           <tags>
             <tag>
@@ -849,12 +841,9 @@
               <placement>a</placement>
               <head>API note:</head>
             </tag>
-            <!--
-              For custom `leaks-private-api` tag (apparently dash separators are not handled
-              correctly)
-            -->
+            <!-- For custom `leaks-private-api` tag. -->
             <tag>
-              <name>leaks</name>
+              <name>leaks-private-api</name>
               <placement>X</placement>
             </tag>
           </tags>
@@ -1085,13 +1074,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <properties>
         <testing.jvm>${testJavaHome}</testing.jvm>
       </properties>
-    </profile>
-    <profile>
-      <!-- workarounds for running tests with JDK1.8 -->
-      <id>test-jdk-8</id>
-      <activation>
-        <jdk>[8,)</jdk>
-      </activation>
     </profile>
     <profile>
       <!-- workarounds for running tests with JDK11 -->

--- a/pom.xml
+++ b/pom.xml
@@ -722,7 +722,7 @@
           <compilerArgs combine.children="override">
             <compilerArg>-XDcompilePolicy=simple</compilerArg>
             <compilerArg>--should-stop=ifError=FLOW</compilerArg>
-            <compilerArg>-Xplugin:ErrorProne -Xep:FutureReturnValueIgnored:OFF -Xep:PreferJavaTimeOverload:OFF -Xep:AnnotateFormatMethod:OFF -Xep:WildcardImport:WARN -Xep:MissingSummary:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:InlineMeSuggester:OFF -Xep:AddressSelection:OFF -XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
+            <compilerArg>-Xplugin:ErrorProne -Xep:FutureReturnValueIgnored:OFF -Xep:PreferJavaTimeOverload:OFF -Xep:AnnotateFormatMethod:OFF -Xep:WildcardImport:WARN -Xep:MissingSummary:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:InlineMeSuggester:OFF -Xep:AddressSelection:OFF -XepExcludedPaths:.*/(?:src/test|target/(?:generated-sources|generated-test-sources))/.*</compilerArg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>java-driver-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.tinkerpop</groupId>
+      <artifactId>gremlin-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -279,7 +279,8 @@ public class CcmBridge implements AutoCloseable {
         if (configDir != null) {
           execute(CommandLine.parse("ccm remove get_version --config-dir=" + configDir));
         }
-      } catch (Exception ignored) {
+      } catch (Exception e) {
+        LOG.warn("Failed to remove temporary CCM cluster used to resolve {}", versionString, e);
       }
     }
     return result;

--- a/test-infra/src/main/java/com/datastax/oss/driver/internal/gremlin/PatchedGremlinDslProcessor.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/internal/gremlin/PatchedGremlinDslProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.gremlin;
+
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDslProcessor;
+
+@SupportedAnnotationTypes("org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDsl")
+public class PatchedGremlinDslProcessor extends GremlinDslProcessor {
+
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    return Collections.singleton("org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDsl");
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+}


### PR DESCRIPTION
Raise the supported runtime/build floor to Java 11 and remove active Java 8 references from build, CI, docs, and live config.

Follow-up:
- #908 tracks dropping public access to `CodecRegistryConstants.PRIMITIVE_CODECS` in the 4.20.0 cycle under #907.

Verification:
- make check
- make -C docs setupenv
- make -C docs test
- make -C docs redirects
- make -C docs multiversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Java 11 or higher now required (was Java 8+)

* **Chores**
  * CI/build workflows and compiler/plugin settings migrated to Java 11
  * Dependency and tooling version bumps; embedded third‑party license updates
  * Documentation and external JDK API links updated to Java 11

* **Features**
  * Added a new public accessor for primitive codecs; legacy public codecs array deprecated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/java-driver/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->