### PR TITLE
build(deps): bump sphinx-scylladb-theme to 1.9.2

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "pygments>=2.18.0",
-    "sphinx-scylladb-theme>=1.9.1",
+    "sphinx-scylladb-theme>=1.9.2",
     "myst-parser>=5.0.0",
     "sphinx-autobuild>=2025.4.8",
     "sphinx>=9.0",

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -243,7 +243,7 @@ requires-dist = [
     { name = "sphinx-autobuild", specifier = ">=2025.4.8" },
     { name = "sphinx-multiversion-scylla", specifier = ">=0.3.7" },
     { name = "sphinx-scylladb-markdown", specifier = ">=0.1.2" },
-    { name = "sphinx-scylladb-theme", specifier = ">=1.9.1" },
+    { name = "sphinx-scylladb-theme", specifier = ">=1.9.2" },
     { name = "sphinx-sitemap", specifier = ">=2.9.0" },
     { name = "wheel", specifier = ">=0.45.0" },
 ]
@@ -743,7 +743,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-scylladb-theme"
-version = "1.9.1"
+version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -756,9 +756,9 @@ dependencies = [
     { name = "sphinx-tabs" },
     { name = "sphinxcontrib-mermaid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4e/e49e351d4c429b8fe3090657d39e956d53dff61187d783caac1cba81bd72/sphinx_scylladb_theme-1.9.1.tar.gz", hash = "sha256:2ba6367f005d2c68eee1916cc16385989b8e53bbddcc81193003bdeb3bd3415e", size = 1676201, upload-time = "2026-03-09T18:10:43.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/92/e30549be27dfdbfb3a1bf52cbc5496c190230dd2d4e7a41c8bafada8f4a2/sphinx_scylladb_theme-1.9.2.tar.gz", hash = "sha256:f4319deeefcc446779375c2d9cbdd922eaf63da092a50def74247dd2156f1274", size = 1683295, upload-time = "2026-04-14T11:07:30.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/30/2b2bae1b022d1fabef405a4857f160464548e08d924f24d0b26d0ca6a848/sphinx_scylladb_theme-1.9.1-py3-none-any.whl", hash = "sha256:6156d60befc3da03bd11991fec9bc590e27ce7cc4ab05aa334edd5611424b106", size = 1662204, upload-time = "2026-03-09T18:10:45.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ff/9957eef93c1b46dbbccd66cb4766d513c1061961daaa60fcfc1a78b3bc20/sphinx_scylladb_theme-1.9.2-py3-none-any.whl", hash = "sha256:1d75463151693c3b31ef48b2401aa4db18953fc515b4061c6f127182242e0280", size = 1669961, upload-time = "2026-04-14T11:07:28.944Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Based on #869, scoped down to the docs dependency update only.

PR #869 includes unrelated repository-wide changes in addition to the dependency bump, so this PR carries the minimal change needed for the scylla-4.x branch.

Changes:
- bump the docs `sphinx-scylladb-theme` requirement from `>=1.9.1` to `>=1.9.2`
- update `docs/uv.lock` to resolve `sphinx-scylladb-theme` 1.9.2 with the matching sdist and wheel hashes

Validation:
- `git diff --check`
- `uv lock --check`