### PR TITLE
test: resolve CCM server flavor per cluster instead of from global properties

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -134,7 +134,9 @@ public class CCMBridge implements CCMAccess {
 
   /**
    * {@link #ENVIRONMENT_MAP} without the variables that depend on which server flavor and version
-   * is installed, i.e. everything a cluster configuring its own version can reuse.
+   * is installed, i.e. everything a cluster configuring its own version can reuse. {@code
+   * SCYLLA_PRODUCT} is stripped even if the surrounding process defined it, so that it can only
+   * ever be re-added for a version that was actually resolved as Enterprise.
    */
   private static final Map<String, String> BASE_ENVIRONMENT_MAP;
 
@@ -255,9 +257,16 @@ public class CCMBridge implements CCMAccess {
     if (ccmJavaHome != null) {
       envMap.put("JAVA_HOME", ccmJavaHome);
     }
+    // The global environment keeps an inherited SCYLLA_PRODUCT: a non-numeric scylla.version (a
+    // branch spec) can't be recognized as Enterprise here, and exporting the variable is the only
+    // way to select the repository in that case.
+    Map<String, String> globalEnvMap = ImmutableMap.copyOf(envMap);
+    ENVIRONMENT_MAP = globalScyllaEnterprise ? withScyllaEnterprise(globalEnvMap) : globalEnvMap;
+    // A cluster that configures its own version derives SCYLLA_PRODUCT from that version instead,
+    // so an inherited value must not reach it: it would install an explicitly configured OSS
+    // version from the Enterprise repository.
+    envMap.remove("SCYLLA_PRODUCT");
     BASE_ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
-    ENVIRONMENT_MAP =
-        globalScyllaEnterprise ? withScyllaEnterprise(BASE_ENVIRONMENT_MAP) : BASE_ENVIRONMENT_MAP;
 
     if (isDse()) {
       GLOBAL_DSE_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
@@ -1062,6 +1071,8 @@ public class CCMBridge implements CCMAccess {
     private boolean start = true;
     private boolean dse = isDse();
     private boolean scylla = GLOBAL_SCYLLA_VERSION_NUMBER != null;
+    private boolean ssl = false;
+    private boolean auth = false;
     private VersionNumber version = null;
     private final Set<String> createOptions = new LinkedHashSet<String>();
     private final Set<String> jvmArgs = new LinkedHashSet<String>();
@@ -1103,40 +1114,22 @@ public class CCMBridge implements CCMAccess {
       return this;
     }
 
-    /** Enables SSL encryption. */
+    /**
+     * Enables SSL encryption.
+     *
+     * <p>Only records the request: which keys and certificates to point the server at depends on
+     * the server flavor, which isn't resolved until {@link #build()}, see {@link
+     * #buildClientEncryptionOptions(ResolvedVersions)}.
+     */
     public Builder withSSL() {
-      cassandraConfiguration.put("client_encryption_options.enabled", "true");
-      if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
-        cassandraConfiguration.put(
-            "client_encryption_options.certificate",
-            DEFAULT_SERVER_CERT_CHAIN_FILE.getAbsolutePath());
-        cassandraConfiguration.put(
-            "client_encryption_options.keyfile", DEFAULT_SERVER_PRIVATE_KEY_FILE.getAbsolutePath());
-      } else {
-        cassandraConfiguration.put("client_encryption_options.optional", "false");
-        cassandraConfiguration.put(
-            "client_encryption_options.keystore", DEFAULT_SERVER_KEYSTORE_FILE.getAbsolutePath());
-        cassandraConfiguration.put(
-            "client_encryption_options.keystore_password", DEFAULT_SERVER_KEYSTORE_PASSWORD);
-      }
+      this.ssl = true;
       return this;
     }
 
     /** Enables client authentication. This also enables encryption ({@link #withSSL()}. */
     public Builder withAuth() {
       withSSL();
-      cassandraConfiguration.put("client_encryption_options.require_client_auth", "true");
-      if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
-        cassandraConfiguration.put(
-            "client_encryption_options.truststore",
-            DEFAULT_SERVER_TRUSTSTORE_PEM_FILE.getAbsolutePath());
-      } else {
-        cassandraConfiguration.put(
-            "client_encryption_options.truststore",
-            DEFAULT_SERVER_TRUSTSTORE_FILE.getAbsolutePath());
-        cassandraConfiguration.put(
-            "client_encryption_options.truststore_password", DEFAULT_SERVER_TRUSTSTORE_PASSWORD);
-      }
+      this.auth = true;
       return this;
     }
 
@@ -1327,6 +1320,13 @@ public class CCMBridge implements CCMAccess {
         cassandraConfiguration.put("native_shard_aware_transport_port", RANDOM_PORT);
         cassandraConfiguration = randomizePorts(cassandraConfiguration);
       }
+      // Explicitly configured entries keep winning over these defaults, as they did when withSSL()
+      // wrote them at builder-configuration time and withCassandraConfiguration() ran after it.
+      for (Map.Entry<String, Object> option : buildClientEncryptionOptions(versions).entrySet()) {
+        if (!cassandraConfiguration.containsKey(option.getKey())) {
+          cassandraConfiguration.put(option.getKey(), option.getValue());
+        }
+      }
       final CCMBridge ccm =
           new CCMBridge(
               clusterName,
@@ -1453,6 +1453,51 @@ public class CCMBridge implements CCMAccess {
     }
 
     /**
+     * The client encryption yaml for a cluster with these versions, empty unless {@link #withSSL()}
+     * or {@link #withAuth()} was called.
+     *
+     * <p>Cassandra and DSE read a JKS keystore and truststore, Scylla reads a PEM certificate, key
+     * and truststore, so the flavor has to be resolved first — which is why this can't be decided
+     * in {@code withSSL()} itself.
+     */
+    Map<String, Object> buildClientEncryptionOptions(ResolvedVersions versions) {
+      if (!ssl) {
+        return ImmutableMap.of();
+      }
+      boolean isScylla = versions.scylla != null;
+      Map<String, Object> options = Maps.newLinkedHashMap();
+      options.put("client_encryption_options.enabled", "true");
+      if (isScylla) {
+        options.put(
+            "client_encryption_options.certificate",
+            DEFAULT_SERVER_CERT_CHAIN_FILE.getAbsolutePath());
+        options.put(
+            "client_encryption_options.keyfile", DEFAULT_SERVER_PRIVATE_KEY_FILE.getAbsolutePath());
+      } else {
+        options.put("client_encryption_options.optional", "false");
+        options.put(
+            "client_encryption_options.keystore", DEFAULT_SERVER_KEYSTORE_FILE.getAbsolutePath());
+        options.put(
+            "client_encryption_options.keystore_password", DEFAULT_SERVER_KEYSTORE_PASSWORD);
+      }
+      if (auth) {
+        options.put("client_encryption_options.require_client_auth", "true");
+        if (isScylla) {
+          options.put(
+              "client_encryption_options.truststore",
+              DEFAULT_SERVER_TRUSTSTORE_PEM_FILE.getAbsolutePath());
+        } else {
+          options.put(
+              "client_encryption_options.truststore",
+              DEFAULT_SERVER_TRUSTSTORE_FILE.getAbsolutePath());
+          options.put(
+              "client_encryption_options.truststore_password", DEFAULT_SERVER_TRUSTSTORE_PASSWORD);
+        }
+      }
+      return options;
+    }
+
+    /**
      * The environment for the CCM commands of a cluster with these versions.
      *
      * <p>{@code SCYLLA_PRODUCT} has to follow the version this particular cluster installs, not the
@@ -1565,6 +1610,10 @@ public class CCMBridge implements CCMAccess {
       if (ipPrefix != builder.ipPrefix) return false;
       if (dse != builder.dse) return false;
       if (scylla != builder.scylla) return false;
+      // Not reflected in cassandraConfiguration until build(), so they have to be compared here —
+      // otherwise an encrypted cluster could be reused for a test that expects a plaintext one.
+      if (ssl != builder.ssl) return false;
+      if (auth != builder.auth) return false;
       if (!Arrays.equals(nodes, builder.nodes)) return false;
       if (version != null ? !version.equals(builder.version) : builder.version != null)
         return false;
@@ -1580,6 +1629,9 @@ public class CCMBridge implements CCMAccess {
       // do not include start as it is not relevant to the settings of the cluster.
       int result = Arrays.hashCode(nodes);
       result = 31 * result + (dse ? 1 : 0);
+      result = 31 * result + (scylla ? 1 : 0);
+      result = 31 * result + (ssl ? 1 : 0);
+      result = 31 * result + (auth ? 1 : 0);
       result = 31 * result + ipPrefix.hashCode();
       result = 31 * result + (version != null ? version.hashCode() : 0);
       result = 31 * result + createOptions.hashCode();

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -430,7 +430,7 @@ public class CCMBridge implements CCMAccess {
     this.thriftPort = thriftPort;
     this.binaryPort = binaryPort;
     this.isDSE = dseVersion != null;
-    this.isScylla = (getGlobalScyllaVersion() != null);
+    this.isScylla = (scyllaVersion != null);
     this.jvmArgs = jvmArgs;
     this.nodes = nodes;
     this.ccmDir = Files.createTempDir();

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -733,24 +733,38 @@ public class CCMBridge implements CCMAccess {
   public void add(int dc, int n) {
     logger.debug(
         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
     String storageItf = ipOfNode(n) + ":" + storagePort;
     String binaryItf = ipOfNode(n) + ":" + binaryPort;
     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
-    execute(
-        CCM_COMMAND
-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
-            + (isDSE ? " --dse" : "")
-            + (isScylla ? " --scylla" : ""),
-        n,
-        dc,
-        ipPrefix,
-        n,
-        thriftItf,
-        storageItf,
-        binaryItf,
-        TestUtils.findAvailablePort(),
-        remoteLogItf);
+    if (isScylla) {
+      // scylla-ccm's `add` command has no thrift option: Scylla never had a Thrift interface.
+      execute(
+          CCM_COMMAND
+              + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b --scylla",
+          n,
+          dc,
+          ipPrefix,
+          n,
+          storageItf,
+          binaryItf,
+          TestUtils.findAvailablePort(),
+          remoteLogItf);
+    } else {
+      String thriftItf = ipOfNode(n) + ":" + thriftPort;
+      execute(
+          CCM_COMMAND
+              + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
+              + (isDSE ? " --dse" : ""),
+          n,
+          dc,
+          ipPrefix,
+          n,
+          thriftItf,
+          storageItf,
+          binaryItf,
+          TestUtils.findAvailablePort(),
+          remoteLogItf);
+    }
   }
 
   @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -126,9 +126,10 @@ public class CCMBridge implements CCMAccess {
    * running tests. For example, if you want to run tests with JDK 6 but against Cassandra 2.0,
    * which requires JDK 7.
    *
-   * <p>This is the environment for the globally configured server version; a cluster that
-   * configures its own version gets one derived from {@link #BASE_ENVIRONMENT_MAP} instead, see
-   * {@link Builder#buildEnvironmentMap(Builder.ResolvedVersions)}.
+   * <p>This is the environment for the globally configured server version, assembled by {@link
+   * #buildGlobalEnvironmentMap}; a cluster that configures its own version gets one derived from
+   * {@link #BASE_ENVIRONMENT_MAP} instead, see {@link
+   * Builder#buildEnvironmentMap(Builder.ResolvedVersions)}.
    */
   private static final Map<String, String> ENVIRONMENT_MAP;
 
@@ -213,6 +214,7 @@ public class CCMBridge implements CCMAccess {
     // Inherit the current environment.
     Map<String, String> envMap = Maps.newHashMap(new ProcessBuilder().environment());
     boolean globalScyllaEnterprise = false;
+    boolean globalScyllaBranchSpec = false;
     ImmutableSet.Builder<String> installArgs = ImmutableSet.builder();
     if (installDirectory != null && !installDirectory.trim().isEmpty()) {
       installArgs.add("--install-dir=" + new File(installDirectory).getAbsolutePath());
@@ -224,6 +226,7 @@ public class CCMBridge implements CCMAccess {
         installArgs.add("-v release:" + inputScyllaVersion);
       } else {
         installArgs.add("-v " + inputScyllaVersion);
+        globalScyllaBranchSpec = true;
       }
       globalScyllaEnterprise = isScyllaEnterpriseVersion(inputScyllaVersion);
     } else if (inputCassandraVersion != null && !inputCassandraVersion.trim().isEmpty()) {
@@ -257,11 +260,8 @@ public class CCMBridge implements CCMAccess {
     if (ccmJavaHome != null) {
       envMap.put("JAVA_HOME", ccmJavaHome);
     }
-    // The global environment keeps an inherited SCYLLA_PRODUCT: a non-numeric scylla.version (a
-    // branch spec) can't be recognized as Enterprise here, and exporting the variable is the only
-    // way to select the repository in that case.
-    Map<String, String> globalEnvMap = ImmutableMap.copyOf(envMap);
-    ENVIRONMENT_MAP = globalScyllaEnterprise ? withScyllaEnterprise(globalEnvMap) : globalEnvMap;
+    ENVIRONMENT_MAP =
+        buildGlobalEnvironmentMap(envMap, globalScyllaEnterprise, globalScyllaBranchSpec);
     // A cluster that configures its own version derives SCYLLA_PRODUCT from that version instead,
     // so an inherited value must not reach it: it would install an explicitly configured OSS
     // version from the Enterprise repository.
@@ -372,6 +372,36 @@ public class CCMBridge implements CCMAccess {
    */
   private static boolean isScyllaEnterpriseVersion(String versionString) {
     return versionString != null && versionString.matches("\\d{4}\\..*");
+  }
+
+  /**
+   * Builds {@link #ENVIRONMENT_MAP}, the environment for the globally configured server version,
+   * from an inherited process environment.
+   *
+   * <p>Package-private and free of static state so that the {@code SCYLLA_PRODUCT} decision is
+   * assertable without a live process environment -- it is otherwise only reachable through a
+   * static initializer.
+   *
+   * <p>An inherited {@code SCYLLA_PRODUCT} is honoured only for a branch spec, where {@link
+   * #isScyllaEnterpriseVersion} cannot classify the string and exporting the variable is the only
+   * way to select the repository. For a version number, a pure Cassandra run, or no configured
+   * version, the resolved flavor wins and an inherited value is dropped: otherwise a stale {@code
+   * SCYLLA_PRODUCT=enterprise} in the surrounding shell would install an OSS version from the
+   * Enterprise repository.
+   */
+  static Map<String, String> buildGlobalEnvironmentMap(
+      Map<String, String> inheritedEnvironment,
+      boolean scyllaEnterprise,
+      boolean scyllaBranchSpec) {
+    if (scyllaEnterprise) {
+      return withScyllaEnterprise(inheritedEnvironment);
+    }
+    if (scyllaBranchSpec) {
+      return ImmutableMap.copyOf(inheritedEnvironment);
+    }
+    Map<String, String> envMap = Maps.newHashMap(inheritedEnvironment);
+    envMap.remove("SCYLLA_PRODUCT");
+    return ImmutableMap.copyOf(envMap);
   }
 
   /** Adds the CCM variable that makes Scylla install from the Enterprise repository. */
@@ -1142,6 +1172,12 @@ public class CCMBridge implements CCMAccess {
     /**
      * The Cassandra or DSE or Scylla version to use. If not specified the globally configured
      * version is used instead.
+     *
+     * <p>Which of the three this version names is decided by {@link #withDSE(boolean)} and {@link
+     * #withScylla(boolean)}, which default to the flavor of the surrounding run rather than to
+     * anything about this version. Call the matching one alongside this method, or a Cassandra
+     * version passed under {@code -Dscylla.version=...} is resolved as a Scylla release (and vice
+     * versa).
      */
     public Builder withVersion(VersionNumber version) {
       this.version = version;

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -480,7 +480,7 @@ public class CCMBridge implements CCMAccess {
 
   @Override
   public InetSocketAddress jmxAddressOfNode(int n) {
-    if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+    if (isScylla) {
       return new InetSocketAddress(ipOfNode(n), jmxPorts[n - 1]);
     } else {
       return new InetSocketAddress("localhost", jmxPorts[n - 1]);
@@ -1186,37 +1186,60 @@ public class CCMBridge implements CCMAccess {
       return this;
     }
 
+    /** The server versions this builder's configuration resolves to. */
+    static class ResolvedVersions {
+      final boolean versionConfigured;
+      final VersionNumber cassandra;
+      final VersionNumber dse;
+      final VersionNumber scylla;
+
+      ResolvedVersions(
+          boolean versionConfigured,
+          VersionNumber cassandra,
+          VersionNumber dse,
+          VersionNumber scylla) {
+        this.versionConfigured = versionConfigured;
+        this.cassandra = cassandra;
+        this.dse = dse;
+        this.scylla = scylla;
+      }
+    }
+
+    /**
+     * Resolves which flavor and version this builder will create, from the explicitly configured
+     * version (if any) and the globally configured defaults.
+     */
+    ResolvedVersions resolveVersions() {
+      boolean versionConfigured = this.version != null;
+      // No version was explicitly provided, fallback on global config.
+      if (!versionConfigured) {
+        return new ResolvedVersions(
+            false,
+            GLOBAL_CASSANDRA_VERSION_NUMBER,
+            GLOBAL_DSE_VERSION_NUMBER,
+            GLOBAL_SCYLLA_VERSION_NUMBER);
+      } else if (dse) {
+        // given version is the DSE version, base cassandra version on DSE version.
+        return new ResolvedVersions(true, getCassandraVersion(this.version), this.version, null);
+      } else if (scylla) {
+        // Versions from 5.1 to 6.2.0 seem to report release_version 3.0.8 in system_local
+        return new ResolvedVersions(true, VersionNumber.parse("3.0.8"), null, this.version);
+      } else {
+        // given version is cassandra version.
+        return new ResolvedVersions(true, this.version, null, null);
+      }
+    }
+
     public CCMBridge build() {
       // be careful NOT to alter internal state (hashCode/equals) during build!
       String clusterName = TestUtils.generateIdentifier("ccm_");
 
       if (providedClusterName != null) clusterName = providedClusterName;
 
-      VersionNumber dseVersion;
-      VersionNumber cassandraVersion;
-      VersionNumber scyllaVersion;
-      boolean versionConfigured = this.version != null;
-      // No version was explicitly provided, fallback on global config.
-      if (!versionConfigured) {
-        scyllaVersion = GLOBAL_SCYLLA_VERSION_NUMBER;
-        dseVersion = GLOBAL_DSE_VERSION_NUMBER;
-        cassandraVersion = GLOBAL_CASSANDRA_VERSION_NUMBER;
-      } else if (dse) {
-        // given version is the DSE version, base cassandra version on DSE version.
-        scyllaVersion = null;
-        dseVersion = this.version;
-        cassandraVersion = getCassandraVersion(dseVersion);
-      } else if (scylla) {
-        scyllaVersion = this.version;
-        dseVersion = null;
-        // Versions from 5.1 to 6.2.0 seem to report release_version 3.0.8 in system_local
-        cassandraVersion = VersionNumber.parse("3.0.8");
-      } else {
-        // given version is cassandra version.
-        scyllaVersion = null;
-        dseVersion = null;
-        cassandraVersion = this.version;
-      }
+      ResolvedVersions versions = resolveVersions();
+      VersionNumber dseVersion = versions.dse;
+      VersionNumber cassandraVersion = versions.cassandra;
+      VersionNumber scyllaVersion = versions.scylla;
 
       Map<String, Object> cassandraConfiguration = randomizePorts(this.cassandraConfiguration);
       int storagePort = Integer.parseInt(cassandraConfiguration.get("storage_port").toString());
@@ -1255,7 +1278,7 @@ public class CCMBridge implements CCMAccess {
           cassandraConfiguration.put("enable_sasi_indexes", true);
         }
       }
-      if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+      if (scyllaVersion != null) {
         cassandraConfiguration.put("prometheus_port", RANDOM_PORT);
         cassandraConfiguration.put("api_port", RANDOM_PORT);
         cassandraConfiguration.put("native_shard_aware_transport_port", RANDOM_PORT);
@@ -1283,7 +1306,7 @@ public class CCMBridge implements CCMAccess {
                   ccm.close();
                 }
               });
-      ccm.execute(buildCreateCommand(clusterName, versionConfigured, cassandraVersion, dseVersion));
+      ccm.execute(buildCreateCommand(clusterName, versions));
       updateNodeConf(ccm);
       ccm.updateConfig(cassandraConfiguration);
       if (dseVersion != null) {
@@ -1347,11 +1370,7 @@ public class CCMBridge implements CCMAccess {
       return allJvmArgs.toString();
     }
 
-    private String buildCreateCommand(
-        String clusterName,
-        boolean versionConfigured,
-        VersionNumber cassandraVersion,
-        VersionNumber dseVersion) {
+    String buildCreateCommand(String clusterName, ResolvedVersions versions) {
       StringBuilder result = new StringBuilder(CCM_COMMAND + " create");
       result.append(" ").append(clusterName);
       result.append(" -i ").append(ipPrefix);
@@ -1366,17 +1385,25 @@ public class CCMBridge implements CCMAccess {
       }
 
       Set<String> lCreateOptions = new LinkedHashSet<String>(createOptions);
-      if (!versionConfigured) {
+      if (!versions.versionConfigured) {
         // If no version was provided, use the default install ags.
         lCreateOptions.addAll(CASSANDRA_INSTALL_ARGS);
       } else {
-        if (dseVersion != null) {
+        if (versions.dse != null) {
           lCreateOptions.add("--dse");
           lCreateOptions.add("-v");
-          lCreateOptions.add(dseVersion.toString());
+          lCreateOptions.add(versions.dse.toString());
+        } else if (versions.scylla != null) {
+          // Same shape as the Scylla entries of CASSANDRA_INSTALL_ARGS. Note that
+          // SCYLLA_PRODUCT is only derived from the globally configured version: the
+          // environment is a static map shared by every cluster, so an explicitly
+          // configured enterprise version still installs from the OSS repository.
+          lCreateOptions.add("--scylla");
+          lCreateOptions.add("-v");
+          lCreateOptions.add("release:" + versions.scylla);
         } else {
           lCreateOptions.add("-v");
-          lCreateOptions.add(cassandraVersion.toString());
+          lCreateOptions.add(versions.cassandra.toString());
         }
       }
       result.append(" ").append(Joiner.on(" ").join(randomizePorts(lCreateOptions)));

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -125,8 +125,18 @@ public class CCMBridge implements CCMAccess {
    * <p>At times it is necessary to use a separate java install for CCM then what is being used for
    * running tests. For example, if you want to run tests with JDK 6 but against Cassandra 2.0,
    * which requires JDK 7.
+   *
+   * <p>This is the environment for the globally configured server version; a cluster that
+   * configures its own version gets one derived from {@link #BASE_ENVIRONMENT_MAP} instead, see
+   * {@link Builder#buildEnvironmentMap(Builder.ResolvedVersions)}.
    */
   private static final Map<String, String> ENVIRONMENT_MAP;
+
+  /**
+   * {@link #ENVIRONMENT_MAP} without the variables that depend on which server flavor and version
+   * is installed, i.e. everything a cluster configuring its own version can reuse.
+   */
+  private static final Map<String, String> BASE_ENVIRONMENT_MAP;
 
   /**
    * A mapping of full DSE versions to their C* counterpart. This is not meant to be comprehensive.
@@ -200,6 +210,7 @@ public class CCMBridge implements CCMAccess {
     String branch = System.getProperty("cassandra.branch");
     // Inherit the current environment.
     Map<String, String> envMap = Maps.newHashMap(new ProcessBuilder().environment());
+    boolean globalScyllaEnterprise = false;
     ImmutableSet.Builder<String> installArgs = ImmutableSet.builder();
     if (installDirectory != null && !installDirectory.trim().isEmpty()) {
       installArgs.add("--install-dir=" + new File(installDirectory).getAbsolutePath());
@@ -212,11 +223,7 @@ public class CCMBridge implements CCMAccess {
       } else {
         installArgs.add("-v " + inputScyllaVersion);
       }
-      // Detect Scylla Enterprise - it should start with
-      // a 4-digit year.
-      if (inputScyllaVersion.matches("\\d{4}\\..*")) {
-        envMap.put("SCYLLA_PRODUCT", "enterprise");
-      }
+      globalScyllaEnterprise = isScyllaEnterpriseVersion(inputScyllaVersion);
     } else if (inputCassandraVersion != null && !inputCassandraVersion.trim().isEmpty()) {
       installArgs.add("-v " + inputCassandraVersion);
     }
@@ -248,7 +255,9 @@ public class CCMBridge implements CCMAccess {
     if (ccmJavaHome != null) {
       envMap.put("JAVA_HOME", ccmJavaHome);
     }
-    ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
+    BASE_ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
+    ENVIRONMENT_MAP =
+        globalScyllaEnterprise ? withScyllaEnterprise(BASE_ENVIRONMENT_MAP) : BASE_ENVIRONMENT_MAP;
 
     if (isDse()) {
       GLOBAL_DSE_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
@@ -348,6 +357,23 @@ public class CCMBridge implements CCMAccess {
     return osName != null && osName.startsWith("Windows");
   }
 
+  /**
+   * Scylla Enterprise versions start with a 4-digit year (e.g. 2026.1.0), OSS ones don't. CCM
+   * installs them from a different repository, selected with the {@code SCYLLA_PRODUCT} variable.
+   */
+  private static boolean isScyllaEnterpriseVersion(String versionString) {
+    return versionString != null && versionString.matches("\\d{4}\\..*");
+  }
+
+  /** Adds the CCM variable that makes Scylla install from the Enterprise repository. */
+  private static Map<String, String> withScyllaEnterprise(Map<String, String> environmentMap) {
+    // Not an ImmutableMap.Builder: the inherited environment may already define the variable, and
+    // duplicate keys would make build() throw.
+    Map<String, String> envMap = Maps.newHashMap(environmentMap);
+    envMap.put("SCYLLA_PRODUCT", "enterprise");
+    return ImmutableMap.copyOf(envMap);
+  }
+
   private static boolean isVersionNumber(String versionString) {
     try {
       VersionNumber.parse(versionString);
@@ -408,6 +434,9 @@ public class CCMBridge implements CCMAccess {
 
   private final int[] jmxPorts;
 
+  /** The environment to use for this cluster's CCM commands, see {@link #ENVIRONMENT_MAP}. */
+  private final Map<String, String> environmentMap;
+
   protected CCMBridge(
       String clusterName,
       VersionNumber cassandraVersion,
@@ -419,7 +448,8 @@ public class CCMBridge implements CCMAccess {
       int binaryPort,
       int[] jmxPorts,
       String jvmArgs,
-      int[] nodes) {
+      int[] nodes,
+      Map<String, String> environmentMap) {
 
     this.clusterName = clusterName;
     this.cassandraVersion = cassandraVersion;
@@ -435,6 +465,7 @@ public class CCMBridge implements CCMAccess {
     this.nodes = nodes;
     this.ccmDir = Files.createTempDir();
     this.jmxPorts = jmxPorts;
+    this.environmentMap = environmentMap;
   }
 
   public static Builder builder() {
@@ -851,7 +882,19 @@ public class CCMBridge implements CCMAccess {
     }
   }
 
+  /**
+   * Runs a CCM command with the environment of the globally configured server version.
+   *
+   * <p>Note that {@link #getScyllaVersionThroughCcm(String)} reaches this from the static
+   * initializer, before that environment is assigned; commons-exec then inherits this process's
+   * environment as-is.
+   */
   private static String execute(File ccmDir, String command, Object... args) {
+    return execute(ccmDir, ENVIRONMENT_MAP, command, args);
+  }
+
+  private static String execute(
+      File ccmDir, Map<String, String> environmentMap, String command, Object... args) {
     Logger logger = CCMBridge.logger;
     String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;
     Closer closer = Closer.create();
@@ -887,7 +930,7 @@ public class CCMBridge implements CCMAccess {
       ExecuteStreamHandler streamHandler = new PumpStreamHandler(outStream, errStream);
       executor.setStreamHandler(streamHandler);
       executor.setWatchdog(watchDog);
-      int retValue = executor.execute(cli, ENVIRONMENT_MAP);
+      int retValue = executor.execute(cli, environmentMap);
       if (retValue != 0) {
         logger.error(
             "Non-zero exit code ({}) returned from executing ccm command: {}",
@@ -917,7 +960,7 @@ public class CCMBridge implements CCMAccess {
   }
 
   private String execute(String command, Object... args) {
-    return execute(this.ccmDir, command, args);
+    return execute(this.ccmDir, this.environmentMap, command, args);
   }
 
   /**
@@ -1296,7 +1339,8 @@ public class CCMBridge implements CCMAccess {
               binaryPort,
               generatedJmxPorts,
               joinJvmArgs(),
-              nodes);
+              nodes,
+              buildEnvironmentMap(versions));
 
       Runtime.getRuntime()
           .addShutdownHook(
@@ -1394,10 +1438,8 @@ public class CCMBridge implements CCMAccess {
           lCreateOptions.add("-v");
           lCreateOptions.add(versions.dse.toString());
         } else if (versions.scylla != null) {
-          // Same shape as the Scylla entries of CASSANDRA_INSTALL_ARGS. Note that
-          // SCYLLA_PRODUCT is only derived from the globally configured version: the
-          // environment is a static map shared by every cluster, so an explicitly
-          // configured enterprise version still installs from the OSS repository.
+          // Same shape as the Scylla entries of CASSANDRA_INSTALL_ARGS. Which repository this
+          // installs from is decided by buildEnvironmentMap.
           lCreateOptions.add("--scylla");
           lCreateOptions.add("-v");
           lCreateOptions.add("release:" + versions.scylla);
@@ -1408,6 +1450,24 @@ public class CCMBridge implements CCMAccess {
       }
       result.append(" ").append(Joiner.on(" ").join(randomizePorts(lCreateOptions)));
       return result.toString();
+    }
+
+    /**
+     * The environment for the CCM commands of a cluster with these versions.
+     *
+     * <p>{@code SCYLLA_PRODUCT} has to follow the version this particular cluster installs, not the
+     * globally configured one: otherwise an explicitly configured Enterprise version would install
+     * from the OSS repository (and vice-versa).
+     */
+    static Map<String, String> buildEnvironmentMap(ResolvedVersions versions) {
+      if (!versions.versionConfigured) {
+        // The global environment is already derived from the same version.
+        return ENVIRONMENT_MAP;
+      } else if (versions.scylla != null && isScyllaEnterpriseVersion(versions.scylla.toString())) {
+        return withScyllaEnterprise(BASE_ENVIRONMENT_MAP);
+      } else {
+        return BASE_ENVIRONMENT_MAP;
+      }
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
@@ -7,7 +7,8 @@ import org.testng.annotations.Test;
 
 /**
  * Unit tests for the part of {@link CCMBridge.Builder} that decides which server flavor and version
- * to install. No CCM cluster is created.
+ * to install, i.e. the {@code ccm create} command and the environment it runs in. No CCM cluster is
+ * created.
  *
  * <p>Each test configures the flavor explicitly, so that it doesn't depend on the {@code
  * scylla.version} / {@code dse} system properties of the surrounding run.
@@ -32,6 +33,25 @@ public class CCMBridgeCreateCommandTest {
     assertThat(command).doesNotContain("--dse");
     // 3.0.8 is only what Scylla reports in system.local, it is never an install target
     assertThat(command).doesNotContain("3.0.8");
+
+    // 2026.1.0 is an Enterprise version, it must not be installed from the OSS repository
+    assertThat(CCMBridge.Builder.buildEnvironmentMap(versions))
+        .containsEntry("SCYLLA_PRODUCT", "enterprise");
+  }
+
+  @Test(groups = "unit")
+  public void should_not_use_enterprise_repository_for_open_source_scylla_version() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(false)
+            .withScylla(true)
+            .withVersion(VersionNumber.parse("6.2.0"));
+
+    ResolvedVersions versions = builder.resolveVersions();
+    assertThat(versions.scylla).isEqualTo(VersionNumber.parse("6.2.0"));
+
+    // Would leak in from a `-Dscylla.version=<year>.<x>` run if the product was global
+    assertThat(CCMBridge.Builder.buildEnvironmentMap(versions)).doesNotContainKey("SCYLLA_PRODUCT");
   }
 
   @Test(groups = "unit")
@@ -50,6 +70,26 @@ public class CCMBridgeCreateCommandTest {
     String command = builder.buildCreateCommand("test_cluster", versions);
     assertThat(command).contains("-v 4.1.3");
     assertThat(command).doesNotContain("--scylla").doesNotContain("--dse");
+
+    assertThat(CCMBridge.Builder.buildEnvironmentMap(versions)).doesNotContainKey("SCYLLA_PRODUCT");
+  }
+
+  /**
+   * The globally configured version keeps the environment built for it in the static initializer:
+   * that one is derived from the raw {@code scylla.version} string, which may be a branch spec
+   * whose resolved version number looks like an Enterprise one without being installed as such.
+   */
+  @Test(groups = "unit")
+  public void should_use_global_environment_when_no_version_configured() {
+    VersionNumber cassandra = VersionNumber.parse("3.0.8");
+    VersionNumber enterpriseScylla = VersionNumber.parse("2026.1.0");
+
+    assertThat(
+            CCMBridge.Builder.buildEnvironmentMap(
+                new ResolvedVersions(false, cassandra, null, enterpriseScylla)))
+        .isSameAs(
+            CCMBridge.Builder.buildEnvironmentMap(
+                new ResolvedVersions(false, cassandra, null, null)));
   }
 
   @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
@@ -3,6 +3,7 @@ package com.datastax.driver.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.CCMBridge.Builder.ResolvedVersions;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.testng.annotations.Test;
 
@@ -192,5 +193,64 @@ public class CCMBridgeCreateCommandTest {
     String command = builder.buildCreateCommand("test_cluster", versions);
     assertThat(command).contains("--dse").contains("-v 6.8.0");
     assertThat(command).doesNotContain("--scylla");
+  }
+
+  /**
+   * An environment as inherited from a shell that exported {@code SCYLLA_PRODUCT}, e.g. left over
+   * from an earlier step of the same CI job.
+   */
+  private static Map<String, String> inheritedEnterpriseEnvironment() {
+    return ImmutableMap.of("PATH", "/usr/bin", "SCYLLA_PRODUCT", "enterprise");
+  }
+
+  @Test(groups = "unit")
+  public void should_use_enterprise_repository_for_global_enterprise_version() {
+    Map<String, String> environment =
+        CCMBridge.buildGlobalEnvironmentMap(inheritedEnterpriseEnvironment(), true, false);
+
+    assertThat(environment).containsEntry("SCYLLA_PRODUCT", "enterprise");
+    assertThat(environment).containsEntry("PATH", "/usr/bin");
+  }
+
+  /**
+   * The global version is a number that isn't Enterprise, so the repository is known: an inherited
+   * value must not override it, or an OSS version is looked up in the Enterprise repository.
+   */
+  @Test(groups = "unit")
+  public void should_drop_inherited_product_for_global_open_source_version() {
+    Map<String, String> environment =
+        CCMBridge.buildGlobalEnvironmentMap(inheritedEnterpriseEnvironment(), false, false);
+
+    assertThat(environment).doesNotContainKey("SCYLLA_PRODUCT");
+    assertThat(environment).containsEntry("PATH", "/usr/bin");
+  }
+
+  /**
+   * A branch spec can't be classified as Enterprise or OSS by its version string, so exporting
+   * {@code SCYLLA_PRODUCT} is the only way to select the repository: that one inherited value has
+   * to survive.
+   */
+  @Test(groups = "unit")
+  public void should_keep_inherited_product_for_global_branch_spec() {
+    Map<String, String> environment =
+        CCMBridge.buildGlobalEnvironmentMap(inheritedEnterpriseEnvironment(), false, true);
+
+    assertThat(environment).containsEntry("SCYLLA_PRODUCT", "enterprise");
+  }
+
+  /**
+   * A pure Cassandra run, or no configured version at all: nothing about the run asks for the
+   * Enterprise repository, so a stale inherited value must not reach ccm.
+   */
+  @Test(groups = "unit")
+  public void should_drop_inherited_product_when_no_scylla_version_configured() {
+    Map<String, String> environment =
+        CCMBridge.buildGlobalEnvironmentMap(
+            ImmutableMap.of("JAVA_HOME", "/opt/java", "SCYLLA_PRODUCT", "enterprise"),
+            false,
+            false);
+
+    assertThat(environment).doesNotContainKey("SCYLLA_PRODUCT");
+    assertThat(environment).containsEntry("JAVA_HOME", "/opt/java");
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
@@ -1,0 +1,72 @@
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.CCMBridge.Builder.ResolvedVersions;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the part of {@link CCMBridge.Builder} that decides which server flavor and version
+ * to install. No CCM cluster is created.
+ *
+ * <p>Each test configures the flavor explicitly, so that it doesn't depend on the {@code
+ * scylla.version} / {@code dse} system properties of the surrounding run.
+ */
+public class CCMBridgeCreateCommandTest {
+
+  @Test(groups = "unit")
+  public void should_create_scylla_cluster_when_scylla_version_configured() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(false)
+            .withScylla(true)
+            .withVersion(VersionNumber.parse("2026.1.0"));
+
+    ResolvedVersions versions = builder.resolveVersions();
+    assertThat(versions.scylla).isEqualTo(VersionNumber.parse("2026.1.0"));
+    assertThat(versions.cassandra).isEqualTo(VersionNumber.parse("3.0.8"));
+    assertThat(versions.dse).isNull();
+
+    String command = builder.buildCreateCommand("test_cluster", versions);
+    assertThat(command).contains("--scylla").contains("-v release:2026.1.0");
+    assertThat(command).doesNotContain("--dse");
+    // 3.0.8 is only what Scylla reports in system.local, it is never an install target
+    assertThat(command).doesNotContain("3.0.8");
+  }
+
+  @Test(groups = "unit")
+  public void should_create_cassandra_cluster_when_cassandra_version_configured() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(false)
+            .withScylla(false)
+            .withVersion(VersionNumber.parse("4.1.3"));
+
+    ResolvedVersions versions = builder.resolveVersions();
+    assertThat(versions.cassandra).isEqualTo(VersionNumber.parse("4.1.3"));
+    assertThat(versions.dse).isNull();
+    assertThat(versions.scylla).isNull();
+
+    String command = builder.buildCreateCommand("test_cluster", versions);
+    assertThat(command).contains("-v 4.1.3");
+    assertThat(command).doesNotContain("--scylla").doesNotContain("--dse");
+  }
+
+  @Test(groups = "unit")
+  public void should_create_dse_cluster_when_dse_version_configured() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(true)
+            .withScylla(false)
+            .withVersion(VersionNumber.parse("6.8.0"));
+
+    ResolvedVersions versions = builder.resolveVersions();
+    assertThat(versions.dse).isEqualTo(VersionNumber.parse("6.8.0"));
+    assertThat(versions.cassandra).isNotNull();
+    assertThat(versions.scylla).isNull();
+
+    String command = builder.buildCreateCommand("test_cluster", versions);
+    assertThat(command).contains("--dse").contains("-v 6.8.0");
+    assertThat(command).doesNotContain("--scylla");
+  }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeCreateCommandTest.java
@@ -3,12 +3,13 @@ package com.datastax.driver.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.CCMBridge.Builder.ResolvedVersions;
+import java.util.Map;
 import org.testng.annotations.Test;
 
 /**
  * Unit tests for the part of {@link CCMBridge.Builder} that decides which server flavor and version
- * to install, i.e. the {@code ccm create} command and the environment it runs in. No CCM cluster is
- * created.
+ * to install, i.e. the {@code ccm create} command, the environment it runs in and the
+ * flavor-specific yaml it writes. No CCM cluster is created.
  *
  * <p>Each test configures the flavor explicitly, so that it doesn't depend on the {@code
  * scylla.version} / {@code dse} system properties of the surrounding run.
@@ -90,6 +91,89 @@ public class CCMBridgeCreateCommandTest {
         .isSameAs(
             CCMBridge.Builder.buildEnvironmentMap(
                 new ResolvedVersions(false, cassandra, null, null)));
+  }
+
+  /**
+   * Scylla reads a PEM certificate and key, not the JKS keystore Cassandra reads, so an explicitly
+   * configured Scylla cluster must not be given the Cassandra settings just because the surrounding
+   * run has no {@code scylla.version}.
+   */
+  @Test(groups = "unit")
+  public void should_use_pem_client_encryption_for_configured_scylla_version() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(false)
+            .withScylla(true)
+            .withVersion(VersionNumber.parse("2026.1.0"))
+            .withAuth();
+
+    Map<String, Object> options = builder.buildClientEncryptionOptions(builder.resolveVersions());
+
+    assertThat(options)
+        .containsEntry("client_encryption_options.enabled", "true")
+        .containsEntry("client_encryption_options.require_client_auth", "true")
+        .containsKey("client_encryption_options.certificate")
+        .containsKey("client_encryption_options.keyfile")
+        .containsKey("client_encryption_options.truststore");
+    assertThat(options)
+        .doesNotContainKey("client_encryption_options.keystore")
+        .doesNotContainKey("client_encryption_options.keystore_password")
+        .doesNotContainKey("client_encryption_options.truststore_password");
+  }
+
+  /** The mirror image: an explicit Cassandra version under a global Scylla run. */
+  @Test(groups = "unit")
+  public void should_use_keystore_client_encryption_for_configured_cassandra_version() {
+    CCMBridge.Builder builder =
+        CCMBridge.builder()
+            .withDSE(false)
+            .withScylla(false)
+            .withVersion(VersionNumber.parse("4.1.3"))
+            .withAuth();
+
+    Map<String, Object> options = builder.buildClientEncryptionOptions(builder.resolveVersions());
+
+    assertThat(options)
+        .containsEntry("client_encryption_options.enabled", "true")
+        .containsEntry("client_encryption_options.require_client_auth", "true")
+        .containsKey("client_encryption_options.keystore")
+        .containsKey("client_encryption_options.keystore_password")
+        .containsKey("client_encryption_options.truststore")
+        .containsKey("client_encryption_options.truststore_password");
+    assertThat(options)
+        .doesNotContainKey("client_encryption_options.certificate")
+        .doesNotContainKey("client_encryption_options.keyfile");
+  }
+
+  /** {@code withSSL()} alone must not enable client certificate authentication. */
+  @Test(groups = "unit")
+  public void should_not_require_client_auth_without_with_auth() {
+    CCMBridge.Builder sslOnly = CCMBridge.builder().withDSE(false).withScylla(true).withSSL();
+    assertThat(sslOnly.buildClientEncryptionOptions(sslOnly.resolveVersions()))
+        .containsEntry("client_encryption_options.enabled", "true")
+        .doesNotContainKey("client_encryption_options.require_client_auth");
+
+    CCMBridge.Builder plaintext = CCMBridge.builder().withDSE(false).withScylla(true);
+    assertThat(plaintext.buildClientEncryptionOptions(plaintext.resolveVersions())).isEmpty();
+  }
+
+  /**
+   * {@code ssl}/{@code auth} are no longer reflected in {@code cassandraConfiguration} at
+   * configuration time, so {@link CCMBridge.Builder} has to compare them itself: {@link CCMCache}
+   * keys cached clusters on the builder, and would otherwise hand an encrypted cluster to a test
+   * that asked for a plaintext one.
+   */
+  @Test(groups = "unit")
+  public void should_not_consider_encrypted_and_plaintext_clusters_equal() {
+    CCMBridge.Builder plaintext = CCMBridge.builder().withNodes(1);
+    CCMBridge.Builder encrypted = CCMBridge.builder().withNodes(1).withSSL();
+    CCMBridge.Builder authenticated = CCMBridge.builder().withNodes(1).withAuth();
+
+    assertThat(plaintext).isNotEqualTo(encrypted).isNotEqualTo(authenticated);
+    assertThat(encrypted).isNotEqualTo(authenticated);
+    assertThat(encrypted).isEqualTo(CCMBridge.builder().withNodes(1).withSSL());
+    assertThat(encrypted.hashCode())
+        .isEqualTo(CCMBridge.builder().withNodes(1).withSSL().hashCode());
   }
 
   @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMConfig.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMConfig.java
@@ -50,15 +50,20 @@ public @interface CCMConfig {
   int[] numberOfNodes() default {};
 
   /**
-   * The C* or DSE version to use; defaults to the version defined by the System property {@code
-   * cassandra.version}.
+   * The C*, DSE or Scylla version to use; defaults to the version defined by the System property
+   * {@code cassandra.version}.
    *
    * <p>Note that setting this attribute completely overrides the System properties {@code
    * cassandra.version} and {@code cassandra.directory}.
    *
+   * <p>Which server this version names is decided by {@link #dse()} and {@link #scylla()}, which
+   * default to the flavor of the surrounding run. Set the matching one explicitly whenever this
+   * attribute is set, or a Cassandra version will be installed as Scylla (or vice versa) depending
+   * on how the test run was invoked.
+   *
    * <p>This attribute is ignored if {@link #ccmProvider()} is defined.
    *
-   * @return The C* or DSE version to use
+   * @return The C*, DSE or Scylla version to use
    * @see CCMBridge#getCassandraVersion()
    */
   String version() default "";
@@ -74,6 +79,20 @@ public @interface CCMConfig {
    *     (default).
    */
   boolean[] dse() default {};
+
+  /**
+   * Whether to launch a Scylla instance rather than an OSS C*.
+   *
+   * <p>Note that setting this attribute completely overrides the System property {@code
+   * scylla.version}: only whether Scylla is launched, not which version. Set it together with
+   * {@link #version()} so that an explicitly configured version is installed as the server it
+   * actually names, instead of inheriting the flavor of the surrounding run.
+   *
+   * <p>This attribute is ignored if {@link #ccmProvider()} is defined.
+   *
+   * @return {@code true} to launch a Scylla instance, {@code false} to launch an OSS C* instance.
+   */
+  boolean[] scylla() default {};
 
   /**
    * Configuration items to add to cassandra.yaml configuration file. Each configuration item must

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -345,6 +345,14 @@ public class CCMTestsSupport {
     }
 
     @SuppressWarnings("SimplifiableIfStatement")
+    private Boolean scylla() {
+      for (CCMConfig ann : annotations) {
+        if (ann != null && ann.scylla().length > 0) return ann.scylla()[0];
+      }
+      return null;
+    }
+
+    @SuppressWarnings("SimplifiableIfStatement")
     private boolean ssl() {
       for (CCMConfig ann : annotations) {
         if (ann != null && ann.ssl().length > 0) return ann.ssl()[0];
@@ -497,14 +505,19 @@ public class CCMTestsSupport {
           ccmBuilder = CCMBridge.builder().withNodes(numberOfNodes()).notStarted();
         }
 
+        // Set the flavor before the version: which server an explicitly configured version names
+        // is decided by these flags, which otherwise default to the flavor of the surrounding run.
+        Boolean dse = dse();
+        if (dse != null) ccmBuilder.withDSE(dse);
+        Boolean scylla = scylla();
+        if (scylla != null) ccmBuilder.withScylla(scylla);
+
         String versionStr = version();
         if (versionStr != null) {
           VersionNumber version = VersionNumber.parse(versionStr);
           ccmBuilder.withVersion(version);
         }
 
-        Boolean dse = dse();
-        if (dse != null) ccmBuilder.withDSE(dse);
         if (ssl()) ccmBuilder.withSSL();
         if (auth()) ccmBuilder.withAuth();
         for (Map.Entry<String, Object> entry : config().entrySet()) {

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
@@ -84,7 +84,7 @@ public class ProtocolVersionRenegotiationTest extends CCMTestsSupport {
 
   /** @jira_ticket JAVA-1367 */
   @Test(groups = "short", enabled = false /* @IntegrationTestDisabledCassandra3Failure */)
-  @CCMConfig(version = "2.1.16", createCluster = false)
+  @CCMConfig(version = "2.1.16", scylla = false, createCluster = false)
   public void should_negotiate_when_no_version_provided() {
     if (protocolVersion.compareTo(ProtocolVersion.NEWEST_SUPPORTED) >= 0) {
       throw new SkipException("Server supports newest protocol version driver supports");

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -172,6 +172,8 @@ public class RecommissionedNodeTest {
             .withStoragePort(mainCcm.getStoragePort())
             .withThriftPort(mainCcm.getThriftPort())
             .withBinaryPort(mainCcm.getBinaryPort())
+            // 2.1.20 is a Cassandra version: say so, or a Scylla run would install it as Scylla.
+            .withScylla(false)
             .withVersion(VersionNumber.parse("2.1.20"));
     otherCcm = CCMCache.get(otherCcmBuilder);
     otherCcm.waitForUp(1);

--- a/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
@@ -24,8 +24,8 @@ import org.testng.annotations.Test;
     })
 @ScyllaOnly
 @ScyllaVersion(minOSS = "6.0.0", minEnterprise = "2024.2", description = "Needs to support tablets")
-public class TabletsIT extends CCMTestsSupport {
-  private static final Logger LOG = LoggerFactory.getLogger(TabletsIT.class);
+public class TabletsTest extends CCMTestsSupport {
+  private static final Logger LOG = LoggerFactory.getLogger(TabletsTest.class);
   private static final int INITIAL_TABLETS = 32;
   private static final int QUERIES = 1600;
   private static final int REPLICATION_FACTOR = 2;

--- a/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TabletsTest.java
@@ -190,8 +190,13 @@ public class TabletsTest extends CCMTestsSupport {
           continue;
         }
         Session session = sessionEntry.getValue().get();
-        // Empty out tablets information
-        session.getCluster().getMetadata().getTabletMap().removeTableMappings(KEYSPACE_NAME);
+        // Empty out tablets information. The mapping is keyed by the lowercased keyspace name, as
+        // reported by the server, so the key has to be lowercased here too or this is a no-op.
+        session
+            .getCluster()
+            .getMetadata()
+            .getTabletMap()
+            .removeTableMappings(KEYSPACE_NAME.toLowerCase());
         Statement stmt;
         try {
           stmt = stmtEntry.getValue().apply(session);
@@ -226,6 +231,10 @@ public class TabletsTest extends CCMTestsSupport {
                   stmtEntry.getKey(), sessionEntry.getKey()));
           continue;
         }
+        // executeOnAllHostsAndReturnIfResultHasTabletsInfo pins the statement to a specific host
+        // while hunting for tablet info. Clear that pin, otherwise the routing check below always
+        // observes the pinned host and can never detect misrouting.
+        stmt.setHost(null);
         if (!checkIfRoutedProperly(session, stmt)) {
           testErrors.add(
               String.format(
@@ -343,6 +352,11 @@ public class TabletsTest extends CCMTestsSupport {
     int expectedNodesCount = stmt.isLWT() ? 1 : REPLICATION_FACTOR;
     Set<Host> nodes = new HashSet<>();
     for (int i = 0; i < REPLICATION_FACTOR * 3; i++) {
+      // PagingOptimizingLoadBalancingPolicy returns Statement.getLastHost() ahead of the real query
+      // plan, and that field is set after every successful BoundStatement execution. Clearing it
+      // keeps the loop from being pinned to the first coordinator, which would let any routing
+      // behaviour satisfy the check below.
+      stmt.setLastHost(null);
       nodes.add(session.execute(stmt).getExecutionInfo().getQueriedHost());
     }
     return nodes.size() <= expectedNodesCount;

--- a/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class ZeroTokenNodesIT {
+public class ZeroTokenNodesTest {
 
   @DataProvider(name = "loadBalancingPolicies")
   public static Object[][] loadBalancingPolicies() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ZeroTokenNodesTest.java
@@ -173,12 +173,17 @@ public class ZeroTokenNodesTest {
         queriedNodes.add(rs.getExecutionInfo().getQueriedHost().getEndPoint().resolve());
       }
 
+      // containsOnly, not containsExactly: queriedNodes is a HashSet, whose iteration order is
+      // hash-derived rather than insertion order, so an order-sensitive assertion is a latent
+      // flake.
+      // AssertJ 1.7.1, pinned by this module, has no containsExactlyInAnyOrder; for a Set,
+      // containsOnly is equivalent to it.
       if (isDcAware) {
         assertThat(queriedNodes)
-            .containsExactly(ccmBridge.addressOfNode(1), ccmBridge.addressOfNode(2));
+            .containsOnly(ccmBridge.addressOfNode(1), ccmBridge.addressOfNode(2));
       } else {
         assertThat(queriedNodes)
-            .containsExactly(
+            .containsOnly(
                 ccmBridge.addressOfNode(1),
                 ccmBridge.addressOfNode(2),
                 ccmBridge.addressOfNode(3),

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
@@ -29,9 +29,14 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.TestUtils;
+import com.google.common.base.Throwables;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 /**
@@ -41,11 +46,52 @@ import org.testng.annotations.Test;
 @CCMConfig(numberOfNodes = 3)
 public class LWTLoadBalancingTest extends CCMTestsSupport {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(LWTLoadBalancingTest.class);
+
+  /** Equal to the node count, so that every node is a replica of every partition. */
+  private static final int REPLICATION_FACTOR = 3;
+
+  private static final int EXECUTIONS = 30;
+
   @Override
   public Cluster.Builder createClusterBuilder() {
     return Cluster.builder()
         .withLoadBalancingPolicy(
             new TokenAwarePolicy(new RoundRobinPolicy(), TokenAwarePolicy.ReplicaOrdering.RANDOM));
+  }
+
+  /**
+   * Override to create the keyspace with a replication factor greater than 1. The default test
+   * keyspace created by {@link CCMTestsSupport} is hardcoded to RF=1, and with a single replica per
+   * partition "the first replica" is trivially unique — every assertion below would hold under
+   * {@code REGULAR} routing too, so the tests could not tell {@code PRESERVE_REPLICA_ORDER} apart
+   * from {@code RANDOM}.
+   *
+   * <p>Tablets are disabled when running against Scylla: with tablets enabled, replica placement
+   * comes from the tablet map, which is empty until it has been learned from a misrouted query, and
+   * an empty replica list makes the LWT query plan fall back to the child policy — a non-replica
+   * coordinator on the first execution. Cassandra does not support the tablets property.
+   */
+  @Override
+  protected void initTestKeyspace() {
+    try {
+      keyspace = TestUtils.generateIdentifier("ks_");
+      LOGGER.debug("Using keyspace " + keyspace);
+      boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
+      session()
+          .execute(
+              String.format(
+                  "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+                      + " 'datacenter1': %d}"
+                      + (isScylla ? " AND tablets = {'enabled': false}" : ""),
+                  keyspace,
+                  REPLICATION_FACTOR));
+      useKeyspace(keyspace);
+    } catch (Exception e) {
+      errorOut();
+      LOGGER.error("Could not create test keyspace", e);
+      Throwables.propagate(e);
+    }
   }
 
   @Override
@@ -65,25 +111,15 @@ public class LWTLoadBalancingTest extends CCMTestsSupport {
     simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
-    BoundStatement boundSelect = preparedSelect.bind(1, 0);
 
     // Verify statement properties
     assertThat(simpleSelect.isLWT()).isFalse();
     assertThat(simpleSelect.getConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
 
-    // Execute multiple times and collect coordinators — with PRESERVE_REPLICA_ORDER routing,
-    // the same partition key should always be routed to the same first replica.
-    Set<InetSocketAddress> coordinators = new HashSet<>();
-    for (int i = 0; i < 30; i++) {
-      ResultSet rs = session.execute(boundSelect);
-      Host coordinator = rs.getExecutionInfo().getQueriedHost();
-      assertThat(coordinator).isNotNull();
-      coordinators.add(coordinator.getEndPoint().resolve());
-    }
-
     // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key,
-    // so all 30 executions should hit the same coordinator.
-    assertThat(coordinators).hasSize(1);
+    // so every execution should hit the same coordinator. Contrast with the non-serial control in
+    // should_spread_non_serial_select_across_replicas, which shares the same statement and policy.
+    assertThat(collectCoordinators(session, preparedSelect, 1)).hasSize(1);
   }
 
   @Test(groups = "short")
@@ -95,18 +131,58 @@ public class LWTLoadBalancingTest extends CCMTestsSupport {
     simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
-    BoundStatement boundSelect = preparedSelect.bind(2, 0);
 
-    // Execute multiple times and collect coordinators
+    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key.
+    assertThat(collectCoordinators(session, preparedSelect, 2)).hasSize(1);
+  }
+
+  /**
+   * Control for the two tests above. This is the same statement against the same table, executed by
+   * the same {@code TokenAwarePolicy(RoundRobinPolicy, RANDOM)} — only the consistency level
+   * differs. A non-serial level takes the {@code REGULAR} routing path, which shuffles the replicas
+   * on every query, so the coordinator must vary. If this test ever collapses to a single
+   * coordinator as well, the {@code hasSize(1)} assertions above have stopped proving anything
+   * about {@code PRESERVE_REPLICA_ORDER}.
+   */
+  @Test(groups = "short")
+  public void should_spread_non_serial_select_across_replicas() {
+    Session session = session();
+
+    SimpleStatement simpleSelect =
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
+    simpleSelect.setConsistencyLevel(ConsistencyLevel.ONE);
+
+    PreparedStatement preparedSelect = session.prepare(simpleSelect);
+    BoundStatement boundSelect = preparedSelect.bind(3, 0);
+
+    assertThat(boundSelect.isLWT()).isFalse();
+    assertThat(boundSelect.getConsistencyLevel().isSerial()).isFalse();
+
+    // Uniform over REPLICATION_FACTOR replicas across EXECUTIONS queries, so the probability of a
+    // false failure here is REPLICATION_FACTOR^(1 - EXECUTIONS).
+    assertThat(collectCoordinators(session, preparedSelect, 3).size()).isGreaterThan(1);
+  }
+
+  /**
+   * Executes {@code prepared} against partition {@code pk} {@link #EXECUTIONS} times and returns
+   * the distinct coordinators used.
+   *
+   * <p>A fresh {@link BoundStatement} is bound for every execution on purpose. {@link
+   * PagingOptimizingLoadBalancingPolicy}, which the driver wraps around the configured policy,
+   * returns {@code Statement.getLastHost()} ahead of the real query plan, and that field is set on
+   * every successful {@code BoundStatement} execution. Reusing a single instance would therefore
+   * pin the coordinator after the first query and make every assertion in this class hold
+   * regardless of how routing actually behaves.
+   */
+  private static Set<InetSocketAddress> collectCoordinators(
+      Session session, PreparedStatement prepared, int pk) {
     Set<InetSocketAddress> coordinators = new HashSet<>();
-    for (int i = 0; i < 30; i++) {
-      ResultSet rs = session.execute(boundSelect);
+    for (int i = 0; i < EXECUTIONS; i++) {
+      ResultSet rs = session.execute(prepared.bind(pk, 0));
       Host coordinator = rs.getExecutionInfo().getQueriedHost();
       assertThat(coordinator).isNotNull();
       coordinators.add(coordinator.getEndPoint().resolve());
     }
-
-    // With PRESERVE_REPLICA_ORDER, the first replica is deterministic for a given partition key.
-    assertThat(coordinators).hasSize(1);
+    return coordinators;
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
  * through the LWT load-balancing path (PRESERVE_REPLICA_ORDER).
  */
 @CCMConfig(numberOfNodes = 3)
-public class LWTLoadBalancingIT extends CCMTestsSupport {
+public class LWTLoadBalancingTest extends CCMTestsSupport {
 
   @Override
   public Cluster.Builder createClusterBuilder() {
@@ -61,7 +61,7 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
     Session session = session();
 
     SimpleStatement simpleSelect =
-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 1, 0);
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
     simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);
@@ -91,7 +91,7 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
     Session session = session();
 
     SimpleStatement simpleSelect =
-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 2, 0);
+        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
     simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
 
     PreparedStatement preparedSelect = session.prepare(simpleSelect);

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderTest.java
@@ -37,7 +37,7 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import java.util.Iterator;
 import org.testng.annotations.Test;
 
-public class SchemaBuilderIT extends CCMTestsSupport {
+public class SchemaBuilderTest extends CCMTestsSupport {
 
   // Test relies on existence of 'ks' keyspace,
   // but no such keyspace is created. If (fixed) created,


### PR DESCRIPTION
Fixes #983.

> **Stacked on #982.** The first three commits (`f0ffa5ca14`, `1119088802`, `5b3588ebe0`) belong to that PR — review only the last four here. Will be rebased onto `scylla-3.x` once #982 merges.

## Why this is a separate PR

#982 exists to unblock `driver-core`'s four CCM tests that Surefire never discovered. Reviewing it surfaced that `CCMBridge` resolves the server flavor from **global system properties** throughout, so a cluster configuring its own version gets the surrounding run's flavor instead of its own. Three fixes for that were written and live-verified on #982's branch, but they're a refactor of the CCM test harness rather than part of unblocking the tests — so they moved here, verbatim, and #982 went back to being the rename plus the `ccm add` fix it made necessary.

None of this is reachable from CI today (see #983 for why), so it is footgun removal that makes the harness behave as its API claims, not a live CI failure. Sibling to #800, the same bug class in 4.x.

## `099a169abf` — pass `--scylla` to `ccm create` when Scylla mode is explicit

`buildCreateCommand` only ever received the resolved Cassandra and DSE versions, so its `versionConfigured` branch emitted `-v <cassandraVersion>` and never `--scylla`. For Scylla that Cassandra version is hardcoded to `3.0.8` — what Scylla reports in `system.local`, not an install target — so `withVersion(...)` under `-Dscylla.version=...` had CCM build an Apache Cassandra 3.0.8 cluster while `add()` passed `--scylla` and `getScyllaVersion()` reported Scylla. The requested version was discarded outright.

- `buildCreateCommand` now takes the whole resolution and emits `--scylla -v release:<version>`, the same shape the globally configured Scylla version already produces via `CASSANDRA_INSTALL_ARGS`.
- The version resolution moved out of `build()` into `resolveVersions()` returning a `ResolvedVersions` holder — a straight extraction, no behaviour change, but it makes the flavor decision assertable without starting a cluster.
- `jmxAddressOfNode()` and the Scylla-only yaml ports (`prometheus_port`, `api_port`, `native_shard_aware_transport_port`) now use the per-instance version.

## `9f34037f3b` — `SCYLLA_PRODUCT` follows the version each cluster installs

`ENVIRONMENT_MAP` was built once in the static initializer and, being immutable and shared by every cluster, gave a builder that configures its own version the wrong repository in *both* directions:

- global OSS + explicit Enterprise version → `SCYLLA_PRODUCT` unset → Enterprise version installed from the OSS repository.
- global Enterprise + explicit OSS version → `SCYLLA_PRODUCT=enterprise` leaks in → OSS version looked up in the Enterprise repository.

- The map is split into a flavor-independent `BASE_ENVIRONMENT_MAP` and a per-cluster environment built by `buildEnvironmentMap(ResolvedVersions)`, sibling to `buildCreateCommand`. It is threaded through the `CCMBridge` instance, so every ccm command a bridge issues — `create`, `add`, `start` — sees its own environment, not just the create.
- The 4-digit-year Enterprise check is now the shared `isScyllaEnterpriseVersion` helper, used by both the static initializer and the per-cluster path.
- `withScyllaEnterprise` copies into a `HashMap` rather than using `ImmutableMap.Builder`: the inherited process environment may already define `SCYLLA_PRODUCT`, and duplicate keys would make `build()` throw.

## `58bf916fc6` — client encryption follows the flavor, `SCYLLA_PRODUCT` can't be inherited

**`SCYLLA_PRODUCT` inherited from the surrounding shell.** The previous commit derived the variable from the resolved version, but `BASE_ENVIRONMENT_MAP` still copied the process environment verbatim — so an exported `SCYLLA_PRODUCT=enterprise` reached every cluster configuring its own version, installing an explicitly configured *OSS* version from the Enterprise repository. It is now stripped there, leaving `withScyllaEnterprise` as the only way the variable gets set.

**Client encryption picked the wrong flavor's TLS yaml.** `withSSL()`/`withAuth()` chose between Cassandra's JKS keystore/truststore and Scylla's PEM `certificate`/`keyfile`/truststore by reading the global `scylla.version` at builder-configuration time — before the flavor is resolved, and before `withVersion()` has any effect. Both directions were wrong.

- The two methods now only record the request. `buildClientEncryptionOptions(ResolvedVersions)` derives the yaml at build time, sibling to `buildCreateCommand` and `buildEnvironmentMap`.
- Explicitly configured entries still win over these defaults, preserving the precedence that applied when `withCassandraConfiguration()` ran after `withSSL()` — this matters for `SSLSessionTicketsTest`, the one test that sets a `client_encryption_options.*` key of its own.
- `Builder.equals`/`hashCode` now compare `ssl`/`auth` directly. This is required, not cosmetic: they no longer show up in `cassandraConfiguration` at configuration time, and `CCMCache` keys cached clusters on the builder, so without it an encrypted cluster could be handed to a test that asked for a plaintext one. `hashCode` also picks up `scylla`, which `equals` already compared.

Unlike the other two, this one is reachable without a `withScylla()` call: `CCMTestsSupport.ccmBuilder` calls `withVersion()` before `withSSL()`, so `@CCMConfig(version = ..., ssl = true)` is enough. It still isn't reachable from CI, because the only SSL tests are `SSLTestBase` subclasses, which use `@CCMConfig(ssl = true, createCluster = false)` and never configure a version.

## Testing

Carried over from #982, where these commits were originally verified:

- `CCMBridgeCreateCommandTest` (new, `unit` group, no CCM) pins the explicit-version branches of `ccm create` — Scylla gets `--scylla -v release:<version>` and never `3.0.8`, Cassandra gets a bare `-v`, DSE gets `--dse` — plus the execution environment and the flavor-specific client-encryption yaml. Each case sets the flavor explicitly so it doesn't depend on the surrounding run's system properties. 9/9 pass, with and without `-Dscylla.version=2026.1.0` and with or without `SCYLLA_PRODUCT` exported.
- Falsified each fix rather than just observing green:
  - Making `buildEnvironmentMap` return `ENVIRONMENT_MAP` unconditionally fails the Enterprise case under a global OSS run, and the OSS + Cassandra cases under `-Dscylla.version=2026.1.0` — one failure per leak direction.
  - Dropping the `SCYLLA_PRODUCT` strip makes the two `doesNotContainKey` assertions fail under `SCYLLA_PRODUCT=enterprise`.
  - Restoring the global read in `buildClientEncryptionOptions` fails the Scylla case under a Cassandra run and the Cassandra case under `-Dscylla.version=2026.1.0`.
  - Removing the `ssl`/`auth` comparison from `equals` fails the cache-key test.
- Live-ran the `short`-group SSL tests against Scylla 2026.1.0 — `SSLEncryptionTest` + `SSLAuthenticatedEncryptionTest`, 9/9 pass. These are the tests CI actually exercises through this code, so this confirms the PEM path is unchanged end-to-end. The JKS path is left to the Cassandra IT legs; local CCM can't start Apache Cassandra here.
- Re-ran `ZeroTokenNodesTest` live (7 real clusters, plaintext): 7/7 — a regression check on the builder-equality change.
- Full `driver-core` `unit` group green, so the `Builder.equals`/`hashCode` change breaks nothing else.
- CI: `099a169abf` and `9f34037f3b` each passed all 10 checks including the four IT legs.

## `82028f1425` — the last two flavor decisions

The two findings raised against the commits above. Both are pre-existing `scylla-3.x` behavior rather than regressions from them, and neither is reachable from CI.

**`SCYLLA_PRODUCT` could still be inherited for the globally configured version.** `9f34037f3b` stripped an inherited value from `BASE_ENVIRONMENT_MAP`, so no cluster configuring its own version could pick one up, but `ENVIRONMENT_MAP` was copied *before* that strip and kept whatever the surrounding shell exported. That is what `scylla-3.x` always did — one env map, no strip at all — but the comment justifying it only covered a branch spec, while the code also applied it to a numeric OSS version, a pure Cassandra run, and no configured version. In each of those the repository is already known from the resolved flavor, so a stale `SCYLLA_PRODUCT=enterprise` would install an OSS version from the Enterprise repository.

The assembly moved into `buildGlobalEnvironmentMap`, which strips the inherited value unless the version is a branch spec — the one case `isScyllaEnterpriseVersion` cannot classify, where exporting the variable is the only way to select the repository. Extracting it is what makes the decision testable at all: it is otherwise reachable only through a static initializer reading the live process environment, which is why the previous global-path test could assert nothing but `isSameAs`.

**`@CCMConfig` could not declare Scylla.** `Builder.scylla` defaults to `GLOBAL_SCYLLA_VERSION_NUMBER != null` and `withVersion()` doesn't touch it, so under a Scylla run an explicit Cassandra version resolves as a Scylla release. Base silently installed C\* 3.0.8 and discarded the requested version; since `099a169abf` started honouring the flag it fails loudly instead. Neither is right — and a test could not fix itself, because `@CCMConfig` forwards `dse` but had no Scylla equivalent, and `version()`'s javadoc still called itself "the C\* or DSE version to use".

Added the `scylla` attribute, forwarded it from `CCMTestsSupport` alongside `dse` and ahead of `withVersion`, and documented on both `withVersion()` and `@CCMConfig.version()` that the flavor flags decide what the version names. The two call sites that configure a version without a flavor now say which they mean — `ProtocolVersionRenegotiationTest`'s `2.1.16` and `RecommissionedNodeTest`'s `2.1.20` are both Cassandra versions.

Testing:

- `CCMBridgeCreateCommandTest` grows to 13 cases, covering all four `SCYLLA_PRODUCT` paths against a *synthetic* inherited environment, so they hold regardless of the surrounding run. 13/13 with and without `-Dscylla.version=2026.1.0` and with `SCYLLA_PRODUCT=enterprise` exported.
- Falsified by making `buildGlobalEnvironmentMap` always keep the inherited value: exactly the two strip cases fail, the Enterprise and branch-spec cases still pass.
- Full `driver-core` `unit` group green — 640 tests, 0 failures — so the `@CCMConfig` addition breaks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
