### PR TITLE
build: remove maven-javadoc-plugin skip in core-shaded

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -280,9 +280,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -293,11 +290,22 @@
               <sourcepath>${project.build.directory}/shaded-sources</sourcepath>
               <excludePackageNames>com.datastax.*.driver.internal*,com.datastax.oss.driver.shaded*</excludePackageNames>
               <!--
-                javadoc processes the shaded Netty sources (even though they're not included in the
-                report), and will complain if it doesn't find JCTools classes.
-                Add the dependency just to avoid warnings:
+                javadoc processes the shaded Netty and Jackson sources (even though they're not
+                included in the report), and will fail if transitive compile-time dependencies of
+                those libraries are missing from the javadoc classpath. Add the ones that are not
+                already present as transitive compile dependencies of core-shaded.
+                failOnError=false handles any remaining missing packages (e.g. ch.randelshofer:
+                fastdoubleparser, which is bundled-and-shaded inside jackson-core and has no
+                standalone published coordinate we can resolve here).
               -->
+              <failOnError>false</failOnError>
               <additionalDependencies>
+                <additionalDependency>
+                  <!-- Netty 4.1.x uses @NotNull, @VisibleForTesting, @Async.Execute/Schedule -->
+                  <groupId>org.jetbrains</groupId>
+                  <artifactId>annotations</artifactId>
+                  <version>23.0.0</version>
+                </additionalDependency>
                 <additionalDependency>
                   <groupId>org.xerial.snappy</groupId>
                   <artifactId>snappy-java</artifactId>


### PR DESCRIPTION
## Summary

Fixes `core-shaded` javadoc generation broken since deaeb1c44 ("build: drop Java 8 support", May 25 2026), which added `<skip>true</skip>` to the `maven-javadoc-plugin` in `core-shaded/pom.xml` to paper over a javadoc compilation failure introduced by the Netty 4.1.135.Final bump.

## Problem

With `<skip>true</skip>` at the plugin level, no javadoc jar is attached for the `core-shaded` artifact during a release. Sonatype Central rejects the upload because javadoc jars are required for all published artifacts.

The underlying compilation failure was caused by two missing dependencies on the javadoc classpath when processing the shaded sources:

1. **`org.jetbrains:annotations`** — Netty 4.1.135.Final added `@NotNull`, `@VisibleForTesting`, and `@Async.Execute/Schedule` from this package.
2. **`ch.randelshofer:fastdoubleparser`** — Jackson 2.21.x sources reference this package, but it is bundled-and-shaded inside `jackson-core` with no standalone resolvable Maven coordinate.

## Changes

- Remove the `<skip>true</skip>` global plugin configuration.
- Add `org.jetbrains:annotations:23.0.0` to `additionalDependencies` in the `attach-javadocs` execution (same version Netty uses as a provided dependency).
- Add `<failOnError>false</failOnError>` to the `attach-javadocs` execution to tolerate the unresolvable fastdoubleparser references. Those sources are already excluded from the javadoc output via `excludePackageNames`, so the jar still contains the full public API documentation.

## Test plan

- [ ] Trigger a release build and confirm the `core-shaded` javadoc jar is generated and accepted by Sonatype Central.