### PR TITLE
fix: correct input reference and upload-logs condition in release workflow (3.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Checkout Code One Commit Before ${{ inputs.version_tag }}
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
         if: inputs.target-tag != 'scylla-3.x'
         env:
-          RELEASE_TARGET_TAG: ${{ inputs.version_tag }}
+          RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
         run: make checkout-one-commit-before
 
       - name: Set up Java
@@ -81,7 +81,6 @@ jobs:
         run: make release-dry-run
 
       - name: Upload release logs
-        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: maven-stdout


### PR DESCRIPTION
## What

Two pre-existing bugs in `.github/workflows/release.yml` on `scylla-3.x`, both confirmed by [release run](https://github.com/scylladb/java-driver/actions/runs/25297315236).

### Bug 1 — wrong input reference in re-release step

The `Checkout Code One Commit Before` step referenced `inputs.version_tag` in both the step name and `RELEASE_TARGET_TAG` env var. The actual workflow input is named `target-tag`. Since `inputs.version_tag` is undefined, the expression always evaluates to empty string.

**Evidence from [run](https://github.com/scylladb/java-driver/actions/runs/25297315236):** step 3 appears in CI logs as:
```
Checkout Code One Commit Before   ← no tag value
```
and its conclusion is `skipped` (correct for a normal release where `target-tag == 'scylla-3.x'`), but if someone triggers a re-release with a specific tag (e.g. `3.11.5.15`), `RELEASE_TARGET_TAG` would be empty and `make checkout-one-commit-before` would silently operate on the wrong commit.

**Fix:** replace both occurrences of `inputs.version_tag` with `inputs.target-tag`.

### Bug 2 — release logs not uploaded on success

`Upload release logs` had `if: failure()`, so the artifact was skipped whenever the release completed successfully.

**Evidence from [run](https://github.com/scylladb/java-driver/actions/runs/25297315236):** step 9 `Upload release logs` is `skipped` despite the run succeeding. Release logs are an audit trail for every release — not just failed ones. `scylla-4.x` already uploads unconditionally.

**Fix:** remove the `if: failure()` condition to align both branches.

## Changes

```diff
-      - name: Checkout Code One Commit Before ${{ inputs.version_tag }}
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
         if: inputs.target-tag != 'scylla-3.x'
         env:
-          RELEASE_TARGET_TAG: ${{ inputs.version_tag }}
+          RELEASE_TARGET_TAG: ${{ inputs.target-tag }}

       - name: Upload release logs
-        if: failure()
         uses: actions/upload-artifact@...
```

## Notes

- No behaviour change for the normal release path (`target-tag == 'scylla-3.x'`); the re-release step is skipped in that case either way.
- This is a prerequisite fix before merging [#898](https://github.com/scylladb/java-driver/pull/898) (validate matrix patches), which also touches this file.