### PR TITLE
docs: point 3.x readers at the 4.x migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,20 @@ big-endian systems, but _Scylla_ does not officially support these systems.
 If you are upgrading from a previous version of the driver, be sure to have a look at
 the [upgrade guide](/upgrade_guide/).
 
+## Migrating to Java Driver 4.x
 
+The [4.x migration guide](https://java-driver.docs.scylladb.com/stable/upgrade_guide/) covers the
+API changes in detail. The first thing to change is the dependency: the artifacts are renamed, while
+the `com.scylladb` group id stays the same.
+
+| Driver 3.x | Driver 4.x |
+|---|---|
+| `scylla-driver-core` | `java-driver-core`, plus `java-driver-query-builder` if you use the query builder |
+| `scylla-driver-mapping` | `java-driver-mapper-runtime`, plus the `java-driver-mapper-processor` annotation processor |
+| `scylla-driver-extras` | no counterpart; its codecs are either native to 4.x core or covered by its custom-codec support |
+
+All four 4.x artifacts are published under `com.scylladb` from **4.7.2.0** onwards; there is no
+earlier 4.x release under this group id.
 
 ## License
 &copy; DataStax, Inc. 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -3,6 +3,10 @@
 The purpose of this guide is to detail changes made by successive
 versions of the Java driver.
 
+Note that Java Driver 3.x is in maintenance mode and receives critical bug fixes only. If you are
+moving to Java Driver 4.x rather than between 3.x versions, see the
+[4.x migration guide](https://java-driver.docs.scylladb.com/stable/upgrade_guide/) instead.
+
 ### 3.11.5.19
 
 1.  `ColumnDefinitions` now reports a double-quoted name whose case matches no definition as absent,


### PR DESCRIPTION
## DRIVER-854: give 3.x readers a route to 4.x

Companion to #919 (the deprecation announcement on this branch) and #997 (the docs-site half on
`scylla-4.x`). Split out of #919 so the announcement and the migration route review separately.

### Changes

| File | Change |
|---|---|
| `README.md` | New "Migrating to Java Driver 4.x" section after the existing "Upgrading from previous versions", with the 3.x → 4.x artifact mapping |
| `upgrade_guide/README.md` | A note at the top routing readers who are leaving 3.x, rather than moving between 3.x versions, to the 4.x guide |

The 3.x tree currently tells a reader to consult its own upgrade guide for moving *between* 3.x
versions and says nothing about moving off 3.x. Both files now name the deprecation and link out.

### The guide already exists; this links to it

The 3.x → 4.x guide is the `### 4.0.0` section of `upgrade_guide/README.md` on `scylla-4.x`
(~430 lines: Maven coordinates, packages, configuration, session, load balancing, statements, result
sets, type mappings, metrics, metadata, query builder), published at
[/stable/upgrade_guide/](https://java-driver.docs.scylladb.com/stable/upgrade_guide/). So this PR
links there instead of restating it.

#997 moves that section onto its own page, `upgrade_guide/from_3x/`. The links here stay on the
guide's root on purpose: `/stable/` is built from the newest release branch in `BRANCHES`, not from
`scylla-4.x`, so the new page becomes reachable there only once a release branch containing it is
cut. Both links keep working either way, since the root page is where the pointer to it lives.

What is worth stating on this branch is the artifact rename, since it is the first thing that stops
a 3.x build from resolving — and the 4.x guide never mentions the 3.x coordinates a reader is
leaving. #997 adds the matching table on the 4.x side.

| Driver 3.x | Driver 4.x |
|---|---|
| `scylla-driver-core` | `java-driver-core` (+ `java-driver-query-builder`) |
| `scylla-driver-mapping` | `java-driver-mapper-runtime` (+ `java-driver-mapper-processor`) |
| `scylla-driver-extras` | no counterpart — codecs only |

### Scope: this reaches GitHub, not the documentation site

`scylla-3.x` is **not a published doc version** — no branch's `BRANCHES` list contains it, and
[`/scylla-3.x/`](https://java-driver.docs.scylladb.com/scylla-3.x/) returns 404. The published 3.x
versions are the six frozen `scylla-3.{7.2,10.2,11.0,11.2,11.4,11.5}.x` branches.

`Docs / Build PR` will pass on this PR, because this branch has its own `docs-pr.yaml` that builds
the tree in isolation. **That green check says nothing about the live site.** It is worth being
explicit, since `docs/source/index.md` is a symlink to this `README.md`, so the section does render
into a docs build — just not into a *published* one.

The site-visible deprecation notice, with a link to the same migration guide on every page of all
six published 3.x versions, ships in **#997** from the publishing branch. It needs no change to any
of the frozen branches.

### Verification

Built with the pinned 3.x docs toolchain (Sphinx 7.2.6, `sphinx-scylladb-theme` 1.7.2) using the
same options as `make -C docs test`, i.e. `-W --keep-going`: `build succeeded`. Confirmed the new
section renders on the landing page and that the Markdown table renders as a table on this older
toolchain, and that the note renders at the top of the upgrade guide.

Part of [DRIVER-483] / [DRIVER-854].

[DRIVER-483]: https://scylladb.atlassian.net/browse/DRIVER-483
[DRIVER-854]: https://scylladb.atlassian.net/browse/DRIVER-854
