### PR TITLE
fix: release pre-acquired stream ids

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
@@ -282,10 +282,12 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
     abortGlobalRequestOrChosenCallback(error);
   }
 
-  private void abortGlobalRequestOrChosenCallback(@NonNull Throwable error) {
-    if (!chosenCallback.completeExceptionally(error)) {
+  private boolean abortGlobalRequestOrChosenCallback(@NonNull Throwable error) {
+    boolean completedChosenCallback = chosenCallback.completeExceptionally(error);
+    if (!completedChosenCallback) {
       chosenCallback.thenAccept(callback -> callback.abort(error, false));
     }
+    return completedChosenCallback;
   }
 
   public CompletionStage<ResultSetT> handle() {
@@ -367,23 +369,51 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
         abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors));
       }
     } else if (!chosenCallback.isDone()) {
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleSpeculativeExecution,
-              logPrefix);
-      inFlightCallbacks.add(nodeResponseCallback);
-      channel
-          .write(
-              getMessage(statement),
-              isTracingEnabled(statement),
-              createPayload(statement),
-              nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+      boolean writeSubmitted = false;
+      Throwable terminalPreWriteFailure = null;
+      NodeResponseCallback nodeResponseCallback = null;
+      try {
+        nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleSpeculativeExecution,
+                logPrefix);
+        inFlightCallbacks.add(nodeResponseCallback);
+        Future<java.lang.Void> writeFuture =
+            channel.write(
+                getMessage(statement),
+                isTracingEnabled(statement),
+                createPayload(statement),
+                nodeResponseCallback);
+        writeSubmitted = true;
+        writeFuture.addListener(nodeResponseCallback);
+      } catch (Throwable t) {
+        if (!writeSubmitted && activeExecutionsCount.decrementAndGet() == 0) {
+          if (abortGlobalRequestOrChosenCallback(t)) {
+            terminalPreWriteFailure = t;
+          }
+        }
+        throw t;
+      } finally {
+        if (!writeSubmitted) {
+          if (nodeResponseCallback != null) {
+            inFlightCallbacks.remove(nodeResponseCallback);
+          }
+          try {
+            channel.cancelPreAcquireId();
+          } finally {
+            if (terminalPreWriteFailure != null) {
+              throttler.signalError(this, terminalPreWriteFailure);
+            }
+          }
+        }
+      }
+    } else {
+      channel.cancelPreAcquireId();
     }
   }
 
@@ -486,6 +516,16 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
       // chosenCallback should always be complete by the time tests call this
       throw new AssertionError("Expected callback to be chosen at this point");
     }
+  }
+
+  @VisibleForTesting
+  int getActiveExecutionsCount() {
+    return activeExecutionsCount.get();
+  }
+
+  @VisibleForTesting
+  int getInFlightCallbackCount() {
+    return inFlightCallbacks.size();
   }
 
   private void recordError(@NonNull Node node, @NonNull Throwable error) {

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -302,29 +302,37 @@ public class GraphRequestHandler implements Throttled {
             NO_SUCCESSFUL_EXECUTION);
       }
     } else {
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              queryPlan,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleNextExecution,
-              logPrefix);
-      DriverExecutionProfile executionProfile =
-          Conversions.resolveExecutionProfile(statement, context);
-      GraphProtocol graphSubProtocol =
-          GraphConversions.resolveGraphSubProtocol(statement, graphSupportChecker, context);
-      Message message =
-          GraphConversions.createMessageFromGraphStatement(
-              statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
-      Map<String, ByteBuffer> customPayload =
-          GraphConversions.createCustomPayload(
-              statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
-      channel
-          .write(message, statement.isTracing(), customPayload, nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+      boolean writeSubmitted = false;
+      try {
+        NodeResponseCallback nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                queryPlan,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleNextExecution,
+                logPrefix);
+        DriverExecutionProfile executionProfile =
+            Conversions.resolveExecutionProfile(statement, context);
+        GraphProtocol graphSubProtocol =
+            GraphConversions.resolveGraphSubProtocol(statement, graphSupportChecker, context);
+        Message message =
+            GraphConversions.createMessageFromGraphStatement(
+                statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
+        Map<String, ByteBuffer> customPayload =
+            GraphConversions.createCustomPayload(
+                statement, graphSubProtocol, executionProfile, context, graphBinaryModule);
+        Future<java.lang.Void> writeFuture =
+            channel.write(message, statement.isTracing(), customPayload, nodeResponseCallback);
+        writeSubmitted = true;
+        writeFuture.addListener(nodeResponseCallback);
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
@@ -131,9 +131,32 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
               String.format(
                   "%s has reached its maximum number of simultaneous requests", channel)));
     } else {
-      channel.write(message, false, customPayload, this).addListener(this::onWriteComplete);
+      boolean writeSubmitted = false;
+      try {
+        Future<Void> writeFuture = channel.write(message, false, customPayload, this);
+        writeSubmitted = true;
+        writeFuture.addListener(this::onWriteComplete);
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
     return result;
+  }
+
+  /**
+   * Cancels a stream id reservation supplied by the caller.
+   *
+   * <p>This is only valid when {@code shouldPreAcquireId} is {@code false}; otherwise this handler
+   * does not own a reservation before {@link #start()}.
+   */
+  protected final void cancelCallerOwnedPreAcquireId() {
+    if (shouldPreAcquireId) {
+      throw new IllegalStateException(
+          "Cannot cancel a caller-owned reservation when this handler pre-acquires its own id");
+    }
+    channel.cancelPreAcquireId();
   }
 
   private void onWriteComplete(Future<? super Void> future) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
@@ -104,10 +105,11 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
   private final long startTimeNanos;
   private final RequestThrottler throttler;
   private final SessionMetricUpdater metricUpdater;
+  private final AtomicBoolean holdsExternalReservation;
 
   protected ThrottledAdminRequestHandler(
       DriverChannel channel,
-      boolean preAcquireId,
+      boolean shouldPreAcquireId,
       Message message,
       Map<String, ByteBuffer> customPayload,
       Duration timeout,
@@ -118,7 +120,7 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
       Class<? extends Result> expectedResponseType) {
     super(
         channel,
-        preAcquireId,
+        shouldPreAcquireId,
         message,
         customPayload,
         timeout,
@@ -128,31 +130,56 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
     this.startTimeNanos = System.nanoTime();
     this.throttler = throttler;
     this.metricUpdater = metricUpdater;
+    this.holdsExternalReservation = new AtomicBoolean(!shouldPreAcquireId);
   }
 
   @Override
   public CompletionStage<ResultT> start() {
     // Don't write request yet, wait for green light from throttler
-    throttler.register(this);
+    try {
+      throttler.register(this);
+    } catch (Throwable t) {
+      cancelExternalReservation();
+      // Registration can fail before the throttler admits this request, so complete the result
+      // without calling this class's override, which would signal a permit that was never acquired.
+      super.setFinalError(t);
+      throw t;
+    }
     return result;
   }
 
   @Override
   public void onThrottleReady(boolean wasDelayed) {
-    if (wasDelayed) {
-      metricUpdater.updateTimer(
-          DefaultSessionMetric.THROTTLING_DELAY,
-          null,
-          System.nanoTime() - startTimeNanos,
-          TimeUnit.NANOSECONDS);
+    try {
+      if (wasDelayed) {
+        metricUpdater.updateTimer(
+            DefaultSessionMetric.THROTTLING_DELAY,
+            null,
+            System.nanoTime() - startTimeNanos,
+            TimeUnit.NANOSECONDS);
+      }
+      holdsExternalReservation.set(false);
+      super.start();
+    } catch (Throwable t) {
+      cancelExternalReservation();
+      setFinalError(t);
+      throw t;
     }
-    super.start();
   }
 
   @Override
   public void onThrottleFailure(@NonNull RequestThrottlingException error) {
+    cancelExternalReservation();
     metricUpdater.incrementCounter(DefaultSessionMetric.THROTTLING_ERRORS, null);
     setFinalError(error);
+  }
+
+  private void cancelExternalReservation() {
+    // register() can invoke onThrottleReady() synchronously. If that callback throws, both
+    // onThrottleReady() and start() catch the same failure, so cancellation must be idempotent.
+    if (holdsExternalReservation.compareAndSet(true, false)) {
+      cancelCallerOwnedPreAcquireId();
+    }
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequest.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequest.java
@@ -72,10 +72,31 @@ abstract class ChannelHandlerRequest implements ResponseCallback {
               String.format(
                   "%s has reached its maximum number of simultaneous requests", channel)));
     } else {
-      DriverChannel.RequestMessage message =
-          new DriverChannel.RequestMessage(getRequest(), false, Frame.NO_PAYLOAD, this);
-      ChannelFuture writeFuture = channel.writeAndFlush(message);
-      writeFuture.addListener(this::writeListener);
+      boolean writeSubmitted = false;
+      DriverChannel.RequestMessage message = null;
+      try {
+        message =
+            new DriverChannel.RequestMessage(
+                getRequest(), false, Frame.NO_PAYLOAD, this, inFlightHandler);
+        ChannelFuture writeFuture = channel.writeAndFlush(message);
+        DriverChannel.RequestMessage submittedMessage = message;
+        writeFuture.addListener(
+            future -> {
+              if (!future.isSuccess()) {
+                submittedMessage.cancelPreAcquireId();
+              }
+              writeListener(future);
+            });
+        writeSubmitted = true;
+      } finally {
+        if (!writeSubmitted) {
+          if (message == null) {
+            inFlightHandler.cancelPreAcquireId();
+          } else {
+            message.cancelPreAcquireId();
+          }
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
@@ -19,17 +19,21 @@ package com.datastax.oss.driver.internal.core.channel;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.connection.ClosedConnectionException;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.EventExecutor;
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.jcip.annotations.ThreadSafe;
@@ -59,19 +63,26 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
 
   @Override
   public ChannelFuture writeAndFlush(Channel channel, Object message) {
-    ChannelPromise writePromise = channel.newPromise();
+    Flusher flusher = getFlusher(channel);
+    ChannelPromise writePromise =
+        new DefaultChannelPromise(channel, flusher.listenerNotificationExecutor);
     Write write = new Write(channel, message, writePromise);
-    enqueue(write, channel.eventLoop());
+    flusher.enqueue(write);
     return writePromise;
   }
 
-  private void enqueue(Write write, EventLoop eventLoop) {
-    Flusher flusher = flushers.computeIfAbsent(eventLoop, Flusher::new);
-    flusher.enqueue(write);
+  @Override
+  public EventExecutor listenerNotificationExecutor(Channel channel) {
+    return getFlusher(channel).listenerNotificationExecutor;
+  }
+
+  private Flusher getFlusher(Channel channel) {
+    return flushers.computeIfAbsent(channel.eventLoop(), Flusher::new);
   }
 
   private class Flusher {
     private final EventLoop eventLoop;
+    private final RejectionSafeEventExecutor listenerNotificationExecutor;
 
     // These variables are accessed both from client threads and the event loop
     private final Queue<Write> writes = new ConcurrentLinkedQueue<>();
@@ -82,13 +93,52 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
 
     private Flusher(EventLoop eventLoop) {
       this.eventLoop = eventLoop;
+      this.listenerNotificationExecutor = new RejectionSafeEventExecutor(eventLoop);
     }
 
     private void enqueue(Write write) {
       boolean added = writes.offer(write);
       assert added; // always true (see MpscLinkedAtomicQueue implementation)
       if (running.compareAndSet(false, true)) {
-        eventLoop.execute(this::runOnEventLoop);
+        try {
+          eventLoop.execute(this::runOnEventLoop);
+        } catch (Throwable t) {
+          // execute() rejected the task, so this write can never reach the pipeline. Remove it
+          // before making the flusher schedulable again; otherwise a concurrent retry could submit
+          // a request whose caller has already cancelled its pre-acquired stream id.
+          boolean removed = writes.remove(write);
+          // This assertion only verifies the expected queue state. If assertions are disabled and
+          // a stale message reaches the pipeline, RequestMessage's ownership gate fails its promise
+          // instead of consuming a live stream id.
+          assert removed;
+
+          // Other writers might have enqueued while running was true. The event loop is rejecting
+          // work, so retrying on the same executor cannot make progress; fail them instead.
+          if (t instanceof RejectedExecutionException) {
+            ClosedConnectionException failure = rejectedExecutionFailure(t);
+            failPendingWrites(failure);
+            throw failure;
+          }
+          failPendingWrites(t);
+          throw t;
+        }
+      }
+    }
+
+    private void failPendingWrites(Throwable failure) {
+      while (true) {
+        Write write;
+        while ((write = writes.poll()) != null) {
+          write.fail(failure);
+        }
+
+        // Allow concurrent enqueues to schedule a new run. If a write was added while we still
+        // owned the running flag and nobody claimed it after we released it, reclaim ownership and
+        // fail that write too.
+        running.set(false);
+        if (writes.isEmpty() || !running.compareAndSet(false, true)) {
+          return;
+        }
       }
     }
 
@@ -99,7 +149,11 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
       while ((write = writes.poll()) != null) {
         Channel channel = write.channel;
         channels.add(channel);
-        channel.write(write.message, write.writePromise);
+        try {
+          channel.write(write.message, write.writePromise);
+        } catch (Throwable t) {
+          write.fail(t);
+        }
       }
 
       for (Channel channel : channels) {
@@ -124,10 +178,25 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
       // on. If not, we need to do it ourselves.
       boolean shouldRestartMyself = running.compareAndSet(false, true);
 
-      if (shouldRestartMyself && !eventLoop.isShuttingDown()) {
-        eventLoop.schedule(this::runOnEventLoop, rescheduleIntervalNanos, TimeUnit.NANOSECONDS);
+      if (shouldRestartMyself) {
+        if (eventLoop.isShuttingDown()) {
+          failPendingWrites(
+              rejectedExecutionFailure(
+                  new RejectedExecutionException("Event loop is shutting down")));
+        } else {
+          try {
+            eventLoop.schedule(this::runOnEventLoop, rescheduleIntervalNanos, TimeUnit.NANOSECONDS);
+          } catch (Throwable t) {
+            failPendingWrites(
+                t instanceof RejectedExecutionException ? rejectedExecutionFailure(t) : t);
+          }
+        }
       }
     }
+  }
+
+  private static ClosedConnectionException rejectedExecutionFailure(Throwable cause) {
+    return new ClosedConnectionException("Channel event loop rejected a write task", cause);
   }
 
   private static class Write {
@@ -139,6 +208,13 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
       this.channel = channel;
       this.message = message;
       this.writePromise = writePromise;
+    }
+
+    private void fail(Throwable failure) {
+      if (message instanceof DriverChannel.RequestMessage) {
+        ((DriverChannel.RequestMessage) message).cancelPreAcquireId();
+      }
+      writePromise.tryFailure(failure);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.ScheduledFuture;
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
@@ -185,7 +186,24 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
                   new RejectedExecutionException("Event loop is shutting down")));
         } else {
           try {
-            eventLoop.schedule(this::runOnEventLoop, rescheduleIntervalNanos, TimeUnit.NANOSECONDS);
+            ScheduledFuture<?> rescheduleFuture =
+                eventLoop.schedule(
+                    this::runOnEventLoop, rescheduleIntervalNanos, TimeUnit.NANOSECONDS);
+            rescheduleFuture.addListener(
+                future -> {
+                  if (future.isCancelled()) {
+                    failPendingWrites(
+                        rejectedExecutionFailure(
+                            new RejectedExecutionException(
+                                "Event loop cancelled a scheduled write task")));
+                  } else if (!future.isSuccess()) {
+                    Throwable failure = future.cause();
+                    failPendingWrites(
+                        failure instanceof RejectedExecutionException
+                            ? rejectedExecutionFailure(failure)
+                            : failure);
+                  }
+                });
           } catch (Throwable t) {
             failPendingWrites(
                 t instanceof RejectedExecutionException ? rejectedExecutionFailure(t) : t);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -37,12 +37,14 @@ import com.datastax.oss.driver.internal.core.protocol.ShardingInfo;
 import com.datastax.oss.driver.internal.core.protocol.ShardingInfo.ConnectionShardingInfo;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.protocol.internal.Message;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import java.net.SocketAddress;
@@ -50,6 +52,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import net.jcip.annotations.ThreadSafe;
 
 /**
@@ -73,6 +76,7 @@ public class DriverChannel {
   private final Channel channel;
   private final InFlightHandler inFlightHandler;
   private final WriteCoalescer writeCoalescer;
+  private final EventExecutor listenerNotificationExecutor;
   private final ProtocolVersion protocolVersion;
   private final AtomicBoolean closing = new AtomicBoolean();
   private final AtomicBoolean forceClosing = new AtomicBoolean();
@@ -87,10 +91,16 @@ public class DriverChannel {
     this.channel = channel;
     this.inFlightHandler = channel.pipeline().get(InFlightHandler.class);
     this.writeCoalescer = writeCoalescer;
+    this.listenerNotificationExecutor = writeCoalescer.listenerNotificationExecutor(channel);
     this.protocolVersion = protocolVersion;
   }
 
   /**
+   * Once this method is entered, it takes ownership of the caller's pre-acquired stream id: it
+   * either submits the request to {@link InFlightHandler} or cancels the reservation and returns a
+   * failed future. Callers must invoke {@link #cancelPreAcquireId()} themselves only if they fail
+   * before reaching this method.
+   *
    * @return a future that succeeds when the request frame was successfully written on the channel.
    *     Beyond that, the caller will be notified through the {@code responseCallback}.
    */
@@ -100,10 +110,38 @@ public class DriverChannel {
       Map<String, ByteBuffer> customPayload,
       ResponseCallback responseCallback) {
     if (closing.get()) {
-      return channel.newFailedFuture(new IllegalStateException("Driver channel is closing"));
+      cancelPreAcquireId();
+      return newFailedWriteFuture(new IllegalStateException("Driver channel is closing"));
     }
-    RequestMessage message = new RequestMessage(request, tracing, customPayload, responseCallback);
-    return writeCoalescer.writeAndFlush(channel, message);
+    RequestMessage message =
+        new RequestMessage(request, tracing, customPayload, responseCallback, inFlightHandler);
+    try {
+      Future<Void> writeFuture = writeCoalescer.writeAndFlush(channel, message);
+      writeFuture.addListener(
+          future -> {
+            if (!future.isSuccess()) {
+              message.cancelPreAcquireId();
+            }
+          });
+      // A custom coalescer might return a promise whose listener executor already rejects tasks.
+      // If the write failed synchronously, the listener above might not have run. The ownership
+      // transition is atomic, so this check is safe even if the listener did run.
+      if (writeFuture.isDone() && !writeFuture.isSuccess()) {
+        message.cancelPreAcquireId();
+      }
+      return writeFuture;
+    } catch (Throwable t) {
+      // This method must not throw after taking ownership because callers only cancel failures
+      // that happen before they invoke it.
+      message.cancelPreAcquireId();
+      return newFailedWriteFuture(t);
+    }
+  }
+
+  private Future<Void> newFailedWriteFuture(Throwable failure) {
+    // Event-loop shutdown can reject listener notification. The shared executor falls back to the
+    // completing thread so retry/error handling still runs, possibly inline on this call stack.
+    return listenerNotificationExecutor.newFailedFuture(failure);
   }
 
   /**
@@ -193,7 +231,9 @@ public class DriverChannel {
    *
    * <p>There must be <b>exactly one</b> invocation of this method before each call to {@link
    * #write(Message, boolean, Map, ResponseCallback)}. If this method returns true, the client
-   * <b>must</b> proceed with the write. If it returns false, it <b>must not</b> proceed.
+   * <b>must</b> proceed with the write or call {@link #cancelPreAcquireId()} if it fails before
+   * reaching the write. If it returns false, it must neither proceed with the write nor cancel the
+   * reservation.
    *
    * <p>This method is used together with {@link #getAvailableIds()} to track how many requests are
    * currently executing on the channel, and avoid submitting a request that would result in a
@@ -218,6 +258,14 @@ public class DriverChannel {
    */
   public boolean preAcquireId() {
     return inFlightHandler.preAcquireId();
+  }
+
+  /**
+   * Cancels the reservation made by a successful {@link #preAcquireId()} call when its matching
+   * request cannot be submitted to {@link #write(Message, boolean, Map, ResponseCallback)}.
+   */
+  public void cancelPreAcquireId() {
+    inFlightHandler.cancelPreAcquireId();
   }
 
   /**
@@ -323,20 +371,49 @@ public class DriverChannel {
   // This is essentially a stripped-down Frame. We can't materialize the frame before writing,
   // because we need the stream id, which is assigned from within the event loop.
   static class RequestMessage {
+    private static final AtomicIntegerFieldUpdater<RequestMessage> OWNS_PRE_ACQUIRE_ID =
+        AtomicIntegerFieldUpdater.newUpdater(RequestMessage.class, "ownsPreAcquireId");
+
     final Message request;
     final boolean tracing;
     final Map<String, ByteBuffer> customPayload;
     final ResponseCallback responseCallback;
+    private final InFlightHandler preAcquireIdOwner;
 
+    @SuppressWarnings("unused") // accessed through OWNS_PRE_ACQUIRE_ID
+    private volatile int ownsPreAcquireId;
+
+    @VisibleForTesting
     RequestMessage(
         Message message,
         boolean tracing,
         Map<String, ByteBuffer> customPayload,
         ResponseCallback responseCallback) {
+      this(message, tracing, customPayload, responseCallback, null);
+    }
+
+    RequestMessage(
+        Message message,
+        boolean tracing,
+        Map<String, ByteBuffer> customPayload,
+        ResponseCallback responseCallback,
+        InFlightHandler preAcquireIdOwner) {
       this.request = message;
       this.tracing = tracing;
       this.customPayload = customPayload;
       this.responseCallback = responseCallback;
+      this.preAcquireIdOwner = preAcquireIdOwner;
+      this.ownsPreAcquireId = preAcquireIdOwner == null ? 0 : 1;
+    }
+
+    boolean markPreAcquireIdAsSubmitted() {
+      return preAcquireIdOwner == null || OWNS_PRE_ACQUIRE_ID.compareAndSet(this, 1, 0);
+    }
+
+    void cancelPreAcquireId() {
+      if (OWNS_PRE_ACQUIRE_ID.compareAndSet(this, 1, 0)) {
+        preAcquireIdOwner.cancelPreAcquireId();
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
@@ -117,6 +117,14 @@ public class InFlightHandler extends ChannelDuplexHandler {
   }
 
   private void write(ChannelHandlerContext ctx, RequestMessage message, ChannelPromise promise) {
+    // From this point on, this handler owns the pre-acquired stream id and is responsible for
+    // releasing it on every failure path.
+    if (!message.markPreAcquireIdAsSubmitted()) {
+      LOG.warn(
+          "[{}] Dropping write because its stream id reservation was already cancelled", logPrefix);
+      promise.setFailure(new IllegalStateException("Stream id reservation was already cancelled"));
+      return;
+    }
     if (closingGracefully) {
       promise.setFailure(new IllegalStateException("Channel is closing"));
       streamIds.cancelPreAcquire();
@@ -394,6 +402,10 @@ public class InFlightHandler extends ChannelDuplexHandler {
 
   boolean preAcquireId() {
     return streamIds.preAcquire();
+  }
+
+  void cancelPreAcquireId() {
+    streamIds.cancelPreAcquire();
   }
 
   int getInFlight() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/PassThroughWriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/PassThroughWriteCoalescer.java
@@ -20,18 +20,34 @@ package com.datastax.oss.driver.internal.core.channel;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.EventExecutor;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import net.jcip.annotations.ThreadSafe;
 
 /** No-op implementation of the write coalescer: each write is flushed immediately. */
 @ThreadSafe
 public class PassThroughWriteCoalescer implements WriteCoalescer {
 
+  private final ConcurrentMap<EventLoop, RejectionSafeEventExecutor> listenerExecutors =
+      new ConcurrentHashMap<>();
+
   public PassThroughWriteCoalescer(@SuppressWarnings("unused") DriverContext context) {
     // nothing to do
   }
 
   @Override
+  public EventExecutor listenerNotificationExecutor(Channel channel) {
+    return listenerExecutors.computeIfAbsent(channel.eventLoop(), RejectionSafeEventExecutor::new);
+  }
+
+  @Override
   public ChannelFuture writeAndFlush(Channel channel, Object message) {
-    return channel.writeAndFlush(message);
+    ChannelPromise promise =
+        new DefaultChannelPromise(channel, listenerNotificationExecutor(channel));
+    return channel.writeAndFlush(message, promise);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/RejectionSafeEventExecutor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/RejectionSafeEventExecutor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs promise listeners on their channel's event loop in the normal case, but falls back to the
+ * completing thread when that event loop rejects the notification task during shutdown.
+ */
+class RejectionSafeEventExecutor extends AbstractEventExecutor {
+  private final EventLoop eventLoop;
+
+  RejectionSafeEventExecutor(EventLoop eventLoop) {
+    super(eventLoop.parent());
+    this.eventLoop = eventLoop;
+  }
+
+  @Override
+  public boolean inEventLoop() {
+    return eventLoop.inEventLoop();
+  }
+
+  @Override
+  public boolean inEventLoop(Thread thread) {
+    return eventLoop.inEventLoop(thread);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    try {
+      eventLoop.execute(command);
+    } catch (RejectedExecutionException e) {
+      ImmediateEventExecutor.INSTANCE.execute(command);
+    }
+  }
+
+  @Override
+  public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+    return eventLoop.shutdownGracefully(quietPeriod, timeout, unit);
+  }
+
+  @Override
+  public Future<?> terminationFuture() {
+    return eventLoop.terminationFuture();
+  }
+
+  @Override
+  @Deprecated
+  public void shutdown() {
+    eventLoop.shutdownGracefully();
+  }
+
+  @Override
+  public boolean isShuttingDown() {
+    return eventLoop.isShuttingDown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return eventLoop.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return eventLoop.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return eventLoop.awaitTermination(timeout, unit);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
@@ -24,8 +24,8 @@ import net.jcip.annotations.NotThreadSafe;
 /**
  * Manages the set of identifiers used to distinguish multiplexed requests on a channel.
  *
- * <p>{@link #preAcquire()} / {@link #getAvailableIds()} follow atomic semantics. See {@link
- * DriverChannel#preAcquireId()} for more explanations.
+ * <p>{@link #preAcquire()}, {@link #cancelPreAcquire()}, and {@link #getAvailableIds()} follow
+ * atomic semantics. See {@link DriverChannel#preAcquireId()} for more explanations.
  *
  * <p>Other methods are not synchronized, they are only called by {@link InFlightHandler} on the I/O
  * thread.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/WriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/WriteCoalescer.java
@@ -19,6 +19,7 @@ package com.datastax.oss.driver.internal.core.channel;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Optimizes the write operations on Netty channels.
@@ -29,6 +30,15 @@ import io.netty.channel.ChannelFuture;
  * to be accumulated and flushed together for better performance.
  */
 public interface WriteCoalescer {
+  /**
+   * Returns the executor to notify write-future listeners. Notifications normally run on the
+   * channel's event loop, but must fall back to the completing thread if shutdown rejects them.
+   * Implementations must use this executor for the future returned by {@link #writeAndFlush}.
+   */
+  default EventExecutor listenerNotificationExecutor(Channel channel) {
+    return new RejectionSafeEventExecutor(channel.eventLoop());
+  }
+
   /**
    * Writes and flushes the message to the channel, possibly at a later time, but <b>the order of
    * messages must be preserved</b>.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -229,14 +229,22 @@ public class CqlPrepareHandler implements Throttled {
     if (channel == null) {
       setFinalError(AllNodesFailedException.fromErrors(this.errors));
     } else {
-      InitialPrepareCallback initialPrepareCallback =
-          new InitialPrepareCallback(request, node, channel, retryCount);
+      boolean writeSubmitted = false;
+      try {
+        InitialPrepareCallback initialPrepareCallback =
+            new InitialPrepareCallback(request, node, channel, retryCount);
 
-      Prepare message = toPrepareMessage(request);
+        Prepare message = toPrepareMessage(request);
 
-      channel
-          .write(message, false, request.getCustomPayload(), initialPrepareCallback)
-          .addListener(initialPrepareCallback);
+        Future<Void> writeFuture =
+            channel.write(message, false, request.getCustomPayload(), initialPrepareCallback);
+        writeSubmitted = true;
+        writeFuture.addListener(initialPrepareCallback);
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 
@@ -316,20 +324,26 @@ public class CqlPrepareHandler implements Throttled {
       LOG.trace("[{}] Could not get a channel to reprepare on {}, skipping", logPrefix, node);
       return CompletableFuture.completedFuture(null);
     } else {
-      ThrottledAdminRequestHandler<ByteBuffer> handler =
-          ThrottledAdminRequestHandler.prepare(
-              channel,
-              false,
-              toPrepareMessage(request),
-              request.getCustomPayload(),
-              Conversions.resolveRequestTimeout(request, executionProfile),
-              throttler,
-              session.getMetricUpdater(),
-              logPrefix);
+      ThrottledAdminRequestHandler<ByteBuffer> handler;
+      try {
+        handler =
+            ThrottledAdminRequestHandler.prepare(
+                channel,
+                false,
+                toPrepareMessage(request),
+                request.getCustomPayload(),
+                Conversions.resolveRequestTimeout(request, executionProfile),
+                throttler,
+                session.getMetricUpdater(),
+                logPrefix);
+      } catch (Throwable t) {
+        channel.cancelPreAcquireId();
+        throw t;
+      }
       return handler
           .start()
           .handle(
-              (result, error) -> {
+              (preparedId, error) -> {
                 if (error == null) {
                   LOG.trace("[{}] Successfully reprepared on {}", logPrefix, node);
                 } else {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -409,30 +409,39 @@ public class CqlRequestHandler implements Throttled {
         setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
       }
     } else {
-      Statement finalStatement = statement;
-      String nodeRequestId =
-          this.requestIdGenerator
-              .map((g) -> g.getNodeRequestId(finalStatement, sessionRequestId))
-              .orElse(Integer.toString(this.hashCode()));
-      statement =
-          this.requestIdGenerator
-              .map((g) -> g.getDecoratedStatement(finalStatement, nodeRequestId))
-              .orElse(finalStatement);
+      boolean writeSubmitted = false;
+      try {
+        Statement finalStatement = statement;
+        String nodeRequestId =
+            this.requestIdGenerator
+                .map((g) -> g.getNodeRequestId(finalStatement, sessionRequestId))
+                .orElse(Integer.toString(this.hashCode()));
+        statement =
+            this.requestIdGenerator
+                .map((g) -> g.getDecoratedStatement(finalStatement, nodeRequestId))
+                .orElse(finalStatement);
 
-      NodeResponseCallback nodeResponseCallback =
-          new NodeResponseCallback(
-              statement,
-              node,
-              queryPlan,
-              channel,
-              currentExecutionIndex,
-              retryCount,
-              scheduleNextExecution,
-              logPrefixJoiner.join(this.sessionName, nodeRequestId, currentExecutionIndex));
-      Message message = Conversions.toMessage(statement, executionProfile, context);
-      channel
-          .write(message, statement.isTracing(), statement.getCustomPayload(), nodeResponseCallback)
-          .addListener(nodeResponseCallback);
+        NodeResponseCallback nodeResponseCallback =
+            new NodeResponseCallback(
+                statement,
+                node,
+                queryPlan,
+                channel,
+                currentExecutionIndex,
+                retryCount,
+                scheduleNextExecution,
+                logPrefixJoiner.join(this.sessionName, nodeRequestId, currentExecutionIndex));
+        Message message = Conversions.toMessage(statement, executionProfile, context);
+        Future<java.lang.Void> writeFuture =
+            channel.write(
+                message, statement.isTracing(), statement.getCustomPayload(), nodeResponseCallback);
+        writeSubmitted = true;
+        writeFuture.addListener(nodeResponseCallback);
+      } finally {
+        if (!writeSubmitted) {
+          channel.cancelPreAcquireId();
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -168,7 +168,9 @@ public class ChannelPool implements AsyncAutoCloseable {
    *     request path, and we want to avoid complex check-then-act semantics; therefore this might
    *     race and return a channel that is already closed, or {@code null}. In those cases, it is up
    *     to the caller to fail fast and move to the next node.
-   *     <p>There is no need to return the channel.
+   *     <p>A non-null result owns a pre-acquired stream id. The caller must either submit a request
+   *     through {@link DriverChannel#write} or release it through {@link
+   *     DriverChannel#cancelPreAcquireId()} if it cannot submit.
    */
   public DriverChannel next(@Nullable Token routingKey, @Nullable Integer shardSuggestion) {
     if (!singleThreaded.initialized) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -269,6 +269,7 @@ public class DefaultSession implements CqlSession {
         return null;
       } else if (channel.closeFuture().isDone()) {
         LOG.trace("[{}] Pool returned closed connection to {}, skipping", logPrefix, node);
+        channel.cancelPreAcquireId();
         return null;
       } else {
         return channel;

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousCqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousCqlRequestHandlerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -49,7 +50,9 @@ import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.servererrors.BootstrappingException;
+import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.internal.core.ProtocolFeature;
 import com.datastax.oss.driver.internal.core.cql.PoolBehavior;
@@ -208,6 +211,34 @@ public class ContinuousCqlRequestHandlerTest extends ContinuousCqlRequestHandler
                       .handle())
           .isInstanceOf(IllegalStateException.class)
           .hasMessage("Cannot execute continuous paging requests with protocol version " + version);
+    }
+  }
+
+  @Test
+  public void should_unwind_execution_if_request_setup_fails_before_write() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    SimpleStatement statement = Mockito.spy(SimpleStatement.newInstance("mock query"));
+    doThrow(failure).when(statement).getCustomPayload();
+    RequestThrottler throttler = mock(RequestThrottler.class);
+    RequestHandlerTestHarness.Builder builder =
+        continuousHarnessBuilder().withProtocolVersion(DSE_V2);
+    PoolBehavior node1Behavior = builder.customBehavior(node1);
+
+    try (RequestHandlerTestHarness harness = builder.build()) {
+      when(harness.getContext().getRequestThrottler()).thenReturn(throttler);
+      ContinuousCqlRequestHandler handler =
+          new ContinuousCqlRequestHandler(
+              statement, harness.getSession(), harness.getContext(), "test");
+      CompletionStage<ContinuousAsyncResultSet> resultSetFuture = handler.handle();
+
+      assertThatThrownBy(() -> handler.onThrottleReady(false)).isSameAs(failure);
+
+      assertThatStage(resultSetFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+      assertThat(handler.getActiveExecutionsCount()).isZero();
+      assertThat(handler.getInFlightCallbackCount()).isZero();
+      node1Behavior.verifyNoWrite();
+      node1Behavior.verifyPreAcquireCancelled();
+      verify(throttler).signalError(handler, failure);
     }
   }
 

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/graph/ContinuousGraphRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/graph/ContinuousGraphRequestHandlerSpeculativeExecutionTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -257,6 +258,59 @@ public class ContinuousGraphRequestHandlerSpeculativeExecutionTest {
               anyLong(),
               eq(TimeUnit.NANOSECONDS));
       verifyNoMoreInteractions(nodeMetricUpdater1);
+    }
+  }
+
+  @Test
+  @UseDataProvider(location = DseTestDataProviders.class, value = "idempotentGraphConfig")
+  public void should_cancel_pre_acquired_id_if_result_completes_after_channel_acquired(
+      boolean defaultIdempotence, GraphStatement<?> statement) throws Exception {
+    GraphRequestHandlerTestHarness.Builder harnessBuilder =
+        GraphRequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
+    PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
+    PoolBehavior node2Behavior = harnessBuilder.customBehavior(node2);
+
+    try (GraphRequestHandlerTestHarness harness = harnessBuilder.build()) {
+      SpeculativeExecutionPolicy speculativeExecutionPolicy =
+          harness.getContext().getSpeculativeExecutionPolicy(DriverExecutionProfile.DEFAULT_NAME);
+      long firstExecutionDelay = 100L;
+      when(speculativeExecutionPolicy.nextExecution(
+              any(Node.class), eq(null), eq(statement), eq(1)))
+          .thenReturn(firstExecutionDelay);
+
+      GraphBinaryModule module = createGraphBinaryModule(harness.getContext());
+      CompletionStage<AsyncGraphResultSet> resultSetFuture =
+          new ContinuousGraphRequestHandler(
+                  statement,
+                  harness.getSession(),
+                  harness.getContext(),
+                  "test",
+                  module,
+                  graphSupportChecker)
+              .handle();
+      node1Behavior.verifyWrite();
+      node1Behavior.setWriteSuccess();
+
+      CapturedTimeout speculativeExecution = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution.getDelay(TimeUnit.MILLISECONDS))
+          .isEqualTo(firstExecutionDelay);
+
+      // Simulate the initial execution winning after the speculative execution reserves an ID,
+      // but before it submits its write.
+      doAnswer(
+              invocation -> {
+                node1Behavior.setResponseSuccess(
+                    defaultDseFrameOf(singleGraphRow(GraphProtocol.GRAPH_BINARY_1_0, module)));
+                return node2Behavior.getChannel();
+              })
+          .when(harness.getSession())
+          .getChannel(eq(node2), anyString());
+
+      speculativeExecution.task().run(speculativeExecution);
+
+      assertThatStage(resultSetFuture).isSuccess();
+      node2Behavior.verifyNoWrite();
+      node2Behavior.verifyPreAcquireCancelled();
     }
   }
 

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandlerTest.java
@@ -27,10 +27,12 @@ import static com.datastax.dse.driver.internal.core.graph.GraphTestUtils.singleG
 import static com.datastax.oss.driver.api.core.type.codec.TypeCodecs.BIGINT;
 import static com.datastax.oss.driver.api.core.type.codec.TypeCodecs.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -575,6 +577,37 @@ public class GraphRequestHandlerTest {
     assertThat(m).isInstanceOf(Query.class);
     Query q = ((Query) m);
     assertThat(q.options.consistency).isEqualTo(DefaultConsistencyLevel.THREE.getProtocolCode());
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_graph_payload_conversion_fails() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    ScriptGraphStatement graphStatement =
+        Mockito.spy(ScriptGraphStatement.newInstance("mock query"));
+    doThrow(failure).when(graphStatement).getCustomPayload();
+
+    GraphRequestHandlerTestHarness.Builder builder = GraphRequestHandlerTestHarness.builder();
+    PoolBehavior nodeBehavior = builder.customBehavior(node);
+    try (GraphRequestHandlerTestHarness harness = builder.build()) {
+      GraphSupportChecker graphSupportChecker = mock(GraphSupportChecker.class);
+      when(graphSupportChecker.inferGraphProtocol(any(), any(), any()))
+          .thenReturn(GRAPH_BINARY_1_0);
+      GraphBinaryModule module = createGraphBinaryModule(harness.getContext());
+
+      assertThatThrownBy(
+              () ->
+                  new GraphRequestHandler(
+                      graphStatement,
+                      harness.getSession(),
+                      harness.getContext(),
+                      "test",
+                      module,
+                      graphSupportChecker))
+          .isSameAs(failure);
+
+      nodeBehavior.verifyNoWrite();
+      nodeBehavior.verifyPreAcquireCancelled();
+    }
   }
 
   @DataProvider

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.adminrequest;
+
+import static com.datastax.oss.driver.Assertions.assertThatStage;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
+import com.datastax.oss.driver.api.core.session.throttling.Throttled;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.request.Query;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ThrottledAdminRequestHandlerTest {
+
+  @Mock private DriverChannel channel;
+  @Mock private RequestThrottler throttler;
+  @Mock private SessionMetricUpdater metricUpdater;
+  private final AtomicInteger availableIds = new AtomicInteger(1);
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(channel.preAcquireId()).thenAnswer(invocation -> availableIds.compareAndSet(1, 0));
+    doAnswer(
+            invocation -> {
+              if (!availableIds.compareAndSet(0, 1)) {
+                throw new AssertionError("No caller-owned reservation to cancel");
+              }
+              return null;
+            })
+        .when(channel)
+        .cancelPreAcquireId();
+  }
+
+  @Test
+  public void should_release_permit_and_reservation_when_metric_update_throws() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    ThrottledAdminRequestHandler<AdminResult> handler = newHandler();
+    handler.start();
+    doThrow(failure)
+        .when(metricUpdater)
+        .updateTimer(
+            eq(DefaultSessionMetric.THROTTLING_DELAY),
+            isNull(),
+            anyLong(),
+            eq(TimeUnit.NANOSECONDS));
+
+    assertThatThrownBy(() -> handler.onThrottleReady(true)).isSameAs(failure);
+
+    assertThat(availableIds.get()).isEqualTo(1);
+    verify(throttler).signalError(handler, failure);
+    verify(channel, never()).write(any(), anyBoolean(), anyMap(), any());
+    assertThatStage(handler.result).isFailed(error -> assertThat(error).isSameAs(failure));
+  }
+
+  @Test
+  public void should_release_permit_when_synchronous_write_throws() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    ThrottledAdminRequestHandler<AdminResult> handler = newHandler();
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Throttled.class).onThrottleReady(false);
+              return null;
+            })
+        .when(throttler)
+        .register(handler);
+    doThrow(failure).when(channel).write(any(), anyBoolean(), anyMap(), eq(handler));
+
+    assertThatThrownBy(handler::start).isSameAs(failure);
+
+    assertThat(availableIds.get()).isEqualTo(1);
+    verify(throttler).signalError(handler, failure);
+    assertThatStage(handler.result).isFailed(error -> assertThat(error).isSameAs(failure));
+  }
+
+  @Test
+  public void should_complete_result_without_releasing_permit_when_registration_throws() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    ThrottledAdminRequestHandler<AdminResult> handler = newHandler();
+    doThrow(failure).when(throttler).register(handler);
+
+    assertThatThrownBy(handler::start).isSameAs(failure);
+
+    assertThat(availableIds.get()).isEqualTo(1);
+    verify(throttler, never()).signalError(handler, failure);
+    assertThatStage(handler.result).isFailed(error -> assertThat(error).isSameAs(failure));
+  }
+
+  private ThrottledAdminRequestHandler<AdminResult> newHandler() {
+    assertThat(channel.preAcquireId()).isTrue();
+    assertThat(availableIds.get()).isZero();
+    return ThrottledAdminRequestHandler.query(
+        channel,
+        false,
+        new Query("mock query"),
+        Frame.NO_PAYLOAD,
+        Duration.ZERO,
+        throttler,
+        metricUpdater,
+        "test",
+        "mock query");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequestTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequestTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.request.Query;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ChannelHandlerRequestTest {
+
+  @Mock private ChannelHandlerContext context;
+  @Mock private Channel channel;
+  @Mock private ChannelPipeline pipeline;
+  @Mock private EventLoop eventLoop;
+  @Mock private InFlightHandler inFlightHandler;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(context.channel()).thenReturn(channel);
+    when(context.pipeline()).thenReturn(pipeline);
+    when(pipeline.get(InFlightHandler.class)).thenReturn(inFlightHandler);
+    when(channel.eventLoop()).thenReturn(eventLoop);
+    when(eventLoop.inEventLoop()).thenReturn(true);
+    when(inFlightHandler.preAcquireId()).thenReturn(true);
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_request_construction_fails() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    TestRequest request = new TestRequest(failure);
+
+    assertThatThrownBy(request::send).isSameAs(failure);
+
+    verify(inFlightHandler).cancelPreAcquireId();
+    verify(channel, never()).writeAndFlush(any());
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_raw_write_throws() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    TestRequest request = new TestRequest(null);
+    doThrow(failure).when(channel).writeAndFlush(any());
+
+    assertThatThrownBy(request::send).isSameAs(failure);
+
+    verify(inFlightHandler).cancelPreAcquireId();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_raw_write_fails_asynchronously() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    TestRequest request = new TestRequest(null);
+    request.expectFailure = true;
+    ChannelPromise writePromise =
+        new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+    when(channel.writeAndFlush(any())).thenReturn(writePromise);
+
+    request.send();
+    writePromise.setFailure(failure);
+
+    verify(inFlightHandler).cancelPreAcquireId();
+    assertThat(request.failureCause).isSameAs(failure);
+  }
+
+  private class TestRequest extends ChannelHandlerRequest {
+
+    private final RuntimeException requestFailure;
+    private boolean expectFailure;
+    private Throwable failureCause;
+
+    private TestRequest(RuntimeException requestFailure) {
+      super(context, 1000);
+      this.requestFailure = requestFailure;
+    }
+
+    @Override
+    String describe() {
+      return "test request";
+    }
+
+    @Override
+    Message getRequest() {
+      if (requestFailure != null) {
+        throw requestFailure;
+      }
+      return new Query("mock query");
+    }
+
+    @Override
+    void onResponse(Message response) {}
+
+    @Override
+    void fail(String message, Throwable cause) {
+      if (!expectFailure) {
+        throw new AssertionError("Unexpected failure callback", cause);
+      }
+      failureCause = cause;
+    }
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescerTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.connection.ClosedConnectionException;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.request.Query;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import java.time.Duration;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DefaultWriteCoalescerTest {
+
+  @Mock private DriverContext context;
+  @Mock private DriverConfig config;
+  @Mock private DriverExecutionProfile executionProfile;
+  @Mock private Channel channel;
+  @Mock private EventLoop eventLoop;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(context.getConfig()).thenReturn(config);
+    when(config.getDefaultProfile()).thenReturn(executionProfile);
+    when(executionProfile.getDuration(DefaultDriverOption.COALESCER_INTERVAL))
+        .thenReturn(Duration.ZERO);
+    when(channel.eventLoop()).thenReturn(eventLoop);
+    when(eventLoop.inEventLoop()).thenReturn(true);
+  }
+
+  @Test
+  public void should_fail_concurrent_writes_and_allow_later_enqueue_if_initial_scheduling_fails() {
+    DefaultWriteCoalescer coalescer = new DefaultWriteCoalescer(context);
+    Object rejectedMessage = new Object();
+    StreamIdGenerator streamIds = new StreamIdGenerator(1);
+    assertThat(streamIds.preAcquire()).isTrue();
+    DriverChannel.RequestMessage queuedMessage = newRequestMessage(streamIds);
+    Object laterMessage = new Object();
+    AtomicReference<ChannelFuture> queuedFuture = new AtomicReference<>();
+    RejectedExecutionException failure = new RejectedExecutionException("mock failure");
+
+    doAnswer(
+            invocation -> {
+              // Simulate another caller enqueueing while the first scheduling attempt owns the
+              // running flag.
+              queuedFuture.set(coalescer.writeAndFlush(channel, queuedMessage));
+              throw failure;
+            })
+        .doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(eventLoop)
+        .execute(any(Runnable.class));
+
+    assertThatThrownBy(() -> coalescer.writeAndFlush(channel, rejectedMessage))
+        .isInstanceOf(ClosedConnectionException.class)
+        .hasCause(failure);
+
+    verify(channel, never()).write(any(), any(ChannelPromise.class));
+    assertThat(queuedFuture.get())
+        .isFailed(
+            error ->
+                assertThat(error).isInstanceOf(ClosedConnectionException.class).hasCause(failure));
+    assertThat(streamIds.getAvailableIds()).isEqualTo(1);
+
+    // Listener notification must not depend on the same event loop that rejected the write task.
+    when(eventLoop.inEventLoop()).thenReturn(false);
+    AtomicReference<Throwable> listenerFailure = new AtomicReference<>();
+    queuedFuture.get().addListener(future -> listenerFailure.set(future.cause()));
+    assertThat(listenerFailure.get())
+        .isInstanceOf(ClosedConnectionException.class)
+        .hasCause(failure);
+
+    // The failed drain releases the running flag, so a later write can schedule normally.
+    when(eventLoop.inEventLoop()).thenReturn(true);
+    coalescer.writeAndFlush(channel, laterMessage);
+    verify(channel).write(eq(laterMessage), any(ChannelPromise.class));
+    verify(channel).flush();
+  }
+
+  @Test
+  public void should_fail_concurrently_enqueued_writes_when_event_loop_is_shutting_down() {
+    DefaultWriteCoalescer coalescer = new DefaultWriteCoalescer(context);
+    StreamIdGenerator streamIds = new StreamIdGenerator(1);
+    assertThat(streamIds.preAcquire()).isTrue();
+    DriverChannel.RequestMessage queuedMessage = newRequestMessage(streamIds);
+    AtomicReference<ChannelFuture> queuedFuture = new AtomicReference<>();
+
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(eventLoop)
+        .execute(any(Runnable.class));
+    doAnswer(
+            invocation -> {
+              queuedFuture.set(coalescer.writeAndFlush(channel, queuedMessage));
+              return null;
+            })
+        .when(channel)
+        .flush();
+    when(eventLoop.isShuttingDown()).thenReturn(true);
+
+    coalescer.writeAndFlush(channel, new Object());
+
+    assertThat(queuedFuture.get())
+        .isFailed(
+            error ->
+                assertThat(error)
+                    .isInstanceOf(ClosedConnectionException.class)
+                    .hasCauseInstanceOf(RejectedExecutionException.class));
+    assertThat(streamIds.getAvailableIds()).isEqualTo(1);
+  }
+
+  @Test
+  public void should_fail_concurrently_enqueued_writes_when_rescheduling_is_rejected() {
+    DefaultWriteCoalescer coalescer = new DefaultWriteCoalescer(context);
+    StreamIdGenerator streamIds = new StreamIdGenerator(1);
+    assertThat(streamIds.preAcquire()).isTrue();
+    DriverChannel.RequestMessage queuedMessage = newRequestMessage(streamIds);
+    AtomicReference<ChannelFuture> queuedFuture = new AtomicReference<>();
+    RejectedExecutionException failure = new RejectedExecutionException("mock failure");
+
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(eventLoop)
+        .execute(any(Runnable.class));
+    doAnswer(
+            invocation -> {
+              queuedFuture.set(coalescer.writeAndFlush(channel, queuedMessage));
+              return null;
+            })
+        .when(channel)
+        .flush();
+    when(eventLoop.schedule(any(Runnable.class), anyLong(), eq(TimeUnit.NANOSECONDS)))
+        .thenThrow(failure);
+
+    coalescer.writeAndFlush(channel, new Object());
+
+    assertThat(queuedFuture.get())
+        .isFailed(
+            error ->
+                assertThat(error).isInstanceOf(ClosedConnectionException.class).hasCause(failure));
+    assertThat(streamIds.getAvailableIds()).isEqualTo(1);
+  }
+
+  @Test
+  public void should_release_pre_acquired_id_when_channel_write_throws() {
+    DefaultWriteCoalescer coalescer = new DefaultWriteCoalescer(context);
+    StreamIdGenerator streamIds = new StreamIdGenerator(1);
+    assertThat(streamIds.preAcquire()).isTrue();
+    DriverChannel.RequestMessage message = newRequestMessage(streamIds);
+    RuntimeException failure = new RuntimeException("mock failure");
+
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(eventLoop)
+        .execute(any(Runnable.class));
+    doThrow(failure).when(channel).write(eq(message), any(ChannelPromise.class));
+
+    ChannelFuture writeFuture = coalescer.writeAndFlush(channel, message);
+
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    assertThat(streamIds.getAvailableIds()).isEqualTo(1);
+  }
+
+  private DriverChannel.RequestMessage newRequestMessage(StreamIdGenerator streamIds) {
+    InFlightHandler inFlightHandler =
+        new InFlightHandler(
+            DefaultProtocolVersion.V3,
+            streamIds,
+            Integer.MAX_VALUE,
+            0,
+            mock(ChannelPromise.class),
+            null,
+            "test");
+    return new DriverChannel.RequestMessage(
+        new Query("mock query"),
+        false,
+        Frame.NO_PAYLOAD,
+        mock(ResponseCallback.class),
+        inFlightHandler);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescerTest.java
@@ -41,6 +41,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ScheduledFuture;
 import java.time.Duration;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -188,6 +190,55 @@ public class DefaultWriteCoalescerTest {
         .isFailed(
             error ->
                 assertThat(error).isInstanceOf(ClosedConnectionException.class).hasCause(failure));
+    assertThat(streamIds.getAvailableIds()).isEqualTo(1);
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void should_fail_concurrently_enqueued_writes_when_rescheduling_is_cancelled()
+      throws Exception {
+    DefaultWriteCoalescer coalescer = new DefaultWriteCoalescer(context);
+    StreamIdGenerator streamIds = new StreamIdGenerator(1);
+    assertThat(streamIds.preAcquire()).isTrue();
+    DriverChannel.RequestMessage queuedMessage = newRequestMessage(streamIds);
+    AtomicReference<ChannelFuture> queuedFuture = new AtomicReference<>();
+    ScheduledFuture<?> rescheduleFuture = mock(ScheduledFuture.class);
+    AtomicReference<GenericFutureListener> rescheduleListener = new AtomicReference<>();
+
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(eventLoop)
+        .execute(any(Runnable.class));
+    doAnswer(
+            invocation -> {
+              queuedFuture.set(coalescer.writeAndFlush(channel, queuedMessage));
+              return null;
+            })
+        .when(channel)
+        .flush();
+    when(eventLoop.schedule(any(Runnable.class), anyLong(), eq(TimeUnit.NANOSECONDS)))
+        .thenReturn((ScheduledFuture) rescheduleFuture);
+    when(rescheduleFuture.addListener(any()))
+        .thenAnswer(
+            invocation -> {
+              rescheduleListener.set(invocation.getArgument(0));
+              return rescheduleFuture;
+            });
+
+    coalescer.writeAndFlush(channel, new Object());
+
+    when(rescheduleFuture.isCancelled()).thenReturn(true);
+    rescheduleListener.get().operationComplete(rescheduleFuture);
+
+    assertThat(queuedFuture.get())
+        .isFailed(
+            error ->
+                assertThat(error)
+                    .isInstanceOf(ClosedConnectionException.class)
+                    .hasCauseInstanceOf(RejectedExecutionException.class));
     assertThat(streamIds.getAvailableIds()).isEqualTo(1);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
@@ -18,6 +18,11 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.connection.ClosedConnectionException;
@@ -27,11 +32,14 @@ import com.datastax.oss.protocol.internal.response.result.Void;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.RejectedExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -143,6 +151,113 @@ public class DriverChannelTest extends ChannelHandlerTestBase {
         .hasMessageContaining("Channel was force-closed");
   }
 
+  @Test
+  public void should_cancel_pre_acquired_id_when_write_is_rejected_before_submission() {
+    // Given
+    when(streamIds.preAcquire()).thenReturn(true);
+    assertThat(driverChannel.preAcquireId()).isTrue();
+    driverChannel.close();
+
+    // When
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+
+    // Then
+    assertThat(writeFuture).isFailed();
+    verify(streamIds).cancelPreAcquire();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_coalesced_write_throws() {
+    // Given
+    RuntimeException failure = new RuntimeException("mock failure");
+    driverChannel =
+        new DriverChannel(
+            new EmbeddedEndPoint(),
+            channel,
+            (channel, message) -> {
+              throw failure;
+            },
+            DefaultProtocolVersion.V3);
+    when(streamIds.preAcquire()).thenReturn(true);
+    assertThat(driverChannel.preAcquireId()).isTrue();
+
+    // When
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+
+    // Then
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    verify(streamIds).cancelPreAcquire();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_coalesced_write_throws_error() {
+    // Given
+    AssertionError failure = new AssertionError("mock failure");
+    driverChannel =
+        new DriverChannel(
+            new EmbeddedEndPoint(),
+            channel,
+            (channel, message) -> {
+              throw failure;
+            },
+            DefaultProtocolVersion.V3);
+    when(streamIds.preAcquire()).thenReturn(true);
+    assertThat(driverChannel.preAcquireId()).isTrue();
+
+    // When
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+
+    // Then
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    verify(streamIds).cancelPreAcquire();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_coalesced_write_fails_asynchronously() {
+    // Given
+    RuntimeException failure = new RuntimeException("mock failure");
+    when(streamIds.preAcquire()).thenReturn(true);
+    assertThat(driverChannel.preAcquireId()).isTrue();
+
+    // When
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+    writeCoalescer.failWrites(failure);
+
+    // Then
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    verify(streamIds).cancelPreAcquire();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_when_custom_coalescer_listener_is_rejected() {
+    // Given
+    RuntimeException failure = new RuntimeException("mock failure");
+    EventExecutor rejectingExecutor = mock(EventExecutor.class);
+    when(rejectingExecutor.inEventLoop()).thenReturn(false);
+    doThrow(new RejectedExecutionException()).when(rejectingExecutor).execute(any(Runnable.class));
+    driverChannel =
+        new DriverChannel(
+            new EmbeddedEndPoint(),
+            channel,
+            (channel, message) ->
+                new DefaultChannelPromise(channel, rejectingExecutor).setFailure(failure),
+            DefaultProtocolVersion.V3);
+    when(streamIds.preAcquire()).thenReturn(true);
+    assertThat(driverChannel.preAcquireId()).isTrue();
+
+    // When
+    Future<java.lang.Void> writeFuture =
+        driverChannel.write(new Query("test"), false, Frame.NO_PAYLOAD, new MockResponseCallback());
+
+    // Then
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    verify(streamIds).cancelPreAcquire();
+  }
+
   // Simple implementation that holds all the writes, and flushes them when it's explicitly
   // triggered.
   private class MockWriteCoalescer implements WriteCoalescer {
@@ -159,6 +274,12 @@ public class DriverChannelTest extends ChannelHandlerTestBase {
     void triggerFlush() {
       for (Map.Entry<Object, ChannelPromise> entry : messages) {
         channel.writeAndFlush(entry.getKey(), entry.getValue());
+      }
+    }
+
+    void failWrites(Throwable failure) {
+      for (Map.Entry<Object, ChannelPromise> entry : messages) {
+        entry.getValue().tryFailure(failure);
       }
     }
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/InFlightHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/InFlightHandlerTest.java
@@ -82,6 +82,27 @@ public class InFlightHandlerTest extends ChannelHandlerTestBase {
   }
 
   @Test
+  public void should_fail_write_if_pre_acquired_id_was_already_cancelled() {
+    // Given
+    addToPipeline();
+    InFlightHandler handler = channel.pipeline().get(InFlightHandler.class);
+    assertThat(handler.preAcquireId()).isTrue();
+    DriverChannel.RequestMessage message =
+        new DriverChannel.RequestMessage(
+            QUERY, false, Frame.NO_PAYLOAD, new MockResponseCallback(), handler);
+    message.cancelPreAcquireId();
+
+    // When
+    ChannelFuture writeFuture = channel.writeAndFlush(message);
+
+    // Then
+    assertThat(writeFuture)
+        .isFailed(error -> assertThat(error).isInstanceOf(IllegalStateException.class));
+    verify(streamIds).cancelPreAcquire();
+    verify(streamIds, never()).acquire();
+  }
+
+  @Test
   public void should_assign_streamid_and_send_frame() {
     // Given
     addToPipeline();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/PassThroughWriteCoalescerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/PassThroughWriteCoalescerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PassThroughWriteCoalescerTest {
+
+  @Mock private Channel channel;
+  @Mock private EventLoop eventLoop;
+  @Mock private EventLoopGroup eventLoopGroup;
+
+  @Test
+  public void should_notify_write_listener_when_event_loop_rejects_notification() {
+    Object message = new Object();
+    RejectedExecutionException failure = new RejectedExecutionException("mock failure");
+    PassThroughWriteCoalescer coalescer = new PassThroughWriteCoalescer(null);
+
+    when(channel.eventLoop()).thenReturn(eventLoop);
+    when(eventLoop.parent()).thenReturn(eventLoopGroup);
+    when(eventLoop.inEventLoop()).thenReturn(false);
+    doThrow(failure).when(eventLoop).execute(any(Runnable.class));
+    doAnswer(
+            invocation -> {
+              ChannelPromise promise = invocation.getArgument(1);
+              promise.setFailure(failure);
+              return promise;
+            })
+        .when(channel)
+        .writeAndFlush(eq(message), any(ChannelPromise.class));
+
+    ChannelFuture writeFuture = coalescer.writeAndFlush(channel, message);
+    AtomicReference<Throwable> listenerFailure = new AtomicReference<>();
+    writeFuture.addListener(future -> listenerFailure.set(future.cause()));
+
+    assertThat(writeFuture).isFailed(error -> assertThat(error).isSameAs(failure));
+    assertThat(listenerFailure.get()).isSameAs(failure);
+    verify(channel).writeAndFlush(message, (ChannelPromise) writeFuture);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/RejectionSafeEventExecutorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/RejectionSafeEventExecutorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.netty.channel.EventLoop;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Test;
+
+public class RejectionSafeEventExecutorTest {
+
+  @Test
+  public void should_trampoline_nested_tasks_when_event_loop_rejects_them() {
+    EventLoop eventLoop = mock(EventLoop.class);
+    doThrow(new RejectedExecutionException()).when(eventLoop).execute(any(Runnable.class));
+    RejectionSafeEventExecutor executor = new RejectionSafeEventExecutor(eventLoop);
+    List<String> events = new ArrayList<>();
+
+    executor.execute(
+        () -> {
+          events.add("outer start");
+          executor.execute(() -> events.add("inner"));
+          events.add("outer end");
+        });
+
+    assertThat(events).containsExactly("outer start", "outer end", "inner");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
@@ -20,10 +20,13 @@ package com.datastax.oss.driver.internal.core.cql;
 import static com.datastax.oss.driver.Assertions.assertThat;
 import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static com.datastax.oss.driver.internal.core.cql.CqlRequestHandlerTestBase.defaultFrameOf;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -353,6 +356,26 @@ public class CqlPrepareHandlerTest {
       verify(node3Behavior.channel)
           .write(any(Prepare.class), anyBoolean(), eq(payload), any(ResponseCallback.class));
       assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+    }
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_initial_prepare_payload_access_fails() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    DefaultPrepareRequest prepareRequest = spy(new DefaultPrepareRequest("mock query"));
+    doThrow(failure).when(prepareRequest).getCustomPayload();
+    RequestHandlerTestHarness.Builder harnessBuilder = RequestHandlerTestHarness.builder();
+    PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
+
+    try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
+      assertThatThrownBy(
+              () ->
+                  new CqlPrepareHandler(
+                      prepareRequest, harness.getSession(), harness.getContext(), "test"))
+          .isSameAs(failure);
+
+      node1Behavior.verifyNoWrite();
+      node1Behavior.verifyPreAcquireCancelled();
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
@@ -19,6 +19,9 @@ package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
 import static com.datastax.oss.driver.Assertions.assertThatStage;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,6 +40,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.tracker.RequestIdGenerator;
 import com.datastax.oss.driver.internal.core.session.RepreparePayload;
 import com.datastax.oss.driver.internal.core.util.concurrent.CapturingTimer.CapturedTimeout;
 import com.datastax.oss.protocol.internal.request.Prepare;
@@ -60,10 +64,12 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
 
   @Test
   public void should_complete_result_if_first_node_replies_immediately() {
-    try (RequestHandlerTestHarness harness =
-        RequestHandlerTestHarness.builder()
-            .withResponse(node1, defaultFrameOf(singleRow()))
-            .build()) {
+    RequestHandlerTestHarness.Builder harnessBuilder = RequestHandlerTestHarness.builder();
+    PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
+    node1Behavior.setWriteSuccess();
+    node1Behavior.setResponseSuccess(defaultFrameOf(singleRow()));
+
+    try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
       CompletionStage<AsyncResultSet> resultSetFuture =
           new CqlRequestHandler(
@@ -89,6 +95,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
                 assertThat(executionInfo.getSuccessfulExecutionIndex()).isEqualTo(0);
                 assertThat(executionInfo.getWarnings()).isEmpty();
               });
+      node1Behavior.verifyPreAcquireNotCancelled();
     }
   }
 
@@ -146,6 +153,34 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
                                 .singleElement()
                                 .isInstanceOf(NodeUnavailableException.class));
               });
+    }
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_request_decoration_fails_before_write() {
+    RequestIdGenerator requestIdGenerator = mock(RequestIdGenerator.class);
+    RuntimeException failure = new RuntimeException("mock failure");
+    when(requestIdGenerator.getSessionRequestId()).thenReturn("session");
+    when(requestIdGenerator.getNodeRequestId(any(), eq("session"))).thenReturn("node");
+    when(requestIdGenerator.getDecoratedStatement(any(), eq("node"))).thenThrow(failure);
+
+    RequestHandlerTestHarness.Builder harnessBuilder =
+        RequestHandlerTestHarness.builder().withRequestIdGenerator(requestIdGenerator);
+    PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
+
+    try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
+      // This only verifies stream-id cleanup; the other failure-path leaks are tracked in #980.
+      assertThatThrownBy(
+              () ->
+                  new CqlRequestHandler(
+                      UNDEFINED_IDEMPOTENCE_STATEMENT,
+                      harness.getSession(),
+                      harness.getContext(),
+                      "test"))
+          .isSameAs(failure);
+
+      node1Behavior.verifyNoWrite();
+      node1Behavior.verifyPreAcquireCancelled();
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PoolBehavior.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PoolBehavior.java
@@ -87,6 +87,14 @@ public class PoolBehavior {
         .write(any(Message.class), anyBoolean(), anyMap(), any(ResponseCallback.class));
   }
 
+  public void verifyPreAcquireCancelled() {
+    verify(channel).cancelPreAcquireId();
+  }
+
+  public void verifyPreAcquireNotCancelled() {
+    verify(channel, never()).cancelPreAcquireId();
+  }
+
   public void setWriteSuccess() {
     writePromise.setSuccess(null);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -45,6 +45,7 @@ import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
@@ -62,6 +63,7 @@ import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -890,6 +892,36 @@ public class DefaultSessionPoolsTest {
 
     // Pool should have been closed
     verify(pool2, VERIFY_TIMEOUT).setKeyspace(newKeyspace);
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_pool_returns_closed_channel() {
+    ChannelPool pool1 = mockPool(node1);
+    ChannelPool pool2 = mockPool(node2);
+    ChannelPool pool3 = mockPool(node3);
+    MockChannelPoolFactoryHelper factoryHelper =
+        MockChannelPoolFactoryHelper.builder(channelPoolFactory)
+            .success(node1, KEYSPACE, NodeDistance.LOCAL, pool1)
+            .success(node2, KEYSPACE, NodeDistance.LOCAL, pool2)
+            .success(node3, KEYSPACE, NodeDistance.LOCAL, pool3)
+            .build();
+
+    CompletionStage<CqlSession> initFuture = newSession();
+    factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
+    factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
+    factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
+    assertThatStage(initFuture).isSuccess();
+    DefaultSession session =
+        (DefaultSession) CompletableFutures.getCompleted(initFuture.toCompletableFuture());
+    DriverChannel channel = mock(DriverChannel.class);
+    ChannelFuture closeFuture = mock(ChannelFuture.class);
+    when(closeFuture.isDone()).thenReturn(true);
+    when(channel.closeFuture()).thenReturn(closeFuture);
+    when(pool1.next(null, null)).thenReturn(channel);
+
+    assertThat(session.getChannel(node1, "test")).isNull();
+
+    verify(channel).cancelPreAcquireId();
   }
 
   private ChannelPool mockPool(Node node) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
@@ -19,12 +19,20 @@ package com.datastax.oss.driver.internal.core.session;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
 import static com.datastax.oss.driver.Assertions.assertThatStage;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
+import com.datastax.oss.driver.api.core.session.throttling.Throttled;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
@@ -70,6 +78,7 @@ public class ReprepareOnUpTest {
   @Mock private TopologyMonitor topologyMonitor;
   @Mock private MetricsFactory metricsFactory;
   @Mock private SessionMetricUpdater metricUpdater;
+  @Mock private RequestThrottler throttler;
   private Runnable whenPrepared;
   private CompletionStage<Void> done;
 
@@ -90,6 +99,7 @@ public class ReprepareOnUpTest {
 
     when(context.getMetricsFactory()).thenReturn(metricsFactory);
     when(metricsFactory.getSessionUpdater()).thenReturn(metricUpdater);
+    when(context.getRequestThrottler()).thenReturn(throttler);
 
     done = new CompletableFuture<>();
     whenPrepared = () -> ((CompletableFuture<Void>) done).complete(null);
@@ -335,6 +345,52 @@ public class ReprepareOnUpTest {
     }
 
     assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_reprepare_query_fails_before_write() {
+    RuntimeException failure = new RuntimeException("mock failure");
+    doThrow(failure).when(throttler).register(any());
+    ReprepareOnUp reprepareOnUp =
+        new ReprepareOnUp(
+            "test",
+            pool,
+            ImmediateEventExecutor.INSTANCE,
+            getMockPayloads('a'),
+            context,
+            whenPrepared);
+
+    assertThatThrownBy(
+            () -> reprepareOnUp.queryAsync(new Query("mock query"), Collections.emptyMap(), "mock"))
+        .isSameAs(failure);
+
+    verify(channel).cancelPreAcquireId();
+  }
+
+  @Test
+  public void should_cancel_pre_acquired_id_if_reprepare_query_is_rejected_by_throttler() {
+    RequestThrottlingException failure = new RequestThrottlingException("mock failure");
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Throttled.class).onThrottleFailure(failure);
+              return null;
+            })
+        .when(throttler)
+        .register(any());
+    ReprepareOnUp reprepareOnUp =
+        new ReprepareOnUp(
+            "test",
+            pool,
+            ImmediateEventExecutor.INSTANCE,
+            getMockPayloads('a'),
+            context,
+            whenPrepared);
+
+    CompletionStage<AdminResult> result =
+        reprepareOnUp.queryAsync(new Query("mock query"), Collections.emptyMap(), "mock");
+
+    assertThatStage(result).isFailed(error -> assertThat(error).isSameAs(failure));
+    verify(channel).cancelPreAcquireId();
   }
 
   private Map<ByteBuffer, RepreparePayload> getMockPayloads(char... values) {


### PR DESCRIPTION
## Summary
- release pre-acquired stream-id reservations when request setup fails before the write is submitted to InFlightHandler
- recover the default write coalescer when event-loop scheduling rejects a queued write
- unwind continuous-request execution bookkeeping on pre-write setup failures
- cover CQL, prepare, graph, continuous, admin reprepare, direct channel-handler requests, coalescer rejection, and closed pooled channels

Fixes #947.

## Scope

This PR is intentionally limited to failures that occur before a request is accepted by `InFlightHandler`, plus rejection-safe handling of that submission boundary. It does not address failures after `InFlightHandler` has accepted ownership and acquired a concrete stream ID; that separate cleanup path is tracked in #1002. This explicitly reduces the PR scope to pre-submission reservation ownership and related write-scheduling failures.

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH mvn -pl core -Dtest=DefaultWriteCoalescerTest,ChannelHandlerRequestTest,DriverChannelTest,CqlRequestHandlerTest,DefaultSessionPoolsTest,CqlPrepareHandlerTest,GraphRequestHandlerTest,ContinuousCqlRequestHandlerTest,ContinuousGraphRequestHandlerSpeculativeExecutionTest,ReprepareOnUpTest,InFlightHandlerTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -pl core -Dtest=RejectionSafeEventExecutorTest,DriverChannelTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -pl core test` (3,817 unit tests and 76 Reactive Streams TCK tests passed)