### PR TITLE
Skip DSE versions during protocol negotiation

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -23,6 +23,7 @@ under the License.
 
 ### 4.19.2
 
+- [improvement] Skip DSE protocol versions during automatic protocol negotiation
 - [bug] CASSJAVA-116: Retry or Speculative Execution with RequestIdGenerator throws "Duplicate Key"
 
 ### 4.19.1

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
@@ -87,7 +87,10 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
 
   @Override
   public ProtocolVersion highestNonBeta() {
-    ProtocolVersion highest = allVersions.get(allVersions.size() - 1);
+    // DSE protocol versions remain available when forced, but are never useful when negotiating
+    // with ScyllaDB.
+    DefaultProtocolVersion[] ossVersions = DefaultProtocolVersion.values();
+    ProtocolVersion highest = ossVersions[ossVersions.length - 1];
     if (!highest.isBeta()) {
       return highest;
     } else {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistryTest.java
@@ -66,6 +66,11 @@ public class DefaultProtocolVersionRegistryTest {
   }
 
   @Test
+  public void should_pick_highest_non_beta_oss_version_for_negotiation() {
+    assertThat(registry.highestNonBeta()).isEqualTo(V5);
+  }
+
+  @Test
   public void should_downgrade_if_lower_version_available() {
     Optional<ProtocolVersion> downgraded = registry.downgrade(V4);
     downgraded.map(version -> assertThat(version).isEqualTo(V3)).orElseThrow(AssertionError::new);

--- a/manual/core/native_protocol/README.md
+++ b/manual/core/native_protocol/README.md
@@ -52,17 +52,19 @@ first node the driver connects to:
 
 *(1) for previous driver versions, see the [3.x documentation][driver3]*
 
-Since version 4.5.0, the driver can also use DSE protocols when all nodes are running a version of
-DSE. The table below shows the protocol matrix for these cases:
+The driver can also use DSE protocols when they are explicitly configured. Automatic negotiation
+only probes standard Cassandra protocol versions, to avoid attempting DSE protocols against
+ScyllaDB. The table below shows the automatically negotiated versions for DSE:
 
 | DSE version         | Negotiated protocol version with driver 4       |
 |---------------------|-------------------------------------------------|
 | 4.7/4.8             | v3                                              |
 | 5.0                 | v4                                              |
-| 5.1                 | DSE_V1 ²                                        |
-| 6.0/6.7/6.8         | DSE_V2 ²                                        |
+| 5.1                 | v4                                              |
+| 6.0/6.7/6.8         | v4                                              |
+| 7.0+                | v5                                              |
 
-*(2) DSE Protocols are chosen before other Cassandra native protocols.*
+To use DSE-specific features, force `DSE_V1` or `DSE_V2` with `advanced.protocol.version`.
 
 ### Controlling the protocol version
 


### PR DESCRIPTION
## Summary

Fixes #969 by excluding DSE protocol versions from automatic protocol negotiation.

The initial negotiation sequence now uses standard Cassandra protocol versions:

```
V5 → V4 → V3
```

This avoids rejected `DSE_V2` and `DSE_V1` connection attempts when starting a session against ScyllaDB.

Explicitly configured DSE protocol versions remain supported.

## Changes

- Start automatic negotiation with the highest non-beta OSS protocol version.
- Add unit coverage for the negotiation starting version.
- Update native protocol documentation to describe the new behavior.
- Add a changelog entry.

## Testing

```
mvn -pl core -Dtest=DefaultProtocolVersionRegistryTest test
```