### PR TITLE
fix: release pre-acquired stream IDs

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -23,6 +23,7 @@ under the License.
 
 ### 4.19.2
 
+- [bug] PR 947: Release pre-acquired stream IDs when requests fail before being written
 - [bug] CASSJAVA-116: Retry or Speculative Execution with RequestIdGenerator throws "Duplicate Key"
 
 ### 4.19.1

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
@@ -367,23 +367,33 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
         abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors));
       }
     } else if (!chosenCallback.isDone()) {
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleSpeculativeExecution,
-              logPrefix);
-      inFlightCallbacks.add(nodeResponseCallback);
-      channel
-          .write(
-              getMessage(statement),
-              isTracingEnabled(statement),
-              createPayload(statement),
-              nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+      boolean writeSubmitted = false;
+      try {
+        NodeResponseCallback nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleSpeculativeExecution,
+                logPrefix);
+        inFlightCallbacks.add(nodeResponseCallback);
+        channel
+            .write(
+                getMessage(statement),
+                isTracingEnabled(statement),
+                createPayload(statement),
+                nodeResponseCallback)
+            .addListener(nodeResponseCallback);
+        writeSubmitted = true;
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
+    } else {
+      channel.cancelPreAcquireId();
     }
   }
 

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -302,29 +302,37 @@ public class GraphRequestHandler implements Throttled {
             NO_SUCCESSFUL_EXECUTION);
       }
     } else {
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              queryPlan,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleNextExecution,
-              logPrefix);
-      DriverExecutionProfile executionProfile =
-          Conversions.resolveExecutionProfile(statement, context);
-      GraphProtocol graphSubProtocol =
-          GraphConversions.resolveGraphSubProtocol(statement, graphSupportChecker, context);
-      Message message =
-          GraphConversions.createMessageFromGraphStatement(
-              statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
-      Map<String, ByteBuffer> customPayload =
-          GraphConversions.createCustomPayload(
-              statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
-      channel
-          .write(message, statement.isTracing(), customPayload, nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+      boolean writeSubmitted = false;
+      try {
+        NodeResponseCallback nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                queryPlan,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleNextExecution,
+                logPrefix);
+        DriverExecutionProfile executionProfile =
+            Conversions.resolveExecutionProfile(statement, context);
+        GraphProtocol graphSubProtocol =
+            GraphConversions.resolveGraphSubProtocol(statement, graphSupportChecker, context);
+        Message message =
+            GraphConversions.createMessageFromGraphStatement(
+                statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
+        Map<String, ByteBuffer> customPayload =
+            GraphConversions.createCustomPayload(
+                statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
+        channel
+            .write(message, statement.isTracing(), customPayload, nodeResponseCallback)
+            .addListener(nodeResponseCallback);
+        writeSubmitted = true;
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -100,10 +100,16 @@ public class DriverChannel {
       Map<String, ByteBuffer> customPayload,
       ResponseCallback responseCallback) {
     if (closing.get()) {
+      inFlightHandler.cancelPreAcquireId();
       return channel.newFailedFuture(new IllegalStateException("Driver channel is closing"));
     }
     RequestMessage message = new RequestMessage(request, tracing, customPayload, responseCallback);
-    return writeCoalescer.writeAndFlush(channel, message);
+    try {
+      return writeCoalescer.writeAndFlush(channel, message);
+    } catch (Throwable t) {
+      inFlightHandler.cancelPreAcquireId();
+      return channel.newFailedFuture(t);
+    }
   }
 
   /**
@@ -218,6 +224,15 @@ public class DriverChannel {
    */
   public boolean preAcquireId() {
     return inFlightHandler.preAcquireId();
+  }
+
+  /**
+   * Cancels the reservation made by a successful {@link #preAcquireId()} call when the
+   * corresponding request cannot be submitted to {@link #write(Message, boolean, Map,
+   * ResponseCallback)}.
+   */
+  public void cancelPreAcquireId() {
+    inFlightHandler.cancelPreAcquireId();
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
@@ -396,6 +396,10 @@ public class InFlightHandler extends ChannelDuplexHandler {
     return streamIds.preAcquire();
   }
 
+  void cancelPreAcquireId() {
+    streamIds.cancelPreAcquire();
+  }
+
   int getInFlight() {
     return streamIds.getMaxAvailableIds() - streamIds.getAvailableIds();
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -229,14 +229,22 @@ public class CqlPrepareHandler implements Throttled {
     if (channel == null) {
       setFinalError(AllNodesFailedException.fromErrors(this.errors));
     } else {
-      InitialPrepareCallback initialPrepareCallback =
-          new InitialPrepareCallback(request, node, channel, retryCount);
+      boolean writeSubmitted = false;
+      try {
+        InitialPrepareCallback initialPrepareCallback =
+            new InitialPrepareCallback(request, node, channel, retryCount);
 
-      Prepare message = toPrepareMessage(request);
+        Prepare message = toPrepareMessage(request);
 
-      channel
-          .write(message, false, request.getCustomPayload(), initialPrepareCallback)
-          .addListener(initialPrepareCallback);
+        channel
+            .write(message, false, request.getCustomPayload(), initialPrepareCallback)
+            .addListener(initialPrepareCallback);
+        writeSubmitted = true;
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 
@@ -316,28 +324,38 @@ public class CqlPrepareHandler implements Throttled {
       LOG.trace("[{}] Could not get a channel to reprepare on {}, skipping", logPrefix, node);
       return CompletableFuture.completedFuture(null);
     } else {
-      ThrottledAdminRequestHandler<ByteBuffer> handler =
-          ThrottledAdminRequestHandler.prepare(
-              channel,
-              false,
-              toPrepareMessage(request),
-              request.getCustomPayload(),
-              Conversions.resolveRequestTimeout(request, executionProfile),
-              throttler,
-              session.getMetricUpdater(),
-              logPrefix);
-      return handler
-          .start()
-          .handle(
-              (result, error) -> {
-                if (error == null) {
-                  LOG.trace("[{}] Successfully reprepared on {}", logPrefix, node);
-                } else {
-                  Loggers.warnWithException(
-                      LOG, "[{}] Error while repreparing on {}", node, logPrefix, error);
-                }
-                return null;
-              });
+      boolean requestStarted = false;
+      try {
+        ThrottledAdminRequestHandler<ByteBuffer> handler =
+            ThrottledAdminRequestHandler.prepare(
+                channel,
+                false,
+                toPrepareMessage(request),
+                request.getCustomPayload(),
+                Conversions.resolveRequestTimeout(request, executionProfile),
+                throttler,
+                session.getMetricUpdater(),
+                logPrefix);
+        CompletionStage<Void> result =
+            handler
+                .start()
+                .handle(
+                    (preparedId, error) -> {
+                      if (error == null) {
+                        LOG.trace("[{}] Successfully reprepared on {}", logPrefix, node);
+                      } else {
+                        Loggers.warnWithException(
+                            LOG, "[{}] Error while repreparing on {}", node, logPrefix, error);
+                      }
+                      return null;
+                    });
+        requestStarted = true;
+        return result;
+      } finally {
+        if (!requestStarted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -409,30 +409,39 @@ public class CqlRequestHandler implements Throttled {
         setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
       }
     } else {
-      Statement finalStatement = statement;
-      String nodeRequestId =
-          this.requestIdGenerator
-              .map((g) -> g.getNodeRequestId(finalStatement, sessionRequestId))
-              .orElse(Integer.toString(this.hashCode()));
-      statement =
-          this.requestIdGenerator
-              .map((g) -> g.getDecoratedStatement(finalStatement, nodeRequestId))
-              .orElse(finalStatement);
+      boolean writeSubmitted = false;
+      try {
+        Statement finalStatement = statement;
+        String nodeRequestId =
+            this.requestIdGenerator
+                .map((g) -> g.getNodeRequestId(finalStatement, sessionRequestId))
+                .orElse(Integer.toString(this.hashCode()));
+        statement =
+            this.requestIdGenerator
+                .map((g) -> g.getDecoratedStatement(finalStatement, nodeRequestId))
+                .orElse(finalStatement);
 
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              queryPlan,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleNextExecution,
-              logPrefixJoiner.join(this.sessionName, nodeRequestId, currentExecutionIndex));
-      Message message = Conversions.toMessage(statement, executionProfile, context);
-      channel
-          .write(message, statement.isTracing(), statement.getCustomPayload(), nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+        NodeResponseCallback nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                queryPlan,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleNextExecution,
+                logPrefixJoiner.join(this.sessionName, nodeRequestId, currentExecutionIndex));
+        Message message = Conversions.toMessage(statement, executionProfile, context);
+        channel
+            .write(
+                message, statement.isTracing(), statement.getCustomPayload(), nodeResponseCallback)
+            .addListener(nodeResponseCallback);
+        writeSubmitted = true;
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.connection.ClosedConnectionException;
@@ -141,6 +142,17 @@ public class DriverChannelTest extends ChannelHandlerTestBase {
     assertThat(responseCallback.getFailure())
         .isInstanceOf(ClosedConnectionException.class)
         .hasMessageContaining("Channel was force-closed");
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_write_is_rejected_before_submission() {
+    driverChannel.close();
+
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+
+    assertThat(writeFuture).isFailed();
+    verify(streamIds).cancelPreAcquire();
   }
 
   // Simple implementation that holds all the writes, and flushes them when it's explicitly


### PR DESCRIPTION
## Description

### What changed

- Release pre-acquired stream IDs when `DriverChannel.write()` rejects a request before submitting it to the Netty pipeline.
- Release reservations when synchronous request construction fails before `write()` is called.
- Apply the same handling to:
  - CQL requests
  - prepare requests and secondary prepares
  - graph requests
  - continuous paging requests
- Release the reservation when a continuous paging callback completes after channel acquisition but before submission.
- Add regression coverage and update the changelog.

### Root cause

Channel selection calls `preAcquireId()` before returning a channel. Request handlers then perform additional work before the resulting `RequestMessage` reaches `InFlightHandler`.

If that work throws, or `DriverChannel.write()` rejects the request before pipeline submission, `InFlightHandler` never sees the request and therefore cannot release the reservation. Repeated failures can cause available stream-ID accounting to drift and eventually make healthy channels appear saturated.

### Impact

Every successful stream-ID pre-acquisition now ends in one of two outcomes:

- the request is submitted to `InFlightHandler`; or
- the reservation is explicitly released.

Fixes #947.

### Validation

```
mvn -pl core -Dtest=DriverChannelTest,CqlRequestHandlerTest,CqlPrepareHandlerTest test
```

- 18 tests passed
- Formatter and Error Prone checks passed under JDK 17
- `git diff --check` passed