### PR TITLE
fix(deps): align Jackson modules with BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,14 @@
         <dependencies>
 
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>com.scylladb</groupId>
                 <artifactId>scylla-driver-core</artifactId>
                 <version>${project.parent.version}</version>
@@ -199,24 +207,6 @@
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
                 <version>${hdr.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary

- import the FasterXML Jackson BOM at 2.18.9
- align core, databind, annotations, JAX-RS, and module dependencies
- remove individual Jackson dependency-management entries

This is the 3.x counterpart of #987.

## Tests

- `mvn -pl driver-core,driver-extras,driver-examples -am -DskipTests package`
- `mvn -pl driver-extras -am -Dtest=JacksonJsonCodecTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl driver-core enforcer:enforce -Drules=requireUpperBoundDeps -DskipTests`
- verified dependency trees for core, extras, and examples resolve Jackson modules to 2.18.9