### PR TITLE
ci: authenticate integration version lookups

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -212,6 +212,7 @@ jobs:
         id: cassandra-version
         env:
           CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
+          GH_TOKEN: ${{ github.token }}
         run: make resolve-cassandra-version
 
       - name: Pull CCM image from the cache
@@ -246,7 +247,9 @@ jobs:
       - name: Run integration tests on Cassandra (${{ steps.cassandra-version.outputs.value }}) - ${{ matrix.test-group }}
         id: run-integration-tests
         env:
+          CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
           CASSANDRA_VERSION_RESOLVED: ${{ steps.cassandra-version.outputs.value }}
+          GH_TOKEN: ${{ github.token }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
         run: make test-integration-cassandra
 
@@ -324,6 +327,7 @@ jobs:
         id: scylla-version
         env:
           SCYLLA_VERSION: ${{ matrix.scylla-version }}
+          GH_TOKEN: ${{ github.token }}
         run: make resolve-scylla-version
 
       - name: Pull CCM image from the cache


### PR DESCRIPTION
## Problem

The Cassandra and Scylla integration workflows resolve matrix values such as `latest` through helper scripts that can query GitHub. Those lookups were running without `GH_TOKEN`, so CI could fail when anonymous GitHub API requests were rejected or rate-limited before the integration tests started. The Cassandra integration test step could also invoke the same helper logic without the original requested version value.

## Solution

- Pass `${{ github.token }}` to the Cassandra and Scylla version-resolution steps.
- Pass `${{ github.token }}` and the original `CASSANDRA_VERSION` matrix value to the Cassandra integration test step.
- Keep `CASSANDRA_VERSION_RESOLVED` available for the concrete resolved version used by the tests.

## Testing

Not run locally; this change only rewires GitHub Actions environment variables and is exercised by the Cassandra/Scylla integration workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow authentication: inject GH token into database version-resolution steps for Cassandra and Scylla.
  * Also added GH token to the Cassandra integration test step’s environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/java-driver/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->