### PR TITLE
build: downgrade maven-release-plugin to 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>2.5.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
## Summary

- Reverts `maven-release-plugin` from 3.3.1 → **2.5.3** as a short-term workaround to restore the broken release flow on Maven 3.9.16.
- Tracks: #935

## Problem

After bumping to 3.3.1 (released end of May 2026), `release:perform` fails with:

```
Cannot perform release - the preparation step was stopped mid-way.
Please re-run release:prepare to continue, or perform the release from an SCM tag.
```

## Root Cause

`pom.xml` pins `maven-scm-provider-gitexe:1.9.5`, which implements the **SCM 1.x API**. `maven-release-plugin` 3.x requires the **SCM 2.x API** internally. The mismatch causes `release:prepare` to abort mid-lifecycle, leaving the build in a state that blocks `release:perform`.

## Workaround

Revert to 2.5.3, which is compatible with `maven-scm-provider-gitexe:1.9.5` (SCM 1.x). This is a temporary measure — see #935 for the proper 3.x upgrade path (requires upgrading both the plugin and `maven-scm-provider-gitexe` to 2.x together).

## Test plan

- [ ] Trigger a release build on the CI runner (Maven 3.9.16) to confirm `release:prepare` → `release:perform` completes without error.