### PR TITLE
test: skip the third WarningsTest method under Scylla

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -115,6 +115,7 @@ public class WarningsTest extends CCMTestsSupport {
   }
 
   @Test(groups = "isolated")
+  @ScyllaSkip /* @IntegrationTestDisabledScyllaFailure */
   @CassandraVersion("3.0.0")
   public void should_execute_query_and_not_log_server_side_warnings() throws Exception {
     // Get the system property value for disabling logging server side warnings


### PR DESCRIPTION
`WarningsTest` has three tests, all requiring the server to emit Cassandra's `"Aggregation query used without partition key"` warning for `SELECT count(*) FROM foo`. Scylla does not send it. Two were annotated in f475ebd1be *"Disable ITs which fail under Scylla"*; this one was missed. Annotate it too.

Why it was missed, and why it surfaced now:

| Date | Commit | Effect |
|---|---|---|
| 2021-09-06 | f475ebd1be | `@ScyllaSkip` on the two `short`-group methods. This one is `groups = "isolated"`, which was not being run — so it was never observed to fail |
| 2026-06-26 | scylla-java-driver-matrix `9889882` | Adds `-Pisolated` for 3.x tags; the method executes against Scylla for the first time, and fails |
| 2026-07-09 | scylla-java-driver-matrix `33a4459` | Worked around in `versions/scylla/3.11.5.16/patch` rather than fixed here |

Same shape as #1000: a latent test defect masked because the assertion was never really exercised, surfaced by a harness change, then patched per-version in the matrix instead of at source.

Nothing to fix driver-side — `ExecutionInfo.getWarnings()` correctly reports that the server sent no warning. Annotating here makes the file self-consistent and means future tags need no patch hunk.

Not rewritten to assert a warning Scylla *does* emit (e.g. the RF-below-`minimum_replication_factor_warn_threshold` one). That would restore genuine coverage of `DISABLE_QUERY_WARNING_LOGS` — currently zero on Scylla across all three methods — but depends on a config-dependent trigger of unproven stability across versions. Worth a separate ticket.

No matrix-repo change: both currently-tested 3.x versions already suppress this (`3.11.4.0` via `ignore.yaml`, `3.11.5.17` via fallback to `3.11.5.16`'s patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)