### PR TITLE
ci: update github-automation ref to fix unpinned actions/checkout in call_jira_sync.yml

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   jira-sync:
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@7b9848eb304fd3af1e757fe3c3c1ed497515f0fc # main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@ef3a6238c30003cbab9a339c32e5112f6889a197 # main
     with:
       caller_action: ${{ github.event.action }}
     secrets:


### PR DESCRIPTION
## What

Update the pinned commit reference in `call_jira_sync.yml` to a version of `scylladb/github-automation` that pins `actions/checkout` to a full commit SHA.

```diff
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@7b9848eb304fd3af1e757fe3c3c1ed497515f0fc # main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@ef3a6238c30003cbab9a339c32e5112f6889a197 # main
```

## Why

Every PR targeting `scylla-4.x` was failing with:

```
Error: The action actions/checkout@v4 is not allowed in scylladb/java-driver
because all actions must be pinned to a full-length commit SHA.
```

The `scylladb` org policy requires all actions to be pinned to a full 40-character commit SHA. This policy is enforced even inside externally-called reusable workflows. The reusable workflow `main_pr_events_jira_sync.yml` at the previously pinned commit (`7b9848eb…`) used `actions/checkout@v4`, which triggered the policy check.

The new commit (`ef3a6238…`) contains the fix: [scylladb/github-automation#192](https://github.com/scylladb/github-automation/pull/192).

## Notes

- Scope: `scylla-4.x` only (`scylla-3.x` has no `call_jira_sync.yml`)
- This is a **draft PR** pending merge of scylladb/github-automation#192

Closes: #911