### PR TITLE
Fix NPE in ChannelPool metrics methods when pool is uninitialized

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -210,11 +210,17 @@ public class ChannelPool implements AsyncAutoCloseable {
 
   /** @return the number of active channels in the pool. */
   public int size() {
+    if (!singleThreaded.initialized) {
+      return 0;
+    }
     return Arrays.stream(channels).mapToInt(ChannelSet::size).sum();
   }
 
   /** @return the number of available stream ids on all channels in the pool. */
   public int getAvailableIds() {
+    if (!singleThreaded.initialized) {
+      return 0;
+    }
     return Arrays.stream(channels).mapToInt(ChannelSet::getAvailableIds).sum();
   }
 
@@ -223,6 +229,9 @@ public class ChannelPool implements AsyncAutoCloseable {
    *     {@link #getOrphanedIds() orphaned ids}).
    */
   public int getInFlight() {
+    if (!singleThreaded.initialized) {
+      return 0;
+    }
     return Arrays.stream(channels).mapToInt(ChannelSet::getInFlight).sum();
   }
 
@@ -232,6 +241,9 @@ public class ChannelPool implements AsyncAutoCloseable {
    *     might still come from the server.
    */
   public int getOrphanedIds() {
+    if (!singleThreaded.initialized) {
+      return 0;
+    }
     return Arrays.stream(channels).mapToInt(ChannelSet::getOrphanedIds).sum();
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -418,6 +418,13 @@ public class ChannelPool implements AsyncAutoCloseable {
                 } else {
                   resultFuture.complete(false);
                 }
+              } else if (isClosing) {
+                LOG.debug(
+                    "[{}] New channel added ({}) but the pool was closed, closing it",
+                    logPrefix,
+                    driver);
+                driver.forceClose();
+                resultFuture.complete(true);
               } else {
                 initialize(driver);
                 CompletableFutures.completeFrom(addMissingChannels(), resultFuture);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
@@ -149,6 +149,34 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
   }
 
   @Test
+  public void should_return_zero_for_metric_accessors_when_pool_uninitialized() throws Exception {
+    // Reproduce CUSTOMER-413: when the initial connection attempt fails, connectFuture completes
+    // with channels == null (initialize() is only called on the success path). Before the fix,
+    // any call to size/getAvailableIds/getInFlight/getOrphanedIds threw NullPointerException via
+    // Arrays.stream(null), which propagated through the Dropwizard Metrics gauge lambdas
+    // registered in DropwizardNodeMetricUpdater.
+    when(defaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE)).thenReturn(1);
+
+    MockChannelFactoryHelper.builder(channelFactory)
+        .failure(node, "mock channel init failure")
+        .build();
+
+    CompletionStage<ChannelPool> poolFuture =
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
+
+    ChannelPool pool = poolFuture.toCompletableFuture().get();
+
+    // Confirm the precondition: pool entered the map but channels was never initialized
+    assertThat(pool.channels).isNull();
+
+    // All four accessor methods must return 0 without throwing
+    assertThat(pool.size()).isEqualTo(0);
+    assertThat(pool.getAvailableIds()).isEqualTo(0);
+    assertThat(pool.getInFlight()).isEqualTo(0);
+    assertThat(pool.getOrphanedIds()).isEqualTo(0);
+  }
+
+  @Test
   public void should_reconnect_when_init_incomplete() throws Exception {
     // Short delay so we don't have to wait in the test
     when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
@@ -105,6 +105,40 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
   }
 
   @Test
+  public void should_force_close_first_reconnected_channel_when_closed_before_initialized()
+      throws Exception {
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    when(defaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE)).thenReturn(1);
+
+    DriverChannel channel1 = newMockDriverChannel(1);
+    CompletableFuture<DriverChannel> channel1Future = new CompletableFuture<>();
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            // init
+            .failure(node, "mock channel init failure")
+            // reconnection
+            .pending(node, channel1Future)
+            .build();
+
+    CompletionStage<ChannelPool> poolFuture =
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
+
+    factoryHelper.waitForCalls(node, 2);
+    assertThatStage(poolFuture).isSuccess();
+    ChannelPool pool = poolFuture.toCompletableFuture().get();
+
+    CompletionStage<Void> closeFuture = pool.closeAsync();
+    assertThatStage(closeFuture).isSuccess();
+
+    channel1Future.complete(channel1);
+
+    verify(channel1, VERIFY_TIMEOUT).forceClose();
+    verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
   public void should_force_close_all_channels_when_force_closed() throws Exception {
     when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
 
@@ -167,6 +201,40 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     ((ChannelPromise) channel3.closeFuture()).setSuccess();
 
     assertThatStage(closeFuture).isSuccess();
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_force_close_first_reconnected_channel_when_force_closed_before_initialized()
+      throws Exception {
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    when(defaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE)).thenReturn(1);
+
+    DriverChannel channel1 = newMockDriverChannel(1);
+    CompletableFuture<DriverChannel> channel1Future = new CompletableFuture<>();
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            // init
+            .failure(node, "mock channel init failure")
+            // reconnection
+            .pending(node, channel1Future)
+            .build();
+
+    CompletionStage<ChannelPool> poolFuture =
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
+
+    factoryHelper.waitForCalls(node, 2);
+    assertThatStage(poolFuture).isSuccess();
+    ChannelPool pool = poolFuture.toCompletableFuture().get();
+
+    CompletionStage<Void> closeFuture = pool.forceCloseAsync();
+    assertThatStage(closeFuture).isSuccess();
+
+    channel1Future.complete(channel1);
+
+    verify(channel1, VERIFY_TIMEOUT).forceClose();
+    verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
 
     factoryHelper.verifyNoMoreCalls();
   }


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` when Dropwizard Metrics reporters scrape per-node gauge values while the driver is reconnecting to a node.

Affects: `com.scylladb:java-driver-core` (confirmed in `4.18.0.1`, same code present in `scylla-4.x`).

---

## Root Cause

`ChannelPool` has a `ChannelSet[] channels` field that is **not initialized at construction** — it starts as `null`:

```java
// ChannelPool.java
@VisibleForTesting ChannelSet[] channels;  // null until initialize() runs
```

`channels` is only assigned inside `SingleThreaded.initialize()`, which is called **only when the first channel connection succeeds**:

```java
private void initialize(DriverChannel c) {
    ...
    channels = new ChannelSet[shardsCount];   // assigned here
    ...
    initialized = true;                        // set AFTER channels
}
```

When the initial connection **fails**, `makeInitialConnection()` completes `connectFuture` immediately — with `channels` still `null` — and starts a reconnect in the background:

```java
// on the failure branch of makeInitialConnection():
reconnection.start();
connectFuture.complete(ChannelPool.this);  // pool enters PoolManager.pools with channels == null
```

`PoolManager.onPoolsInit()` unconditionally puts every completed pool into the `pools` map (`PoolManager.java:252`). The Javadoc comment there even notes: _"pool init always succeeds"_. This is intentional design — but it means a pool with `channels == null` can be in the map.

### Why the existing null-check doesn't help

`AbstractMetricUpdater` guards against a missing pool entry, but not against an uninitialized pool:

```java
// AbstractMetricUpdater.java
protected int inFlightRequests(Node node) {
    ChannelPool pool = context.getPoolManager().getPools().get(node);
    return (pool == null) ? 0 : pool.getInFlight();  // pool is non-null, but channels is null
}
```

### The NPE

The three gauge methods — and `size()` — call `Arrays.stream(channels)` with no null guard:

```java
public int getInFlight() {
    return Arrays.stream(channels).mapToInt(ChannelSet::getInFlight).sum();
    //                   ^^^^^^^^ NullPointerException when channels == null
}
```

`Arrays.stream(null)` throws `NullPointerException`. This is triggered by any Dropwizard reporter (JMX, Graphite, Prometheus bridge, etc.) that calls `Gauge.getValue()` during the window between a failed initial connection and a successful reconnect.

### Full call chain

```
Metrics reporter  →  Gauge.getValue()
  DropwizardMetricUpdater.java:112   registry.gauge(..., () -> supplier::get)
  DropwizardNodeMetricUpdater.java:50  () -> inFlightRequests(node)
  AbstractMetricUpdater.java:141     pool = getPools().get(node)  [non-null, reconnecting]
  AbstractMetricUpdater.java:142     pool.getInFlight()
  ChannelPool.java:226               Arrays.stream(channels)  →  NPE  (channels == null)
```

Same path applies to `getAvailableIds()` and `getOrphanedIds()`.

---

## Fix

Mirror the guard already used by `next()`, which correctly handles this case via the `initialized` flag:

```java
public DriverChannel next(...) {
    if (!singleThreaded.initialized) {  // ← existing safe pattern
        return null;
    }
    ...
}
```

Apply the same guard to all four affected methods:

```java
public int size() {
    if (!singleThreaded.initialized) return 0;
    return Arrays.stream(channels).mapToInt(ChannelSet::size).sum();
}
// same for getAvailableIds(), getInFlight(), getOrphanedIds()
```

### Why `initialized` and not `channels != null`

`initialized` is declared `volatile` (meaning the JMM guarantees that a thread reading `initialized == true` will also observe all writes that preceded the volatile write, including `channels = new ChannelSet[...]`). The `channels` field itself is **not** `volatile`, so checking it directly would be a weaker guarantee. Using `initialized` is both JMM-correct and consistent with the existing pattern in `next()`.

### Why `size()` is included

`size()` has the identical unguarded `Arrays.stream(channels)` pattern. While it is not currently called from any metrics path, it is a public method and would throw the same NPE if called before initialization.

---

## Changed files

- `core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java`
  - `size()` — add `initialized` guard
  - `getAvailableIds()` — add `initialized` guard
  - `getInFlight()` — add `initialized` guard
  - `getOrphanedIds()` — add `initialized` guard
