### PR TITLE
fix: rename 3.x driver-core CCM ITs to *Test.java so Surefire discovers them

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -430,7 +430,7 @@ public class CCMBridge implements CCMAccess {
     this.thriftPort = thriftPort;
     this.binaryPort = binaryPort;
     this.isDSE = dseVersion != null;
-    this.isScylla = (getGlobalScyllaVersion() != null);
+    this.isScylla = (scyllaVersion != null);
     this.jvmArgs = jvmArgs;
     this.nodes = nodes;
     this.ccmDir = Files.createTempDir();

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -733,24 +733,38 @@ public class CCMBridge implements CCMAccess {
   public void add(int dc, int n) {
     logger.debug(
         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
     String storageItf = ipOfNode(n) + ":" + storagePort;
     String binaryItf = ipOfNode(n) + ":" + binaryPort;
     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
-    execute(
-        CCM_COMMAND
-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
-            + (isDSE ? " --dse" : "")
-            + (isScylla ? " --scylla" : ""),
-        n,
-        dc,
-        ipPrefix,
-        n,
-        thriftItf,
-        storageItf,
-        binaryItf,
-        TestUtils.findAvailablePort(),
-        remoteLogItf);
+    if (isScylla) {
+      // scylla-ccm's `add` command has no thrift option: Scylla never had a Thrift interface.
+      execute(
+          CCM_COMMAND
+              + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b --scylla",
+          n,
+          dc,
+          ipPrefix,
+          n,
+          storageItf,
+          binaryItf,
+          TestUtils.findAvailablePort(),
+          remoteLogItf);
+    } else {
+      String thriftItf = ipOfNode(n) + ":" + thriftPort;
+      execute(
+          CCM_COMMAND
+              + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
+              + (isDSE ? " --dse" : ""),
+          n,
+          dc,
+          ipPrefix,
+          n,
+          thriftItf,
+          storageItf,
+          binaryItf,
+          TestUtils.findAvailablePort(),
+          remoteLogItf);
+    }
   }
 
   @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
@@ -24,8 +24,8 @@ import org.testng.annotations.Test;
     })
 @ScyllaOnly
 @ScyllaVersion(minOSS = "6.0.0", minEnterprise = "2024.2", description = "Needs to support tablets")
-public class TabletsIT extends CCMTestsSupport {
-  private static final Logger LOG = LoggerFactory.getLogger(TabletsIT.class);
+public class TabletsTest extends CCMTestsSupport {
+  private static final Logger LOG = LoggerFactory.getLogger(TabletsTest.class);
   private static final int INITIAL_TABLETS = 32;
   private static final int QUERIES = 1600;
   private static final int REPLICATION_FACTOR = 2;

--- a/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
@@ -190,8 +190,13 @@ public class TabletsTest extends CCMTestsSupport {
           continue;
         }
         Session session = sessionEntry.getValue().get();
-        // Empty out tablets information
-        session.getCluster().getMetadata().getTabletMap().removeTableMappings(KEYSPACE_NAME);
+        // Empty out tablets information. The mapping is keyed by the lowercased keyspace name, as
+        // reported by the server, so the key has to be lowercased here too or this is a no-op.
+        session
+            .getCluster()
+            .getMetadata()
+            .getTabletMap()
+            .removeTableMappings(KEYSPACE_NAME.toLowerCase());
         Statement stmt;
         try {
           stmt = stmtEntry.getValue().apply(session);
@@ -226,6 +231,10 @@ public class TabletsTest extends CCMTestsSupport {
                   stmtEntry.getKey(), sessionEntry.getKey()));
           continue;
         }
+        // executeOnAllHostsAndReturnIfResultHasTabletsInfo pins the statement to a specific host
+        // while hunting for tablet info. Clear that pin, otherwise the routing check below always
+        // observes the pinned host and can never detect misrouting.
+        stmt.setHost(null);
         if (!checkIfRoutedProperly(session, stmt)) {
           testErrors.add(
               String.format(
@@ -343,6 +352,11 @@ public class TabletsTest extends CCMTestsSupport {
     int expectedNodesCount = stmt.isLWT() ? 1 : REPLICATION_FACTOR;
     Set<Host> nodes = new HashSet<>();
     for (int i = 0; i < REPLICATION_FACTOR * 3; i++) {
+      // PagingOptimizingLoadBalancingPolicy returns Statement.getLastHost() ahead of the real query
+      // plan, and that field is set after every successful BoundStatement execution. Clearing it
+      // keeps the loop from being pinned to the first coordinator, which would let any routing
+      // behaviour satisfy the check below.
+      stmt.setLastHost(null);
       nodes.add(session.execute(stmt).getExecutionInfo().getQueriedHost());
     }
     return nodes.size() <= expectedNodesCount;

--- a/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class ZeroTokenNodesIT {
+public class ZeroTokenNodesTest {
 
   @DataProvider(name = "loadBalancingPolicies")
   public static Object[][] loadBalancingPolicies() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
@@ -173,12 +173,17 @@ public class ZeroTokenNodesTest {
         queriedNodes.add(rs.getExecutionInfo().getQueriedHost().getEndPoint().resolve());
       }
 
+      // containsOnly, not containsExactly: queriedNodes is a HashSet, whose iteration order is
+      // hash-derived rather than insertion order, so an order-sensitive assertion is a latent
+      // flake.
+      // AssertJ 1.7.1, pinned by this module, has no containsExactlyInAnyOrder; for a Set,
+      // containsOnly is equivalent to it.
       if (isDcAware) {
         assertThat(queriedNodes)
-            .containsExactly(ccmBridge.addressOfNode(1), ccmBridge.addressOfNode(2));
+            .containsOnly(ccmBridge.addressOfNode(1), ccmBridge.addressOfNode(2));
       } else {
         assertThat(queriedNodes)
-            .containsExactly(
+            .containsOnly(
                 ccmBridge.addressOfNode(1),
                 ccmBridge.addressOfNode(2),
                 ccmBridge.addressOfNode(3),

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
@@ -29,9 +29,14 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.TestUtils;
+import com.google.common.base.Throwables;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 /**
@@ -41,11 +46,52 @@ import org.testng.annotations.Test;
 @CCMConfig(numberOfNodes = 3)
 public class LWTLoadBalancingTest extends CCMTestsSupport {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(LWTLoadBalancingTest.class);
+
+  /** Equal to the node count, so that every node is a replica of every partition. */
+  private static final int REPLICATION_FACTOR = 3;
+
+  private static final int EXECUTIONS = 30;
+
   @Override
   public Cluster.Builder createClusterBuilder() {
     return Cluster.builder()
         .withLoadBalancingPolicy(
             new TokenAwarePolicy(new RoundRobinPolicy(), TokenAwarePolicy.ReplicaOrdering.RANDOM));
+  }
+
+  /**
+   * Override to create the keyspace with a replication factor greater than 1. The default test
+   * keyspace created by {@link CCMTestsSupport} is hardcoded to RF=1, and with a single replica per
+   * partition "the first replica" is trivially unique — every assertion below would hold under
+   * {@code REGULAR} routing too, so the tests could not tell {@code PRESERVE_REPLICA_ORDER} apart
+   * from {@code RANDOM}.
+   *
+   * <p>Tablets are disabled when running against Scylla: with tablets enabled, replica placement
+   * comes from the tablet map, which is empty until it has been learned from a misrouted query, and
+   * an empty replica list makes the LWT query plan fall back to the child policy — a non-replica
+   * coordinator on the first execution. Cassandra does not support the tablets property.
+   */
+  @Override
+  protected void initTestKeyspace() {
+    try {
+      keyspace = TestUtils.generateIdentifier("ks_");
+      LOGGER.debug("Using keyspace " + keyspace);
+      boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
+      session()
+          .execute(
+              String.format(
+                  "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+                      + " 'datacenter1': %d}"
+                      + (isScylla ? " AND tablets = {'enabled': false}" : ""),
+                  keyspace,
+                  REPLICATION_FACTOR));
+      useKeyspace(keyspace);
+    } catch (Exception e) {
+      errorOut();
+      LOGGER.error("Could not create test keyspace", e);
+      Throwables.propagate(e);
+    }
   }
 
   @Override
@@ -65,25 +111,15 @@ public class LWTLoadBalancingTest extends CCMTestsSupport {
     simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
-    BoundStatement boundSelect = preparedSelect.bind(1, 0);
 
     // Verify statement properties
     assertThat(simpleSelect.isLWT()).isFalse();
     assertThat(simpleSelect.getConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
 
-    // Execute multiple times and collect coordinators — with PRESERVE_REPLICA_ORDER routing,
-    // the same partition key should always be routed to the same first replica.
-    Set<InetSocketAddress> coordinators = new HashSet<>();
-    for (int i = 0; i < 30; i++) {
-      ResultSet rs = session.execute(boundSelect);
-      Host coordinator = rs.getExecutionInfo().getQueriedHost();
-      assertThat(coordinator).isNotNull();
-      coordinators.add(coordinator.getEndPoint().resolve());
-    }
-
     // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key,
-    // so all 30 executions should hit the same coordinator.
-    assertThat(coordinators).hasSize(1);
+    // so every execution should hit the same coordinator. Contrast with the non-serial control in
+    // should_spread_non_serial_select_across_replicas, which shares the same statement and policy.
+    assertThat(collectCoordinators(session, preparedSelect, 1)).hasSize(1);
   }
 
   @Test(groups = "short")
@@ -95,18 +131,58 @@ public class LWTLoadBalancingTest extends CCMTestsSupport {
     simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
-    BoundStatement boundSelect = preparedSelect.bind(2, 0);
 
-    // Execute multiple times and collect coordinators
+    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key.
+    assertThat(collectCoordinators(session, preparedSelect, 2)).hasSize(1);
+  }
+
+  /**
+   * Control for the two tests above. This is the same statement against the same table, executed by
+   * the same {@code TokenAwarePolicy(RoundRobinPolicy, RANDOM)} — only the consistency level
+   * differs. A non-serial level takes the {@code REGULAR} routing path, which shuffles the replicas
+   * on every query, so the coordinator must vary. If this test ever collapses to a single
+   * coordinator as well, the {@code hasSize(1)} assertions above have stopped proving anything
+   * about {@code PRESERVE_REPLICA_ORDER}.
+   */
+  @Test(groups = "short")
+  public void should_spread_non_serial_select_across_replicas() {
+    Session session = session();
+
+    SimpleStatement simpleSelect =
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
+    simpleSelect.setConsistencyLevel(ConsistencyLevel.ONE);
+
+    PreparedStatement preparedSelect = session.prepare(simpleSelect);
+    BoundStatement boundSelect = preparedSelect.bind(3, 0);
+
+    assertThat(boundSelect.isLWT()).isFalse();
+    assertThat(boundSelect.getConsistencyLevel().isSerial()).isFalse();
+
+    // Uniform over REPLICATION_FACTOR replicas across EXECUTIONS queries, so the probability of a
+    // false failure here is REPLICATION_FACTOR^(1 - EXECUTIONS).
+    assertThat(collectCoordinators(session, preparedSelect, 3).size()).isGreaterThan(1);
+  }
+
+  /**
+   * Executes {@code prepared} against partition {@code pk} {@link #EXECUTIONS} times and returns
+   * the distinct coordinators used.
+   *
+   * <p>A fresh {@link BoundStatement} is bound for every execution on purpose. {@link
+   * PagingOptimizingLoadBalancingPolicy}, which the driver wraps around the configured policy,
+   * returns {@code Statement.getLastHost()} ahead of the real query plan, and that field is set on
+   * every successful {@code BoundStatement} execution. Reusing a single instance would therefore
+   * pin the coordinator after the first query and make every assertion in this class hold
+   * regardless of how routing actually behaves.
+   */
+  private static Set<InetSocketAddress> collectCoordinators(
+      Session session, PreparedStatement prepared, int pk) {
     Set<InetSocketAddress> coordinators = new HashSet<>();
-    for (int i = 0; i < 30; i++) {
-      ResultSet rs = session.execute(boundSelect);
+    for (int i = 0; i < EXECUTIONS; i++) {
+      ResultSet rs = session.execute(prepared.bind(pk, 0));
       Host coordinator = rs.getExecutionInfo().getQueriedHost();
       assertThat(coordinator).isNotNull();
       coordinators.add(coordinator.getEndPoint().resolve());
     }
-
-    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key.
-    assertThat(coordinators).hasSize(1);
+    return coordinators;
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
  * through the LWT load-balancing path (PRESERVE_REPLICA_ORDER).
  */
 @CCMConfig(numberOfNodes = 3)
-public class LWTLoadBalancingIT extends CCMTestsSupport {
+public class LWTLoadBalancingTest extends CCMTestsSupport {
 
   @Override
   public Cluster.Builder createClusterBuilder() {
@@ -61,7 +61,7 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
     Session session = session();
 
     SimpleStatement simpleSelect =
-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 1, 0);
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
     simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
@@ -91,7 +91,7 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
     Session session = session();
 
     SimpleStatement simpleSelect =
-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 2, 0);
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
     simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderTest.java
@@ -37,7 +37,7 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import java.util.Iterator;
 import org.testng.annotations.Test;
 
-public class SchemaBuilderIT extends CCMTestsSupport {
+public class SchemaBuilderTest extends CCMTestsSupport {
 
   // Test relies on existence of 'ks' keyspace,
   // but no such keyspace is created. If (fixed) created,


### PR DESCRIPTION
## Behavior

`driver-core`'s `*IT.java` CCM integration tests were silently never executed by CI:

- `driver-core/pom.xml` doesn't bind the `maven-failsafe-plugin` in its own `<build><plugins>` — it's only declared in the root `pluginManagement`, and actually bound only inside `driver-tests/osgi/*`.
- Maven Surefire's default `<includes>` (`**/Test*.java`, `**/*Test.java`, `**/*Tests.java`, `**/*TestCase.java`) never match `*IT.java`.
- The `-Pshort`/`-Plong` profiles (used by `make test-integration-scylla`/`test-integration-cassandra`, i.e. `mvn verify -Pshort`) only set the TestNG `test.groups` filter, which only narrows tests *within* files Surefire already selected by name — it can't rescue files Surefire never picked up in the first place.

Confirmed via `mvn help:effective-pom` and by decompiling the actual `SurefireMojo` defaults from the `maven-surefire-plugin` jar — no override exists anywhere in this repo's POMs for `driver-core`.

## Changes

Renamed the 4 affected classes to match Surefire's default discovery pattern, mirroring the identical fix already applied to `DriverConfigReportingCcmIT` → `DriverConfigReportingCcmTest` in #973:

- `TabletsIT` → `TabletsTest`
- `ZeroTokenNodesIT` → `ZeroTokenNodesTest`
- `LWTLoadBalancingIT` → `LWTLoadBalancingTest`
- `SchemaBuilderIT` → `SchemaBuilderTest`

No pom.xml changes needed — pure `git mv` + updating each `public class` declaration.

Now that `LWTLoadBalancingTest` actually runs, it surfaced a real, previously undetected bug: both test methods built a `SimpleStatement` with bound values already attached and then passed it to `session.prepare()`, which throws `IllegalArgumentException: A statement to prepare should not have values`. This file was added in a single commit and had never executed before, so nobody caught it. Fixed by preparing the value-free statement and binding actual values only on the resulting `PreparedStatement`, matching what the test already did on the next line.

### Follow-up: `ccm add` also broke on Scylla

Once the rename made `ZeroTokenNodesTest` actually execute, every "Scylla ITs" CI leg failed uniformly with `ccm: error: no such option: -t`. Root cause: `CCMBridge.add(int, int)` unconditionally passed `-t <thriftItf>` to `ccm add`, but `scylla-ccm`'s `add` command has no Thrift option at all — Scylla never had a Thrift interface. Confirmed against `scylla-ccm`'s actual `ClusterAddCmd` parser (`ccmlib/cmds/cluster_cmds.py`, master).

Fixed by branching on `isScylla` and omitting `-t`/the thrift interface entirely for Scylla clusters. `add(int, int)` is also reached via `add(int n)` → `add(1, n)` from `MetadataTest`, `SessionLeakTest`, `StateListenerTest`, `RefreshConnectedHostTest`, and `NodeRefreshDebouncerTest` — not just `ZeroTokenNodesTest` — so this fix covers all of them whenever they run against a Scylla cluster, not only the newly-enabled test.

### Review round: making the activated assertions actually assert something

Review raised that renaming these classes made them *execute*, but their assertions had never been scrutinised — and several could not fail.

The recurring cause is worth calling out, because it bit two of the three classes: **`PagingOptimizingLoadBalancingPolicy.newQueryPlan` returns `Statement.getLastHost()` ahead of the real query plan, and `PagingOptimizingLatencyTracker.update` sets that field after every successful `BoundStatement` execution.** Any test that re-executes one `BoundStatement` instance in a loop is therefore pinned to its first coordinator, so "all executions hit the same node" holds no matter how routing actually behaves.

**`TabletsTest`** — two independent false-passes:
- `removeTableMappings(KEYSPACE_NAME)` passed mixed-case `"tabletsTest"`, but `TabletMap` keys arrive lowercased from the server and are matched with an exact `equals()`, so the "empty out tablets information" step silently cleared nothing and an iteration could be satisfied by state learned in a previous one. Lowercased, as the three sibling call sites already did.
- `executeOnAllHostsAndReturnIfResultHasTabletsInfo` pins the statement via `setHost()` and never clears it, so `checkIfRoutedProperly` re-executed a pinned statement and `nodes.size() <= REPLICATION_FACTOR` could not fail. The pin is now cleared before the routing check, and `checkIfRoutedProperly` also clears `setLastHost(null)` per iteration to defeat the paging pin described above.

**`LWTLoadBalancingTest`** — could not distinguish `PRESERVE_REPLICA_ORDER` from `RANDOM`:
- The framework's default keyspace is hardcoded to RF=1 (`CCMTestsSupport.initTestKeyspace` formats `CREATE_KEYSPACE_SIMPLE_FORMAT` with a literal `1`, regardless of `@CCMConfig(numberOfNodes = 3)`), so "the first replica" was trivially unique. Now overrides `initTestKeyspace()` to create an **RF=3** keyspace, following `SingleTokenIntegrationTest`'s template — RF=3 so `SERIAL` reads get a 2-of-3 Paxos quorum rather than 2-of-2. Tablets are disabled on Scylla, as in the other replica-placement tests, because an unlearned tablet map yields an empty replica list and drops the LWT plan back to the child policy.
- RF alone does not fix it: both tests re-executed one `BoundStatement`, so `hasSize(1)` was guaranteed by the paging optimisation. Coordinator collection now binds a fresh statement per execution.
- Added `should_spread_non_serial_select_across_replicas` as a control — same statement, table and policy, only a non-serial CL — asserting the coordinator *does* vary.

**`ZeroTokenNodesTest`** — asserted on a `HashSet` with the order-sensitive `containsExactly`; `HashSet` iteration order is hash-derived, so this was a latent flake. Switched to `containsOnly` (AssertJ 1.7.1, which this module pins, has no `containsExactlyInAnyOrder`; for a `Set` it's equivalent, and it is what the rest of the file already uses).

**`CCMBridge`** — `isScylla` was derived from the global `scylla.version` property rather than the constructor's `scyllaVersion`, unlike the sibling `isDSE = dseVersion != null` one line above. Now instance-derived. Behaviour-neutral today (`Builder.scylla` already defaults to the global, `withScylla()` has no callers, and every bridge actually built takes `build()`'s `!versionConfigured` branch where `scyllaVersion` *is* the global) — a footgun removal, not a live bug fix.

### Scope: `CCMBridge` flavor resolution moved to #983

Review of this PR went on to find that `CCMBridge` resolves the server flavor from global system properties throughout, not just in `isScylla` — `buildCreateCommand` ignores the Scylla flag and emits `-v 3.0.8`, `SCYLLA_PRODUCT` derives from the global `scylla.version`, and `withSSL()`/`withAuth()` pick the JKS-vs-PEM yaml at builder-configuration time.

Fixes for all three were written and live-verified on this branch, then pulled back out: they're a refactor of the CCM test harness, not part of unblocking the tests, and none of it is reachable from CI (the IT legs run `mvn verify -Pshort`, and no enabled `short`-group test configures a version while creating a cluster). Tracked as **#983**, with the full analysis and the two remaining CodeRabbit findings recorded there, and a follow-up PR carrying the commits verbatim. Sibling to #800, which is the same bug class in 4.x.

This PR is now just the rename, the `ccm add` fix the rename made necessary, and the assertion fixes above.

### Not addressed: rewriting the LWT tests around a conditional statement

CodeRabbit also asked for `LWTLoadBalancingTest` to use a conditional `INSERT`/`UPDATE`/`DELETE` with `setSerialConsistencyLevel`, on the grounds that `TokenAwarePolicy` "does not use `getSerialConsistencyLevel()` for routing". That premise doesn't apply to these tests: they don't set the serial consistency level. They set the *normal* level to `LOCAL_SERIAL`/`SERIAL`, and `TokenAwarePolicy.getRequestRouting` (`TokenAwarePolicy.java:476-488`) returns the LWT routing method when `statement.isLWT()` **or** when the normal level `isSerial()`. The second branch is exactly what is under test, which is why the tests assert `isLWT()` is `false`. The level survives `prepare()` → `bind()`: `AbstractSession.prepareAsync` copies it onto the `PreparedStatement` (`AbstractSession.java:128-131`) and the `BoundStatement` constructor copies it back off (`BoundStatement.java:89-90`).

The suggested rewrite would exercise the `isLWT()` branch instead and drop coverage of the serial-level branch. Covering `isLWT()` as well would be a reasonable addition, but it belongs to a feature this PR didn't enable — happy to open it as a follow-up.

## Testing

- `mvn -pl driver-core -am compile test-compile` — clean compile.
- Confirmed the discovery gap is closed: `mvn -pl driver-core test -Dtest=<ClassName> -Dtest.groups=short` now actually attempts these classes (previously `Tests run: 0`).
- Live-verified all enabled tests against ScyllaDB 2026.1.0:
  - `TabletsTest`: 3/3 pass — now with routing genuinely exercised
  - `ZeroTokenNodesTest`: 7/7 pass
  - `LWTLoadBalancingTest`: 3/3 pass (2 pre-existing + the new non-serial control)
  - `SchemaBuilderTest`: 0 tests run — all 6 methods are pre-existing `enabled = false`, unrelated to this change.
- Falsification-checked the newly load-bearing assertions rather than just observing green:
  - With a reused `BoundStatement`, the non-serial control collapses to 1 coordinator — identical to the serial tests, i.e. indistinguishable.
  - With `REPLICATION_FACTOR` dropped back to 1, the control fails outright (1 coordinator), confirming the RF bump is what makes the two `hasSize(1)` assertions meaningful.
- CI: this exact head passed all 10 checks, including all four IT legs (`Scylla ITs` LATEST / LTS-LATEST / LTS-PRIOR and `Cassandra ITs 3-LATEST`). An earlier attempt on an intermediate head failed once on `ShardAwarenessTest.correctShardInTracingTest`, a pre-existing flake unrelated to this change.

Fixes #981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
