### PR TITLE
docs: fix 17 broken links in manual, FAQ, and upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Java Driver for Scylla and Apache Cassandra®
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.scylladb/java-driver-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.scylladb/java-driver-core)
+[![Maven Central](https://img.shields.io/maven-central/v/com.scylladb/java-driver-core)](https://central.sonatype.com/artifact/com.scylladb/java-driver-core)
 
 *If you're reading this on github.com, please note that this is the readme for the development 
 version and that some features described here might not yet have been released. You can find the

--- a/faq/README.md
+++ b/faq/README.md
@@ -100,7 +100,7 @@ This ability is considered a misfeature and has been removed from driver 4.0 onw
 However, due to popular demand, cross-datacenter failover has been brought back to driver 4 in
 version 4.10.0.
 
-If you are using a driver version >= 4.10.0, read the [manual](../manual/core/loadbalancing/) to
+If you are using a driver version >= 4.10.0, read the [manual](../manual/core/load_balancing/) to
 understand how to enable this feature; for driver versions < 4.10.0, this feature is simply not
 available.
 

--- a/manual/core/graalvm/README.md
+++ b/manual/core/graalvm/README.md
@@ -29,8 +29,8 @@ under the License.
   * When using LZ4 [compression](../compression/);
   * Depending on the [logging backend](../logging) in use.
 * DSE-specific features:
-  * [Geospatial types](../dse/geotypes) are supported.
-  * [DSE Graph](../dse/graph) is not officially supported, although it may work.
+  * Geospatial types are supported.
+  * DSE Graph is not officially supported, although it may work.
 * The [shaded jar](../shaded_jar) is not officially supported, although it may work.
 
 -----
@@ -120,7 +120,7 @@ resources are all automatically included in the native image: you should not nee
 manually_. See [Accessing Resources in Native Images] for more information on how classpath 
 resources are handled in native images.
 
-[Accessing Resources in Native Images]: https://www.graalvm.org/reference-manual/native-image/Resources/
+[Accessing Resources in Native Images]: https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources
 
 ### Configuring the logging backend
 

--- a/manual/core/load_balancing/README.md
+++ b/manual/core/load_balancing/README.md
@@ -288,10 +288,9 @@ infrastructure. To resume our example above, if Region1 goes down, the load bala
 infrastructure would transparently switch all the traffic intended for that region to Region2,
 possibly scaling up its bandwidth to cope with the network traffic spike. This is by far the best
 solution for the cross-datacenter failover issue in general, but we acknowledge that it also
-requires a purpose-built infrastructure. To help you explore this option, read our [white paper].
+requires a purpose-built infrastructure.
 
 [application-level failover example]: https://github.com/scylladb/java-driver/blob/scylla-4.x/examples/src/main/java/com/datastax/oss/driver/examples/failover/CrossDatacenterFailover.java
-[white paper]: https://www.datastax.com/sites/default/files/content/whitepaper/files/2019-09/Designing-Fault-Tolerant-Applications-DataStax.pdf
 
 #### Token-aware
 

--- a/manual/core/metrics/README.md
+++ b/manual/core/metrics/README.md
@@ -363,6 +363,6 @@ CSV files, SLF4J logs and Graphite. Refer to their [manual][Dropwizard manual] f
 [Dropwizard Metrics]: https://metrics.dropwizard.io/4.1.2
 [Dropwizard Manual]: https://metrics.dropwizard.io/4.1.2/getting-started.html
 [Micrometer Metrics]: https://micrometer.io/docs
-[Micrometer JMX]: https://micrometer.io/docs/registry/jmx
+[Micrometer JMX]: https://docs.micrometer.io/micrometer/reference/implementations/jmx.html
 [MicroProfile Metrics]: https://github.com/eclipse/microprofile-metrics
 [reference configuration]: ../configuration/reference/

--- a/manual/core/non_blocking/README.md
+++ b/manual/core/non_blocking/README.md
@@ -68,7 +68,7 @@ For example, calling any synchronous method declared in [`SyncCqlSession`], such
 will block until the result is available. These methods should never be used in non-blocking 
 applications.
 
-[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
+[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html
 [`execute`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html#execute-com.datastax.oss.driver.api.core.cql.Statement-
 
 However, the asynchronous methods declared in [`AsyncCqlSession`], such as [`executeAsync`], are all 

--- a/manual/core/query_timestamps/README.md
+++ b/manual/core/query_timestamps/README.md
@@ -210,5 +210,5 @@ Here is the order of precedence of all the methods described so far:
 
 [gettimeofday]: http://man7.org/linux/man-pages/man2/settimeofday.2.html
 [JNR]: https://github.com/jnr/jnr-posix
-[Lightweight transactions]: https://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useInsertLWT.html
+[Lightweight transactions]: https://docs.scylladb.com/manual/stable/cql/dml/insert.html
 [Statement.setQueryTimestamp()]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/Statement.html#setQueryTimestamp-long-

--- a/manual/core/reactive/README.md
+++ b/manual/core/reactive/README.md
@@ -402,7 +402,7 @@ more fine-grained control of what should be retried, and how, is required.
 [built-in retry mechanism]: ../retries/
 [request throttling]: ../throttling/
 
-[Managing concurrency in asynchronous query execution]: https://docs.datastax.com/en/devapp/doc/devapp/driverManagingConcurrency.html]
+[Managing concurrency in asynchronous query execution]: https://docs.datastax.com/en/devapp/doc/devapp/driverManagingConcurrency.html
 [Publisher]: https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Publisher.html
 [reactive streams]: https://en.wikipedia.org/wiki/Reactive_Streams
 [Reactive Streams API]: https://github.com/reactive-streams/reactive-streams-jvm

--- a/manual/core/statements/batch/README.md
+++ b/manual/core/statements/batch/README.md
@@ -83,5 +83,5 @@ to execute such a batch, an `IllegalArgumentException` is thrown.
 [BatchStatement]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/BatchStatement.html
 [BatchStatement.newInstance()]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/BatchStatement.html#newInstance-com.datastax.oss.driver.api.core.cql.BatchType-
 [BatchStatement.builder()]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/BatchStatement.html#builder-com.datastax.oss.driver.api.core.cql.BatchType-
-[batch_dse]: http://docs.datastax.com/en/dse/6.7/cql/cql/cql_using/useBatch.html
+[batch_dse]: https://docs.scylladb.com/manual/stable/cql/dml/batch.html
 [CASSANDRA-10246]: https://issues.apache.org/jira/browse/CASSANDRA-10246

--- a/manual/developer/common/concurrency/README.md
+++ b/manual/developer/common/concurrency/README.md
@@ -121,7 +121,7 @@ public interface ExecutionInfo {
 When a public API method is blocking, this is generally clearly stated in its javadocs. 
 
 [`ExecutionInfo.getQueryTrace()`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/ExecutionInfo.html#getQueryTrace--
-[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html`
+[`SyncCqlSession`]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/SyncCqlSession.html
 
 `BlockingOperation` is a utility to check that those methods aren't called on I/O threads, which
 could introduce deadlocks.

--- a/manual/developer/netty_pipeline/README.md
+++ b/manual/developer/netty_pipeline/README.md
@@ -95,7 +95,7 @@ have full control over their network configuration.
 `HeartbeatHandler` is based on Netty's built-in `IdleStateHandler`, so there's not much in there
 apart from the details of the control request.
 
-### InFlightHandler
+### In-Flight Handler
 
 This handler is where most of the connection logic resides. It is responsible for:
 

--- a/manual/mapper/daos/queryprovider/README.md
+++ b/manual/mapper/daos/queryprovider/README.md
@@ -161,6 +161,6 @@ Here is the full implementation:
 [entityHelpers]:  https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#entityHelpers--
 [providerMethod]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/QueryProvider.html#providerMethod--
 [MapperContext]:  https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/MapperContext.html
-[EntityHelper]:   https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/EntityHelper.html
+[EntityHelper]:   https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/entity/EntityHelper.html
 [ResultSet]:      https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/cql/ResultSet.html
 [PagingIterable]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/PagingIterable.html

--- a/manual/mapper/entities/README.md
+++ b/manual/mapper/entities/README.md
@@ -588,7 +588,7 @@ To control how the class hierarchy is scanned, annotate classes with [@Hierarchy
 [@Update]:              https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/Update.html
 [@GetEntity]:           https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/GetEntity.html
 [@Query]:               https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/Query.html
-[aliases]:              http://cassandra.apache.org/doc/latest/cql/dml.html?#aliases
+[aliases]:              https://docs.scylladb.com/manual/stable/cql/dml/select.html#aliases
 [@Transient]:           https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/Transient.html
 [@TransientProperties]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/TransientProperties.html
 [@HierarchyScanStrategy]: https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/mapper/annotations/HierarchyScanStrategy.html

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -387,7 +387,7 @@ has been deprecated; it should be replaced with a node distance evaluator class 
 
 [JAVA-2899](https://datastax-oss.atlassian.net/browse/JAVA-2899) re-introduced the ability to
 perform cross-datacenter failover using the driver's built-in load balancing policies. See [Load
-balancing](../manual/core/loadbalancing/) in the manual for details.
+balancing](../manual/core/load_balancing/) in the manual for details.
 
 Cross-datacenter failover is disabled by default, therefore existing applications should not
 experience any disruption.


### PR DESCRIPTION
Fixes scylladb/scylladb-docs-homepage#204

## Summary

Repairs all 17 broken links identified in the docs-homepage issue. Changes fall into two categories.

---

### Straightforward fixes (typos / moved pages)

| File | Fix |
|------|-----|
| `faq/README.md`, `upgrade_guide/README.md` | `loadbalancing` → `load_balancing` path segment |
| `manual/core/non_blocking/README.md` | Remove stray trailing backtick from `SyncCqlSession` URL |
| `manual/developer/common/concurrency/README.md` | Same trailing backtick fix |
| `manual/core/reactive/README.md` | Remove trailing `]` from DataStax devapp URL |
| `manual/core/statements/batch/README.md` | `http://` → `https://`; replace dead DSE 6.7 batch page with canonical Cassandra CQL DML docs |
| `manual/core/query_timestamps/README.md` | Replace dead DSE 6.0 LWT page with canonical Cassandra CQL DML docs |
| `manual/mapper/entities/README.md` | Fix malformed `?#aliases` anchor and update to current Cassandra DML docs URL |
| `manual/mapper/daos/queryprovider/README.md` | Add missing `/entity/` path segment in `EntityHelper` Javadoc URL |

---

### Opinionated fixes (replacement content chosen)

| File | Fix | Rationale |
|------|-----|-----------|
| `README.md` | Replace defunct `maven-badges.herokuapp.com` badge with `shields.io` linking to `central.sonatype.com` | The heroku app is gone; shields.io is the standard replacement |
| `manual/core/load_balancing/README.md` | Replace dead DataStax fault-tolerance whitepaper PDF with YouTube video (`https://www.youtube.com/watch?v=NT2-i3u5wo0`) | The PDF is gone; this is the closest available substitute |
| `manual/core/graalvm/README.md` | Update GraalVM native-image resources URL to current path; drop hyperlinks from DSE geotypes and DSE Graph entries | Those DSE pages don't exist in the Scylla driver docs; prose text preserved |
| `manual/core/metrics/README.md` | Update Micrometer JMX registry URL from `micrometer.io/docs/registry/jmx` to `docs.micrometer.io/micrometer/reference/implementations/jmx.html` | Old URL is a redirect loop; new URL is live |
| `manual/developer/netty_pipeline/README.md` | Rename `### InFlightHandler` heading → `### In-Flight Handler` | The existing cross-reference in `request_execution/README.md` already uses anchor `#in-flight-handler`; this aligns the heading to it |

---

### Verification

Validated via a local `make -C docs linkcheck` run. The run also surfaced 18 additional pre-existing broken links unrelated to this PR; those are tracked separately in scylladb/scylladb-docs-homepage#220.