### PR TITLE
fix: bump netty to 4.1.135.Final to remediate CVE-2026-44249 and CVE-2026-45416

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.2.2</hdrhistogram.version>
     <metrics.version>4.2.38</metrics.version>
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in


### PR DESCRIPTION
## Summary

Root fix for CVE-2026-44249 and CVE-2026-45416, tracked in scylladb/kafka-connect-scylladb#184.

`netty-handler` prior to `4.1.135.Final` is affected by two HIGH severity vulnerabilities:

- **CVE-2026-44249** (CVSS 8.1): `IpSubnetFilterRule.compareTo()` performs an incorrect masking operation, allowing attackers to bypass IPv6 subnet ACL rules with valid public IP addresses.

- **CVE-2026-45416** (CVSS 7.5): `SslClientHelloHandler.decode()` eagerly allocates up to 16 MiB of unpooled memory when `maxClientHelloLength=0` (the `SniHandler` default). A crafted TLS ClientHello can trigger memory exhaustion (DoS).

## Change

```diff
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
```

One-line change in the root `pom.xml`. All consumers of `java-driver-core` will inherit the fix transitively once a new driver release is published, eliminating the need for downstream `<dependencyManagement>` overrides.

## Follow-up

After this merges and a new release is cut, scylladb/kafka-connect-scylladb will bump `scylladb.version` and remove the temporary BOM override added in Stage 1.
