### PR TITLE
Fix synchronous throttled request failures

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
@@ -254,22 +254,27 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
 
   @Override
   public void onThrottleReady(boolean wasDelayed) {
-    DriverExecutionProfile executionProfile =
-        Conversions.resolveExecutionProfile(initialStatement, context);
-    if (wasDelayed
-        // avoid call to nanoTime() if metric is disabled:
-        && sessionMetricUpdater.isEnabled(
-            DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
-      session
-          .getMetricUpdater()
-          .updateTimer(
-              DefaultSessionMetric.THROTTLING_DELAY,
-              executionProfile.getName(),
-              System.nanoTime() - startTimeNanos,
-              TimeUnit.NANOSECONDS);
+    try {
+      DriverExecutionProfile executionProfile =
+          Conversions.resolveExecutionProfile(initialStatement, context);
+      if (wasDelayed
+          // avoid call to nanoTime() if metric is disabled:
+          && sessionMetricUpdater.isEnabled(
+              DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
+        session
+            .getMetricUpdater()
+            .updateTimer(
+                DefaultSessionMetric.THROTTLING_DELAY,
+                executionProfile.getName(),
+                System.nanoTime() - startTimeNanos,
+                TimeUnit.NANOSECONDS);
+      }
+      activeExecutionsCount.incrementAndGet();
+      sendRequest(initialStatement, null, 0, 0, specExecEnabled);
+    } catch (Throwable error) {
+      abortGlobalRequestOrChosenCallback(error);
+      throttler.signalError(this, error);
     }
-    activeExecutionsCount.incrementAndGet();
-    sendRequest(initialStatement, null, 0, 0, specExecEnabled);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -185,25 +185,29 @@ public class GraphRequestHandler implements Throttled {
 
   @Override
   public void onThrottleReady(boolean wasDelayed) {
-    DriverExecutionProfile executionProfile =
-        Conversions.resolveExecutionProfile(initialStatement, context);
-    if (wasDelayed
-        // avoid call to nanoTime() if metric is disabled:
-        && sessionMetricUpdater.isEnabled(
-            DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
-      sessionMetricUpdater.updateTimer(
-          DefaultSessionMetric.THROTTLING_DELAY,
-          executionProfile.getName(),
-          System.nanoTime() - startTimeNanos,
-          TimeUnit.NANOSECONDS);
+    try {
+      DriverExecutionProfile executionProfile =
+          Conversions.resolveExecutionProfile(initialStatement, context);
+      if (wasDelayed
+          // avoid call to nanoTime() if metric is disabled:
+          && sessionMetricUpdater.isEnabled(
+              DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
+        sessionMetricUpdater.updateTimer(
+            DefaultSessionMetric.THROTTLING_DELAY,
+            executionProfile.getName(),
+            System.nanoTime() - startTimeNanos,
+            TimeUnit.NANOSECONDS);
+      }
+      Queue<Node> queryPlan =
+          initialStatement.getNode() != null
+              ? new SimpleQueryPlan(initialStatement.getNode())
+              : context
+                  .getLoadBalancingPolicyWrapper()
+                  .newQueryPlan(initialStatement, executionProfile.getName(), session);
+      sendRequest(initialStatement, null, queryPlan, 0, 0, true);
+    } catch (Throwable error) {
+      setFinalError(initialStatement, error, null, NO_SUCCESSFUL_EXECUTION);
     }
-    Queue<Node> queryPlan =
-        initialStatement.getNode() != null
-            ? new SimpleQueryPlan(initialStatement.getNode())
-            : context
-                .getLoadBalancingPolicyWrapper()
-                .newQueryPlan(initialStatement, executionProfile.getName(), session);
-    sendRequest(initialStatement, null, queryPlan, 0, 0, true);
   }
 
   public CompletionStage<AsyncGraphResultSet> handle() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -148,18 +148,22 @@ public class CqlPrepareHandler implements Throttled {
 
   @Override
   public void onThrottleReady(boolean wasDelayed) {
-    DriverExecutionProfile executionProfile =
-        Conversions.resolveExecutionProfile(initialRequest, context);
-    if (wasDelayed) {
-      session
-          .getMetricUpdater()
-          .updateTimer(
-              DefaultSessionMetric.THROTTLING_DELAY,
-              executionProfile.getName(),
-              System.nanoTime() - startTimeNanos,
-              TimeUnit.NANOSECONDS);
+    try {
+      DriverExecutionProfile executionProfile =
+          Conversions.resolveExecutionProfile(initialRequest, context);
+      if (wasDelayed) {
+        session
+            .getMetricUpdater()
+            .updateTimer(
+                DefaultSessionMetric.THROTTLING_DELAY,
+                executionProfile.getName(),
+                System.nanoTime() - startTimeNanos,
+                TimeUnit.NANOSECONDS);
+      }
+      sendRequest(initialRequest, null, 0);
+    } catch (Throwable error) {
+      setFinalError(error);
     }
-    sendRequest(initialRequest, null, 0);
   }
 
   public CompletableFuture<PreparedStatement> handle() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -212,27 +212,31 @@ public class CqlRequestHandler implements Throttled {
 
   @Override
   public void onThrottleReady(boolean wasDelayed) {
-    if (wasDelayed
-        // avoid call to nanoTime() if metric is disabled:
-        && sessionMetricUpdater.isEnabled(
-            DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
-      sessionMetricUpdater.updateTimer(
-          DefaultSessionMetric.THROTTLING_DELAY,
-          executionProfile.getName(),
-          System.nanoTime() - startTimeNanos,
-          TimeUnit.NANOSECONDS);
-    }
-    Queue<Node> queryPlan;
-    if (this.initialStatement.getNode() != null) {
-      queryPlan = new SimpleQueryPlan(this.initialStatement.getNode());
-    } else {
-      queryPlan =
-          context
-              .getLoadBalancingPolicyWrapper()
-              .newQueryPlan(initialStatement, executionProfile.getName(), session);
-    }
+    try {
+      if (wasDelayed
+          // avoid call to nanoTime() if metric is disabled:
+          && sessionMetricUpdater.isEnabled(
+              DefaultSessionMetric.THROTTLING_DELAY, executionProfile.getName())) {
+        sessionMetricUpdater.updateTimer(
+            DefaultSessionMetric.THROTTLING_DELAY,
+            executionProfile.getName(),
+            System.nanoTime() - startTimeNanos,
+            TimeUnit.NANOSECONDS);
+      }
+      Queue<Node> queryPlan;
+      if (this.initialStatement.getNode() != null) {
+        queryPlan = new SimpleQueryPlan(this.initialStatement.getNode());
+      } else {
+        queryPlan =
+            context
+                .getLoadBalancingPolicyWrapper()
+                .newQueryPlan(initialStatement, executionProfile.getName(), session);
+      }
 
-    sendRequest(initialStatement, null, queryPlan, 0, 0, true);
+      sendRequest(initialStatement, null, queryPlan, 0, 0, true);
+    } catch (Throwable error) {
+      setFinalError(initialStatement, error, null, -1);
+    }
   }
 
   public CompletionStage<AsyncResultSet> handle() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
@@ -19,6 +19,8 @@ package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
 import static com.datastax.oss.driver.Assertions.assertThatStage;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +59,28 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
+
+  @Test
+  public void should_fail_future_if_throttled_request_setup_throws() {
+    RuntimeException expected = new RuntimeException("mock query plan failure");
+    try (RequestHandlerTestHarness harness = RequestHandlerTestHarness.builder().build()) {
+      when(harness
+              .getContext()
+              .getLoadBalancingPolicyWrapper()
+              .newQueryPlan(any(), anyString(), any()))
+          .thenThrow(expected);
+
+      CompletionStage<AsyncResultSet> resultSetFuture =
+          new CqlRequestHandler(
+                  UNDEFINED_IDEMPOTENCE_STATEMENT,
+                  harness.getSession(),
+                  harness.getContext(),
+                  "test")
+              .handle();
+
+      assertThatStage(resultSetFuture).isFailed(error -> assertThat(error).isSameAs(expected));
+    }
+  }
 
   @Test
   public void should_complete_result_if_first_node_replies_immediately() {


### PR DESCRIPTION
## Summary

Add top-level error handling around `onThrottleReady()` request setup for:

- CQL requests
- prepare requests
- graph requests
- continuous paging requests

Fixes #949.

## Root cause

Request throttlers invoke `onThrottleReady()` directly. Query-plan creation, execution-profile
resolution, metric updates, or request scheduling can throw synchronously from this callback.

Those exceptions previously bypassed the request handlers' normal terminal-error paths. On the
immediate throttler path, this could make `executeAsync()` throw instead of returning a failed
future. On a queued path, the exception could escape on the throttler or event-loop thread and
leave the request future incomplete.

## Solution

Wrap each request handler's `onThrottleReady()` setup in a catch-all error boundary and route
failures through its existing terminal-error flow.

This ensures that synchronous setup failures:

- complete the user-facing future exceptionally;
- release or notify the request throttler correctly;
- behave consistently for immediate and delayed requests.

A regression test verifies that a synchronous query-plan creation failure is returned through a
failed completion stage instead of escaping request construction.

## Testing

- `CqlRequestHandlerTest`: 7 tests passed
- `CqlPrepareHandlerTest`: 9 tests passed
- `GraphRequestHandlerTest`: 30 tests passed
- `ContinuousGraphRequestHandlerTest`: 5 tests passed
- Maven formatting and XML checks passed
- `git diff --check` passed