### PR TITLE
fix: bump netty from 4.1.127 to 4.1.135 to remediate CVE-2026-44249 and CVE-2026-45416

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <guava.version>33.3.1-jre</guava.version>
-        <netty.version>4.1.127.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <netty-tcnative.artifact>netty-tcnative-boringssl-static</netty-tcnative.artifact>
         <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <metrics.version>3.2.6</metrics.version>


### PR DESCRIPTION
## Summary

Bumps `netty.version` from `4.1.127.Final` to `4.1.135.Final` in the `scylla-3.x` branch to remediate:

- **CVE-2026-44249** (CVSS 8.1): `IpSubnetFilterRule.compareTo()` performs an incorrect masking operation, allowing attackers to bypass IPv6 subnet ACL rules with valid public IP addresses.

- **CVE-2026-45416** (CVSS 7.5): `SslClientHelloHandler.decode()` eagerly allocates up to 16 MiB of unpooled memory when `maxClientHelloLength=0` (the `SniHandler` default). A crafted TLS ClientHello can trigger memory exhaustion (DoS).

This also covers **CVE-2026-42583** (CVSS 7.5, fixed in 4.1.131.Final): HTTP Response Splitting via `HttpObjectEncoder`.

## Context

This is the same fix pattern applied in PR #925 for the `scylla-4.x` branch (which bumped netty from 4.1.127 to 4.1.135). The `scylla-3.x` branch (`scylla-driver-parent:3.11.5.x`) has the same vulnerable netty version and requires the same bump.

## Changes

```diff
# pom.xml
-<netty.version>4.1.127.Final</netty.version>
+<netty.version>4.1.135.Final</netty.version>
```
