### PR TITLE
test: support latest Scylla defaults in ITs

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/auth/PlainTextAuthProviderIT.java
@@ -44,16 +44,32 @@ import org.junit.Test;
 
 public class PlainTextAuthProviderIT {
 
+  private static final String USERNAME = "cassandra";
+  private static final String PASSWORD = "cassandra";
+  private static final Version SCYLLA_CUSTOM_SUPERUSER_VERSION = Version.parse("2026.2.0");
+  private static final String SCYLLA_SALTED_PASSWORD =
+      "$6$java-driver-test$2JXL/pXZTuamSsYNH/kE9UUSQETMmKIcdP8Xgdu/fiHsTHSN.EhjmLrMHPVuQ3.4w0h8CDsP/f1trG0kujylG0";
+
   @ClassRule public static final CustomCcmRule CCM_RULE = getCCMRule();
 
   private static CustomCcmRule getCCMRule() {
     CustomCcmRule.Builder builder =
         CustomCcmRule.builder()
             .withCassandraConfiguration("authenticator", "PasswordAuthenticator");
-    if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+    if (requiresExplicitScyllaSuperuser()) {
+      builder =
+          builder
+              .withCassandraConfiguration("auth_superuser_name", USERNAME)
+              .withCassandraConfiguration("auth_superuser_salted_password", SCYLLA_SALTED_PASSWORD);
+    } else if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
       builder = builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
     }
     return builder.build();
+  }
+
+  private static boolean requiresExplicitScyllaSuperuser() {
+    return CcmBridge.isDistributionOf(BackendType.SCYLLA)
+        && CcmBridge.getDistributionVersion().compareTo(SCYLLA_CUSTOM_SUPERUSER_VERSION) >= 0;
   }
 
   @BeforeClass
@@ -69,8 +85,8 @@ public class PlainTextAuthProviderIT {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .withClass(DefaultDriverOption.AUTH_PROVIDER_CLASS, PlainTextAuthProvider.class)
-            .withString(DefaultDriverOption.AUTH_PROVIDER_USER_NAME, "cassandra")
-            .withString(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, "cassandra")
+            .withString(DefaultDriverOption.AUTH_PROVIDER_USER_NAME, USERNAME)
+            .withString(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, PASSWORD)
             .build();
     try (CqlSession session = SessionUtils.newSession(CCM_RULE, loader)) {
       session.execute("select * from system.local where key='local'");
@@ -83,7 +99,7 @@ public class PlainTextAuthProviderIT {
     SessionBuilder<?, ?> builder =
         SessionUtils.baseBuilder()
             .addContactEndPoints(CCM_RULE.getContactPoints())
-            .withAuthCredentials("cassandra", "cassandra");
+            .withAuthCredentials(USERNAME, PASSWORD);
 
     try (CqlSession session = (CqlSession) builder.build()) {
       session.execute("select * from system.local where key='local'");
@@ -93,7 +109,7 @@ public class PlainTextAuthProviderIT {
   @Test
   public void should_connect_with_programmatic_provider() {
 
-    AuthProvider authProvider = new ProgrammaticPlainTextAuthProvider("cassandra", "cassandra");
+    AuthProvider authProvider = new ProgrammaticPlainTextAuthProvider(USERNAME, PASSWORD);
     SessionBuilder<?, ?> builder =
         SessionUtils.baseBuilder()
             .addContactEndPoints(CCM_RULE.getContactPoints())

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
@@ -19,6 +19,7 @@ package com.datastax.oss.driver.api.testinfra.session;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -31,6 +32,8 @@ import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.internal.core.loadbalancing.helper.NodeFilterToDistanceEvaluatorAdapter;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -69,6 +72,10 @@ public class SessionUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SessionUtils.class);
   private static final AtomicInteger keyspaceId = new AtomicInteger();
   private static final String DEFAULT_SESSION_CLASS_NAME = CqlSession.class.getName();
+  private static final String DEFAULT_CCM_DATACENTER = "dc1";
+  private static final Version SCYLLA_ENTERPRISE_TABLETS_DEFAULT_VERSION =
+      Version.parse("2024.2.0");
+  private static final Version SCYLLA_OSS_TABLETS_DEFAULT_VERSION = Version.parse("6.1.0");
 
   private static String getSessionBuilderClass() {
     return System.getProperty(SESSION_BUILDER_CLASS_PROPERTY, DEFAULT_SESSION_CLASS_NAME);
@@ -195,14 +202,29 @@ public class SessionUtils {
   /** Creates a keyspace through the given session instance, with the given profile. */
   public static void createKeyspace(
       Session session, CqlIdentifier keyspace, DriverExecutionProfile profile) {
+    String keyspaceOptions =
+        shouldUseScyllaTabletsWorkaroundForTestKeyspaces()
+            ? String.format(
+                "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '%s' : 1 } "
+                    + "AND tablets = { 'enabled' : false }",
+                DEFAULT_CCM_DATACENTER)
+            : "WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }";
     SimpleStatement createKeyspace =
         SimpleStatement.builder(
-                String.format(
-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
-                    keyspace.asCql(false)))
+                String.format("CREATE KEYSPACE %s %s;", keyspace.asCql(false), keyspaceOptions))
             .setExecutionProfile(profile)
             .build();
     session.execute(createKeyspace, Statement.SYNC);
+  }
+
+  private static boolean shouldUseScyllaTabletsWorkaroundForTestKeyspaces() {
+    if (!CcmBridge.isDistributionOf(BackendType.SCYLLA)) {
+      return false;
+    }
+    Version version = CcmBridge.getDistributionVersion();
+    return CcmBridge.SCYLLA_ENTERPRISE
+        ? version.compareTo(SCYLLA_ENTERPRISE_TABLETS_DEFAULT_VERSION) >= 0
+        : version.compareTo(SCYLLA_OSS_TABLETS_DEFAULT_VERSION) >= 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- use `NetworkTopologyStrategy` in the stable CCM datacenter `dc1` for generated test keyspaces only on Scylla versions where `SimpleStrategy` keyspaces hit tablets restrictions
- disable tablets for those generated keyspaces so existing LWT/CAS integration tests keep the same behavior
- keep `SimpleStrategy` for Cassandra and older Scylla test runs
- configure the Scylla auth superuser explicitly for latest auth integration tests
- split these test-only compatibility changes out of #965

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH mvn -pl test-infra -am -DskipTests test`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH mvn -pl integration-tests -am -DskipTests -DskipITs test-compile`

No issue created: this is a test/CI compatibility split, not a separate product defect.