### PR TITLE
build: align native-protocol BOM version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -83,7 +83,7 @@
       <dependency>
         <groupId>com.scylladb</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.2.1</version>
+        <version>1.5.2.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Publish the same `native-protocol` patch version through the BOM that the parent build already manages.

This keeps BOM consumers on the protocol artifact version used by the build and tested by the driver modules.