### PR TITLE
3.x: fix ShardAwarenessTest.correctShardInTracingTest for Scylla 2025.1

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
@@ -82,12 +82,17 @@ public class ShardAwarenessTest extends CCMTestsSupport {
           event.getSource(),
           event.getThreadName(),
           event.getDescription());
-      assertThat(event.getThreadName()).startsWith(shard);
+      // Only data-local events carry the owning shard. Scylla 2025.1 adds coordinator-side
+      // events that legitimately run on shard 0 regardless of the data shard. Also, since
+      // Scylla 2025.1 the thread name carries a service-level suffix ("shard N/sl:<level>"),
+      // so strip it before comparing.
       if (event.getDescription().contains("querying locally")) {
         anyLocal = true;
+        String normalized = event.getThreadName().replaceFirst("/sl:[^/]*$", "");
+        assertThat(normalized).startsWith(shard);
       }
     }
-    assertThat(anyLocal);
+    assertTrue(anyLocal, "No 'querying locally' trace event was observed for the query");
   }
 
   @Test(groups = "short")
@@ -95,7 +100,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
     session()
         .execute(
-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
+            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'} AND TABLETS = {'enabled': false}");
     session()
         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
 


### PR DESCRIPTION
## Problem

`ShardAwarenessTest.correctShardInTracingTest` fails on Scylla 2025.1 (both `scylla/3.11.4.0` and `scylla/3.11.5.15` matrix entries) with:

```
Expecting: <"shard 0/sl:default"> to start with: <"shard 1">
```

Two Scylla 2025.1 changes contribute to this failure:

1. **Tablets enabled by default for NTS keyspaces** (primary, confirmed): Scylla 2025.1 enables tablets by default for `NetworkTopologyStrategy` keyspaces. With tablets, shard assignment is arbitrary — the driver's hash-based `getShardId(token)` prediction no longer matches the shard that actually handles the request. The test creates `shardawaretest` without explicitly disabling tablets, so the expected and actual shards diverge.

2. **Service-level suffix in thread names**: Since Scylla 2025.1, thread names include a `/sl:` suffix (e.g. `"shard 0/sl:default"`). Note: `startsWith("shard N")` still matches correctly-sharded events — stripping the suffix is defensive hygiene rather than a direct fix.

**Pre-existing bug (unmasked):** `assertThat(anyLocal)` is an AssertJ no-op — it wraps the value but never calls `.isTrue()`. The liveness guard never actually fired even before 2025.1.

## Fix

- Add `AND TABLETS = {'enabled': false}` to `CREATE KEYSPACE shardawaretest` to restore deterministic hash-based shard assignment.
- Narrow the per-event assertion to **only** the `"querying locally"` event (the event that executes on the data-owning shard), making the assertion robust to any future addition of coordinator-side events.
- Strip the `/sl:...` suffix with `replaceFirst("/sl:[^/]*$", "")` before `startsWith(shard)` (defensive hygiene).
- Promote the liveness guard from `assertThat(anyLocal)` (no-op) to `assertTrue(anyLocal, ...)` so the guard actually fires when no local event is found.

## Testing

Verified via staging job [`java-driver-matrix-2025.1` build #2](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-2025.1/2/) — **GREEN** on Scylla `2025.1.15-0.20260624.b48b97fb10bd`, all 4 driver versions (`3.11.4.0`, `3.11.5.15`, `4.18.1.0`, `4.19.0.9`).

`scylla/4.18.1.0` and `scylla/4.19.0.9` pass the test today without changes; this PR targets only `3.11.x` (via matrix patches in the companion [scylla-java-driver-matrix PR #155](https://github.com/scylladb/scylla-java-driver-matrix/pull/155)).