### PR TITLE
docs: fix multiversion build on old branches (javadoc errors)

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -53,6 +53,11 @@ jobs:
 
       - name: Build docs
         run: make -C docs multiversion
+        env:
+          # Old release branches (e.g. scylla-4.15.0.x) have javadoc
+          # comments that only pass doclint on JDK 8.
+          # Don't fail their multiversion javadoc builds on JDK 11.
+          MAVEN_OPTS: -Dmaven.javadoc.failOnError=false
 
       - name: Deploy docs to GitHub Pages
         run: ./docs/_utils/deploy.sh


### PR DESCRIPTION
Fixes docs publication workflow: https://github.com/scylladb/java-driver/actions/workflows/docs-pages.yml

## Problem

The Docs / Publish workflow fails. `sphinx-multiversion` builds previous release branches (e.g. `scylla-4.15.0.x`) whose javadoc only passes doclint on JDK 8. Since the workflow moved to JDK 11, their builds error out (`<table summary>` not valid HTML5, `unknown tag: leaks-private-api`).

## Solution

Set `MAVEN_OPTS: -Dmaven.javadoc.failOnError=false` on the "Build docs" step.