### PR TITLE
docs: deprecate Java Driver 3.x and announce maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Scylla Java Driver for Scylla and Apache Cassandra®
 
+> **Deprecation Notice:** Scylla Java Driver 3.x is now **deprecated** and has
+> entered **maintenance mode**. Only critical bug fixes will be accepted.
+> For new projects and active development, please migrate to
+> [Scylla Java Driver 4.x](https://github.com/scylladb/java-driver/tree/scylla-4.x)
+> ([documentation](https://java-driver.docs.scylladb.com/stable/)).
+
 *If you're reading this on github.com, please note that this is the readme
 for the development version and that some features described here might
 not yet have been released. You can find the documentation for the latest
 version through the [Java driver
 docs](https://docs.scylladb.com/using-scylla/scylla-java-driver/) or via the release tags,
 [e.g.
-3.11.5.0](https://github.com/scylladb/java-driver/releases/tag/3.11.5.0).*
+3.11.5.17](https://github.com/scylladb/java-driver/releases/tag/3.11.5.17).*
 
 A modern, [feature-rich](manual/) and highly tunable Java client
 library for Apache Cassandra (2.1+) and using exclusively Cassandra's binary protocol 
@@ -73,7 +79,7 @@ it in your application using the following Maven dependency
 <dependency>
   <groupId>com.scylladb</groupId>
   <artifactId>scylla-driver-core</artifactId>
-  <version>3.11.5.0</version>
+  <version>3.11.5.17</version>
 </dependency>
 ```
 
@@ -83,7 +89,7 @@ Note that the object mapper is published as a separate artifact:
 <dependency>
   <groupId>com.scylladb</groupId>
   <artifactId>scylla-driver-mapping</artifactId>
-  <version>3.11.5.0</version>
+  <version>3.11.5.17</version>
 </dependency>
 ```
 
@@ -93,7 +99,7 @@ The 'extras' module is also published as a separate artifact:
 <dependency>
   <groupId>com.scylladb</groupId>
   <artifactId>scylla-driver-extras</artifactId>
-  <version>3.11.5.0</version>
+  <version>3.11.5.17</version>
 </dependency>
 ```
 
@@ -107,7 +113,7 @@ by running `dnf -y install libxcrypt-compat`
 
 ## Compatibility
 
-The Java client driver 3.11.5.0 ([branch scylla-3.x](https://github.com/scylladb/java-driver/tree/scylla-3.x)) is compatible with 
+The Java client driver 3.11.5.17 ([branch scylla-3.x](https://github.com/scylladb/java-driver/tree/scylla-3.x)) is compatible with 
 Scylla and Apache Cassandra 2.1, 2.2, 3.0+.
 
 UDT and tuple support is available only when using Apache Cassandra 2.1 or higher.


### PR DESCRIPTION
## DRIVER-854: Deprecating Java Driver 3.x

Announces that Java Driver 3.x is deprecated and in maintenance mode. Part of [DRIVER-483],
tracked as [DRIVER-854].

`README.md` only: the deprecation notice at the top with a link to 4.x, and the version references
updated from `3.11.5.0` to `3.11.5.17` (the current latest 3.x release).

This PR is the announcement. The migration route is #1001 and the docs-site notice is #997, so that
the three review independently.

### No changelog entry

An earlier revision added one to `changelog/README.md`. Dropped: that file records **upstream**
releases only — every commit that has ever touched it is an upstream merge or an upstream
release-prep commit, and no ScyllaDB release (`3.11.5.1` … `3.11.5.17`) appears in it. Fork releases
are documented in GitHub Releases, which is where a reader looks for them. A fork-lifecycle notice
wedged into a list of upstream versions would be the only entry of its kind.

### Which PR the site actually sees

| PR | Branch | Reaches |
|---|---|---|
| **#919** (this one) | `scylla-3.x` | GitHub readers of the 3.x branch |
| #1001 | `scylla-3.x` | GitHub readers — the 4.x migration route |
| #997 | `scylla-4.x` | **the published documentation site**, all six 3.x versions |

The docs-site half cannot live here. `docs-pages.yml` checks out
`${{ github.event.repository.default_branch }}` on every publish regardless of which branch was
pushed, and `scylla-3.x` is not a published doc version at all —
[`/scylla-3.x/`](https://java-driver.docs.scylladb.com/scylla-3.x/) returns 404. `sphinx-multiversion`
takes page content from each version's own ref but `conf.py` and `templates_path` from the publishing
branch, so both `DEPRECATED_VERSIONS` and the deprecation banner only take effect there.

An earlier revision of this PR also edited `docs/source/conf.py` and
`docs/source/_templates/notice.html` on this branch; both were dropped as no-ops for the published
site. To be clear about *why*: a `_templates/` override is a perfectly good mechanism — it is exactly
what #997 now uses to reach the frozen 3.x branches — it just has no effect from here.

### What this means

- Java Driver 3.x enters **maintenance mode** — only critical bug fixes will be accepted.
- Users are directed to migrate to [Java Driver 4.x](https://java-driver.docs.scylladb.com/stable/).
- Once #997 is merged and published, every page of all six published 3.x doc versions carries a
  deprecation notice with a link to the migration guide. (The version picker itself is not marked;
  the theme has no mechanism for that.)

### Remaining DRIVER-483 tasks (out of scope for this PR)

- [x] [DRIVER-852] Inventory of internal tools using java-driver 3.x — published
- [ ] [DRIVER-853] Inventory of external tools and integrations using java-driver 3.x
- [ ] [DRIVER-855] Publish the deprecation announcement in internal and external documentation
      portals — **gates the merge of these three PRs**, per the request to coordinate with the other
      customer-communication channels first
- [ ] [DRIVER-856] Prepare and publish a performance comparison blog post
- [ ] [DRIVER-938] Query `system.clients` to find *deployed* 3.x consumers

[DRIVER-483]: https://scylladb.atlassian.net/browse/DRIVER-483
[DRIVER-852]: https://scylladb.atlassian.net/browse/DRIVER-852
[DRIVER-853]: https://scylladb.atlassian.net/browse/DRIVER-853
[DRIVER-854]: https://scylladb.atlassian.net/browse/DRIVER-854
[DRIVER-855]: https://scylladb.atlassian.net/browse/DRIVER-855
[DRIVER-856]: https://scylladb.atlassian.net/browse/DRIVER-856
[DRIVER-938]: https://scylladb.atlassian.net/browse/DRIVER-938
