### PR TITLE
test: use NTS keyspace in PreparedStatementTest

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -540,8 +540,8 @@ public class PreparedStatementTest extends CCMTestsSupport {
     session()
         .execute(
             "CREATE KEYSPACE \"Test\" WITH replication = { "
-                + "  'class': 'SimpleStrategy',"
-                + "  'replication_factor': '1'"
+                + "  'class': 'NetworkTopologyStrategy',"
+                + "  'datacenter1': '1'"
                 + "}");
     session().execute("CREATE TABLE \"Test\".\"Foo\" (i int PRIMARY KEY)");
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperKeyspaceTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperKeyspaceTest.java
@@ -33,10 +33,10 @@ public class MapperKeyspaceTest extends CCMTestsSupport {
   @Override
   public void onTestContextInitialized() {
     execute(
-        "CREATE KEYSPACE IF NOT EXISTS MapperKeyspaceTest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "CREATE KEYSPACE IF NOT EXISTS MapperKeyspaceTest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
         "CREATE TYPE IF NOT EXISTS MapperKeyspaceTest.address(street text)",
         "CREATE TABLE IF NOT EXISTS MapperKeyspaceTest.user(name text PRIMARY KEY, address frozen<address>)",
-        "CREATE KEYSPACE IF NOT EXISTS MapperKeyspaceTest2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "CREATE KEYSPACE IF NOT EXISTS MapperKeyspaceTest2 WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
         "CREATE TYPE IF NOT EXISTS MapperKeyspaceTest2.address(street text)",
         "CREATE TABLE IF NOT EXISTS MapperKeyspaceTest2.user(name text PRIMARY KEY, address frozen<address>)");
   }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
@@ -43,7 +43,7 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
     // Create type and table
     session1.execute(
         "create keyspace if not exists java_509 "
-            + "with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+            + "with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };");
     session1.execute("create type java_509.my_tuple (" + "type text, " + "value text);");
     session1.execute(
         "create table java_509.my_hash ("
@@ -75,7 +75,7 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
     Session session1 = cluster1.connect();
     session1.execute(
         "create keyspace if not exists java_509b "
-            + "with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+            + "with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };");
     session1.execute("use java_509b");
     session1.execute("create type my_tuple (" + "type text, " + "value text);");
     session1.execute(


### PR DESCRIPTION
Scylla 2026.2.0 rejects SimpleStrategy when tablet replication is enabled. A few short integration tests still created keyspaces with SimpleStrategy, which causes the Scylla IT matrix to fail before the actual test assertions run.

This switches those test keyspaces to NetworkTopologyStrategy with datacenter1 RF=1, matching the 3.x test-suite cleanup already done for other Scylla integration tests.

Observed failures:
- PreparedStatementTest.should_set_routing_key_on_case_sensitive_keyspace_and_table
- MapperKeyspaceTest.beforeTestClass
- UDTFieldMapperTest.udt_and_tables_with_ks_created_in_another_session_should_be_mapped
- UDTFieldMapperTest.udt_and_tables_without_ks_created_in_another_session_should_be_mapped
- InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication

Tested:
- mvn -pl driver-core com.coveo:fmt-maven-plugin:check -Dverbose=false
- mvn -pl driver-core -DskipTests test-compile -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
- mvn -pl driver-core,driver-mapping com.coveo:fmt-maven-plugin:check -Dverbose=false
- mvn -pl driver-mapping -am -DskipTests test-compile -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true