### PR TITLE
fix: bump netty to 4.1.136.Final and lz4-java to 1.11.1 to remediate CVE-2026-59901 and CVE-2026-59949

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
         <slf4j.version>1.7.36</slf4j.version>
         <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <guava.version>33.3.1-jre</guava.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
         <netty-tcnative.artifact>netty-tcnative-boringssl-static</netty-tcnative.artifact>
         <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <metrics.version>3.2.6</metrics.version>
         <snappy.version>1.1.10.7</snappy.version>
-        <lz4.version>1.10.1</lz4.version>
+        <lz4.version>1.11.1</lz4.version>
         <hdr.version>2.2.2</hdr.version>
         <jackson.version>2.18.9</jackson.version>
         <joda.version>2.12.7</joda.version>


### PR DESCRIPTION
Two patch-level dependency bumps on `scylla-3.x`, both remediating CVEs found in a Confluent Hub scan of a downstream consumer (`scylla-cdc-source-connector` v2.0.4).

| CVE | Property | Before | After | Severity |
|---|---|---|---|---|
| CVE-2026-59901 | `netty.version` | 4.1.135.Final | **4.1.136.Final** | HIGH |
| CVE-2026-59949 | `lz4.version` | 1.10.1 | **1.11.1** | MEDIUM (6.5) |

## CVE-2026-59901 — netty-codec, infinite loop in the bzip2 decoder

`Bzip2Decoder` can be driven into a permanent infinite loop by a malformed bzip2 stream, capturing the event-loop thread. The defect is in the run-length-encoding state machine in `Bzip2BlockDecompressor.read()`. Fixed in netty 4.1.136.Final and 4.2.16.Final.

This mirrors #978, which applied the identical netty bump to `scylla-4.x`. `scylla-3.x` was left behind, so `scylla-driver-core:3.11.5.x` still ships the vulnerable codec.

## CVE-2026-59949 — lz4-java, JNI XXHash range validation

The JNI-backed XXHash implementations did not validate their byte array arguments before handing them to native code. `hash(null, 0, 0, seed)` / `update(null, 0, 0)` could pass a null array reference to JNI, causing a fatal JVM crash in `GetPrimitiveArrayCritical`; `update(new byte[16], 0, Integer.MAX_VALUE)` could read far past the end of the Java array. Fixed in 1.11.1 with no user-code changes required.

The driver's own LZ4 usage is unaffected by the behavioural change: `LZ4Compressor` (`driver-core/src/main/java/com/datastax/driver/core/LZ4Compressor.java`) only uses `LZ4Factory.fastestInstance()`, `fastCompressor()` and `fastDecompressor()`, and never touches the XXHash API the advisory concerns. `1.11.1` also preserves the `net/jpountz/**` package layout, so it is a drop-in replacement.

## Why this matters downstream

`scylla-cdc-java` shades `scylla-driver-core` (relocating `io.netty.` → `shaded.com.scylladb.cdc.driver3.`), so the netty version this branch resolves is baked into `scylla-cdc-driver3.jar` and cannot be overridden by any consumer's `dependencyManagement`. The Kafka connector currently carries a `netty-bom:4.1.136.Final` pin purely as a stopgap for the unshaded copy; the shaded one can only be fixed here. Releasing this as 3.11.5.18 lets both clear properly.

## Scope

Root-POM properties only — no source changes. Every netty and lz4 declaration in the tree already resolves through these two properties (`driver-core/pom.xml`, `driver-tests/osgi/pom.xml`, `driver-tests/shading/shaded/pom.xml` all inherit or interpolate them), so there is nothing else to update. `netty-tcnative` is versioned independently and untouched.

## Verification

`4.1.136.Final` is published on Maven Central for every netty module this branch consumes (`netty-handler`, `netty-codec`, `netty-transport-native-epoll`).

`mvn -pl driver-core -am install` on JDK 11 succeeds, and the resulting `scylla-driver-core:3.11.5.18-SNAPSHOT` was consumed by a local `scylla-cdc-java` build to confirm the shade step picks up the fixed netty:

```
$ unzip -p scylla-cdc-driver3-1.3.13-SNAPSHOT.jar META-INF/io.netty.versions.properties
netty-handler.version=4.1.136.Final
```

Leaving the full test matrix to CI — these are dependency-property bumps with no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
