### PR TITLE
fix: bump jackson from 2.18.6 to 2.18.9 to remediate CVE-2026-54512 through CVE-2026-54518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <snappy.version>1.1.10.7</snappy.version>
         <lz4.version>1.10.1</lz4.version>
         <hdr.version>2.2.2</hdr.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <joda.version>2.12.7</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>


### PR DESCRIPTION
## What

Bumps `jackson.version` from `2.18.6` to `2.18.9` in the root POM.

## Why

Remediates CVE-2026-54512 through CVE-2026-54518 in the jackson-databind / jackson-core dependencies (2.18.x line). Jackson 2.18.9 is the latest patch release on the 2.18 branch and contains the security fixes.

This is a patch-level bump within the same minor version — low risk of breaking changes. The driver uses jackson only for configuration file parsing (YAML/JSON).

## Context

This follows the same remediation pattern as the netty bump (#927): fix the vulnerable transitive dependency in the driver, cut a release, and let downstream consumers (scylla-cdc-java, and in turn scylla-cdc-source-connector) pick up the fix transitively through their shade plugins. Confluent Hub's scanner reads the embedded Maven POM metadata inside shaded jars, so the fix must originate at the driver version rather than being pinned downstream.