### PR TITLE
ci: update scylladb/github-automation to latest main (47138e9)

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   jira-sync:
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@7b9848eb304fd3af1e757fe3c3c1ed497515f0fc # main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@47138e9130250ee1a35166cff7dd0e94c8897196 # main
     with:
       caller_action: ${{ github.event.action }}
     secrets:


### PR DESCRIPTION
This PR fixes failing jira sync workflow due to unpinned github action usage in previous version.