### PR TITLE
Fix Micrometer no-SLA session metric test

### DIFF
--- a/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
+++ b/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
@@ -132,6 +132,9 @@ public class MicrometerSessionMetricUpdaterTest {
     when(context.getMetricIdGenerator()).thenReturn(generator);
     when(profile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
         .thenReturn(Duration.ofHours(1));
+    when(profile.getDuration(lowest)).thenReturn(Duration.ofMillis(10));
+    when(profile.getDuration(highest)).thenReturn(Duration.ofSeconds(1));
+    when(profile.getInt(digits)).thenReturn(5);
     when(profile.isDefined(sla)).thenReturn(false);
     when(profile.getDurationList(sla))
         .thenReturn(Arrays.asList(Duration.ofMillis(100), Duration.ofMillis(500)));


### PR DESCRIPTION
## Summary
- stub Micrometer histogram lower bound, upper bound, and precision options in the no-SLA session metric test
- keep the test focused on disabled SLA buckets instead of failing while building distribution configuration

## Testing
- JAVA_HOME=/home/dmitry.kropachev/.sdkman/candidates/java/8.0.452-amzn PATH=/home/dmitry.kropachev/.sdkman/candidates/java/8.0.452-amzn/bin:$PATH mvn -B -ntp -pl metrics/micrometer -Dtest=MicrometerSessionMetricUpdaterTest test