### PR TITLE
Add code coverage measurement for unit and integration tests

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -133,7 +133,31 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java-version }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Run unit tests
+        env:
+          COVERAGE: "true"
         run: make test-unit
+
+      # Flattened to one file per module so the artifact layout does not depend
+      # on how many modules happened to produce data, and named per lane so the
+      # aggregating job can keep each lane's contribution apart.
+      - name: Collect coverage execution data
+        if: ${{ !cancelled() }}
+        run: |
+          shopt -s nullglob
+          mkdir -p coverage-exec
+          for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
+            module="${exec_file%/target/jacoco.exec}"
+            cp "$exec_file" "coverage-exec/${module//\//-}.exec"
+          done
+          ls -l coverage-exec
+
+      - name: Upload coverage execution data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage-exec-unit-${{ matrix.java-version }}
+          path: coverage-exec/
+          if-no-files-found: warn
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -256,7 +280,27 @@ jobs:
           GET_VERSION_VERSION: 0.4.5
           GH_TOKEN: ${{ github.token }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
+          COVERAGE: "true"
         run: make test-integration-cassandra
+
+      - name: Collect coverage execution data
+        if: ${{ !cancelled() }}
+        run: |
+          shopt -s nullglob
+          mkdir -p coverage-exec
+          for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
+            module="${exec_file%/target/jacoco.exec}"
+            cp "$exec_file" "coverage-exec/${module//\//-}.exec"
+          done
+          ls -l coverage-exec
+
+      - name: Upload coverage execution data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage-exec-cassandra-${{ matrix.cassandra-version }}-${{ matrix.java-version }}-${{ matrix.test-group }}
+          path: coverage-exec/
+          if-no-files-found: warn
 
       - name: Upload test results
         if: failure() && steps.run-integration-tests.outcome == 'failure'
@@ -369,7 +413,27 @@ jobs:
         env:
           SCYLLA_VERSION_RESOLVED: ${{ steps.scylla-version.outputs.value }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
+          COVERAGE: "true"
         run: make test-integration-scylla
+
+      - name: Collect coverage execution data
+        if: ${{ !cancelled() }}
+        run: |
+          shopt -s nullglob
+          mkdir -p coverage-exec
+          for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
+            module="${exec_file%/target/jacoco.exec}"
+            cp "$exec_file" "coverage-exec/${module//\//-}.exec"
+          done
+          ls -l coverage-exec
+
+      - name: Upload coverage execution data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage-exec-scylla-${{ matrix.scylla-version }}-${{ matrix.java-version }}-${{ matrix.test-group }}
+          path: coverage-exec/
+          if-no-files-found: warn
 
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -396,3 +460,81 @@ jobs:
           detailed_summary: true
           updateComment: false
           skip_annotations: true
+
+  coverage-report:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    needs: [unit-tests, cassandra-integration-tests, scylla-integration-tests]
+    # Runs even when a test lane failed: partial coverage data is still worth
+    # reporting, and continue-on-error keeps a flaky integration test from
+    # turning this metric into a second failure on the pull request.
+    if: ${{ !cancelled() }}
+    continue-on-error: true
+    timeout-minutes: 20
+
+    # Only needs to read the checkout; same-run artifacts are handled by the
+    # Actions runtime token rather than GITHUB_TOKEN. Scoped on this job alone
+    # so the existing lanes keep the token permissions their reporting steps
+    # rely on.
+    permissions:
+      contents: read
+
+    env:
+      # Overrides the Makefile default of `mvn -B -X -ntp`; this job has nothing
+      # to debug and -X buys a log measured in hundreds of megabytes.
+      MVNCMD: mvn -B -ntp
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Restore maven repository cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-17-maven-${{ hashFiles('**/pom.xml') }}
+
+      - name: Download coverage execution data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-exec-*
+          path: coverage-exec
+
+      # jacoco:report-aggregate picks up every *.exec in a module's target
+      # directory, so each lane's data only has to land there under a name of
+      # its own. The module name was flattened on upload (metrics/micrometer ->
+      # metrics-micrometer), so undo that to find the directory again.
+      - name: Place execution data next to the classes it was recorded against
+        run: |
+          shopt -s nullglob
+          for lane in coverage-exec/*/; do
+            lane_name="$(basename "$lane")"
+            for exec_file in "$lane"*.exec; do
+              module="$(basename "$exec_file" .exec)"
+              if [[ ! -d "$module" && -d "${module/-//}" ]]; then
+                module="${module/-//}"
+              fi
+              mkdir -p "$module/target"
+              cp "$exec_file" "$module/target/jacoco-${lane_name#coverage-exec-}.exec"
+            done
+          done
+          find . -name 'jacoco-*.exec' -printf '%p\t%s bytes\n'
+
+      - name: Aggregate coverage
+        run: make coverage-report
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: coverage-report
+          path: coverage-report/target/site/jacoco-aggregate
+          if-no-files-found: error

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -512,19 +512,40 @@ jobs:
       # directory, so each lane's data only has to land there under a name of
       # its own. The module name was flattened on upload (metrics/micrometer ->
       # metrics-micrometer), so undo that to find the directory again.
+      #
+      # The lanes are listed to the job summary because "if: !cancelled()"
+      # lets this job run with some of them failed or skipped, and a lane
+      # missing its data costs the percentage silently: the report is simply
+      # lower, with nothing in it recording what it was built from.
       - name: Place execution data next to the classes it was recorded against
         run: |
+          set -o pipefail
           shopt -s nullglob
-          for lane in coverage-exec/*/; do
+          lanes=(coverage-exec/*/)
+          if [[ ${#lanes[@]} -eq 0 ]]; then
+            echo '::error::No coverage execution data was downloaded from any test lane.'
+            exit 1
+          fi
+          {
+            echo '### Coverage execution data'
+            echo
+            echo "| Lane | Modules |"
+            echo "| --- | --- |"
+          } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          for lane in "${lanes[@]}"; do
             lane_name="$(basename "$lane")"
+            modules=()
             for exec_file in "$lane"*.exec; do
               module="$(basename "$exec_file" .exec)"
               if [[ ! -d "$module" && -d "${module/-//}" ]]; then
                 module="${module/-//}"
               fi
+              modules+=("$module")
               mkdir -p "$module/target"
               cp "$exec_file" "$module/target/jacoco-${lane_name#coverage-exec-}.exec"
             done
+            echo "| ${lane_name#coverage-exec-} | ${#modules[@]}: ${modules[*]} |" \
+              | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
           done
           find . -name 'jacoco-*.exec' -printf '%p\t%s bytes\n'
 

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -27,6 +27,19 @@ on:
       - ".gitignore"
   workflow_dispatch:
 
+# JaCoCo matches execution data to classes by an id derived from the compiled
+# bytes, and javac 11 and javac 17 do not emit the same bytes for the same
+# source even under --release 11 (they order the constant pool differently).
+# Execution data recorded on one of them is therefore invisible to a report
+# rendered against classes compiled by the other, and invisible is literal:
+# JaCoCo only warns about a name it has no id for at all, so data that loses
+# to a matching id from another lane is dropped without a word. Only the lanes
+# on this JDK are instrumented, and the aggregating job compiles on it and
+# rejects data from any other, so the number stays one the lanes actually
+# produced.
+env:
+  COVERAGE_JAVA_VERSION: "17"
+
 jobs:
   build:
     name: Build
@@ -134,17 +147,20 @@ jobs:
 
       - name: Run unit tests
         env:
-          COVERAGE: "true"
+          COVERAGE: ${{ matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: make test-unit
 
       # Flattened to one file per module so the artifact layout does not depend
       # on how many modules happened to produce data, and named per lane so the
       # aggregating job can keep each lane's contribution apart.
       - name: Collect coverage execution data
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: |
           shopt -s nullglob
           mkdir -p coverage-exec
+          # Read back by the aggregating job, which refuses data compiled by a
+          # different javac than the one it renders the report against.
+          echo '${{ matrix.java-version }}' > coverage-exec/jdk.txt
           for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
             module="${exec_file%/target/jacoco.exec}"
             cp "$exec_file" "coverage-exec/${module//\//-}.exec"
@@ -153,7 +169,7 @@ jobs:
 
       - name: Upload coverage execution data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         with:
           name: coverage-exec-unit-${{ matrix.java-version }}
           path: coverage-exec/
@@ -280,14 +296,17 @@ jobs:
           GET_VERSION_VERSION: 0.4.5
           GH_TOKEN: ${{ github.token }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
-          COVERAGE: "true"
+          COVERAGE: ${{ matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: make test-integration-cassandra
 
       - name: Collect coverage execution data
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: |
           shopt -s nullglob
           mkdir -p coverage-exec
+          # Read back by the aggregating job, which refuses data compiled by a
+          # different javac than the one it renders the report against.
+          echo '${{ matrix.java-version }}' > coverage-exec/jdk.txt
           for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
             module="${exec_file%/target/jacoco.exec}"
             cp "$exec_file" "coverage-exec/${module//\//-}.exec"
@@ -296,7 +315,7 @@ jobs:
 
       - name: Upload coverage execution data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         with:
           name: coverage-exec-cassandra-${{ matrix.cassandra-version }}-${{ matrix.java-version }}-${{ matrix.test-group }}
           path: coverage-exec/
@@ -413,14 +432,17 @@ jobs:
         env:
           SCYLLA_VERSION_RESOLVED: ${{ steps.scylla-version.outputs.value }}
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
-          COVERAGE: "true"
+          COVERAGE: ${{ matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: make test-integration-scylla
 
       - name: Collect coverage execution data
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         run: |
           shopt -s nullglob
           mkdir -p coverage-exec
+          # Read back by the aggregating job, which refuses data compiled by a
+          # different javac than the one it renders the report against.
+          echo '${{ matrix.java-version }}' > coverage-exec/jdk.txt
           for exec_file in */target/jacoco.exec metrics/*/target/jacoco.exec; do
             module="${exec_file%/target/jacoco.exec}"
             cp "$exec_file" "coverage-exec/${module//\//-}.exec"
@@ -429,7 +451,7 @@ jobs:
 
       - name: Upload coverage execution data
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.java-version == env.COVERAGE_JAVA_VERSION }}
         with:
           name: coverage-exec-scylla-${{ matrix.scylla-version }}-${{ matrix.java-version }}-${{ matrix.test-group }}
           path: coverage-exec/
@@ -490,17 +512,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ env.COVERAGE_JAVA_VERSION }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: 17
+          java-version: ${{ env.COVERAGE_JAVA_VERSION }}
           distribution: 'temurin'
 
       - name: Restore maven repository cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-17-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-${{ env.COVERAGE_JAVA_VERSION }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Download coverage execution data
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -534,6 +556,11 @@ jobs:
           } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
           for lane in "${lanes[@]}"; do
             lane_name="$(basename "$lane")"
+            lane_jdk="$(cat "$lane/jdk.txt" 2>/dev/null || true)"
+            if [[ "$lane_jdk" != "$COVERAGE_JAVA_VERSION" ]]; then
+              echo "::error::${lane_name} recorded its execution data on JDK ${lane_jdk:-unknown}, but this job renders the report against classes compiled by JDK ${COVERAGE_JAVA_VERSION}. JaCoCo would drop that lane's data without a warning, so fail here instead."
+              exit 1
+            fi
             modules=()
             for exec_file in "$lane"*.exec; do
               module="$(basename "$exec_file" .exec)"

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,20 @@ MAVEN_OPTS ?=
 
 RELEASE_SKIP_TESTS ?=
 
+# Set COVERAGE=true on any of the test-* targets to attach the JaCoCo agent to
+# the forked test JVMs; `make coverage-report` then aggregates whatever
+# execution data is on disk. Off by default: the agent slows every fork down,
+# and the existing test lanes have to stay able to run without it.
+COVERAGE ?= false
+ifeq ($(filter true 1,$(COVERAGE)),)
+	MVN_COVERAGE :=
+	COVERAGE_PREREQ :=
+else
+	MVN_COVERAGE := -Pcoverage
+	COVERAGE_PREREQ := .clean-coverage-data
+endif
+COVERAGE_REPORT_DIR := coverage-report/target/site/jacoco-aggregate
+
 ifeq (${CCM_CONFIG_DIR},)
 	CCM_CONFIG_DIR = ~/.ccm
 endif
@@ -32,6 +46,18 @@ CCM_CONFIG_DIR := $(shell readlink --canonicalize ${CCM_CONFIG_DIR})
 export SCYLLA_EXT_OPTS
 export SCYLLA_VERSION
 export PATH := $(MAKEFILE_PATH)/bin:$(PATH)
+
+# JaCoCo appends to its execution data by default, which is what lets one lane
+# accumulate coverage across several forks (integration-tests alone runs three).
+# The flip side is that data from an earlier run survives a recompile, and a
+# class that changed in between is then reported uncovered because its checksum
+# no longer matches. Truncating before a run is the fix.
+#
+# Only jacoco.exec is removed -- the file the agent is about to write. Data
+# renamed out of the way to keep one lane's results while another runs (as the
+# CI coverage job does) is left alone.
+.clean-coverage-data:
+	@find . -name 'jacoco.exec' -delete
 
 .install-guava-shaded:
 	$(MVNCMD) install -pl guava-shaded
@@ -290,10 +316,10 @@ check:
 fix:
 	$(MVNCMD) fmt:format xml-format:xml-format
 
-test-unit: .install-guava-shaded
-	$(MVNCMD) test -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+test-unit: .install-guava-shaded $(COVERAGE_PREREQ)
+	$(MVNCMD) test $(MVN_COVERAGE) -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
 
-test-integration-scylla: .install-all-modules .prepare-scylla-ccm resolve-scylla-version .prepare-environment-update-aio-max-nr
+test-integration-scylla: .install-all-modules .prepare-scylla-ccm resolve-scylla-version .prepare-environment-update-aio-max-nr $(COVERAGE_PREREQ)
 	@if [[ -z "$${SCYLLA_VERSION_RESOLVED}" ]]; then
 		SCYLLA_VERSION_RESOLVED=`cat '${SCYLLA_VERSION_FILE}'`
 	fi
@@ -301,9 +327,9 @@ test-integration-scylla: .install-all-modules .prepare-scylla-ccm resolve-scylla
 		echo "ScyllaDB version ${SCYLLA_VERSION} was not resolved"
 		exit 1
 	fi
-	mvn -B -e verify -pl integration-tests -Dccm.version=$${SCYLLA_VERSION_RESOLVED} -Dccm.distribution=scylla -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true $(MAVEN_EXTRA_ARGS)
+	mvn -B -e verify $(MVN_COVERAGE) -pl integration-tests -Dccm.version=$${SCYLLA_VERSION_RESOLVED} -Dccm.distribution=scylla -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true $(MAVEN_EXTRA_ARGS)
 
-test-integration-cassandra: .install-all-modules .prepare-scylla-ccm resolve-cassandra-version
+test-integration-cassandra: .install-all-modules .prepare-scylla-ccm resolve-cassandra-version $(COVERAGE_PREREQ)
 	@if [[ -z "$${CASSANDRA_VERSION_RESOLVED}" ]]; then
 		CASSANDRA_VERSION_RESOLVED=`cat '${CASSANDRA_VERSION_FILE}'`
 	fi
@@ -311,7 +337,51 @@ test-integration-cassandra: .install-all-modules .prepare-scylla-ccm resolve-cas
 		echo "Cassandra version ${CASSANDRA_VERSION} was not resolved"
 		exit 1
 	fi
-	mvn -B -e verify -pl integration-tests -Dccm.version=$${CASSANDRA_VERSION_RESOLVED} -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true $(MAVEN_EXTRA_ARGS)
+	mvn -B -e verify $(MVN_COVERAGE) -pl integration-tests -Dccm.version=$${CASSANDRA_VERSION_RESOLVED} -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true $(MAVEN_EXTRA_ARGS)
+
+# Aggregates the execution data left behind by any COVERAGE=true test run into
+# a single cross-module report -- most importantly attributing the coverage
+# core gets *through* the integration suite back to core's own source, which
+# each module's own report cannot see. Tests are skipped here on purpose: this
+# only reads what is already on disk, so the same target serves one local lane
+# and execution data collected from several CI jobs.
+#
+# report-aggregate is bound to `verify` inside the "coverage" profile (see
+# coverage-report/pom.xml) rather than requested as a bare CLI goal: a CLI goal
+# runs against every project the -am reactor pulls in, which rendered a stray
+# report in all eleven of them (one of those over guava-shaded's relocated
+# classes), and it never sees the execution's own configuration. Keeping the
+# binding inside the profile still leaves a plain `mvn verify`/`mvn install`
+# rendering nothing.
+#
+# .PHONY here (unlike the rest of this file) because these target names
+# collide with real paths -- coverage-report/ is the module's own directory --
+# so make would otherwise treat the target as already up to date and skip it.
+.PHONY: coverage-report clean-coverage
+coverage-report: .install-guava-shaded
+	@if [[ -z "$$(find . -name 'jacoco*.exec' -not -path './coverage-report/*' -print -quit)" ]]; then
+		echo 'No JaCoCo execution data found.'
+		echo "Run the tests with COVERAGE=true first, e.g. 'make test-unit COVERAGE=true'."
+		exit 1
+	fi
+	rm -rf '${COVERAGE_REPORT_DIR}'
+	$(MVNCMD) verify -Pcoverage -pl coverage-report -am -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	if [[ ! -f '${COVERAGE_REPORT_DIR}/jacoco.xml' ]]; then
+		echo 'Maven produced no report at ${COVERAGE_REPORT_DIR}/jacoco.xml.'
+		exit 1
+	fi
+	echo 'HTML report: ${COVERAGE_REPORT_DIR}/index.html'
+	# Read the report-level LINE counter rather than the sibling csv, whose
+	# fields are unquoted and so shift on any class name containing a comma.
+	# Zero covered lines means the execution data did not match these classes
+	# (look for a checksum mismatch in the log), which is worth failing on:
+	# the alternative is a confident-looking 0%.
+	python3 -c 'import sys, xml.etree.ElementTree as ET; r = ET.parse(sys.argv[1]).getroot(); c = next(x for x in r.findall("counter") if x.get("type") == "LINE"); missed, covered = int(c.get("missed")), int(c.get("covered")); total = missed + covered; print("Line coverage: {}/{} ({:.2f}%)".format(covered, total, 100.0 * covered / total if total else 0.0)); sys.exit("No lines are recorded as covered: the execution data is either missing or does not match these classes. Look for a checksum mismatch warning in the Maven log.") if covered == 0 else None' '${COVERAGE_REPORT_DIR}/jacoco.xml' | tee -a "$${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+clean-coverage:
+	find . -name 'jacoco*.exec' -delete
+	find . -type d -path '*/target/site/jacoco*' -exec rm -rf {} +
+	rm -rf coverage-report/target/site
 
 check-no-compile-warnings:
 	@$(MAKE) compile-all | grep WARNING >/tmp/all-compile-warnings.log || true

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,25 @@ RELEASE_SKIP_TESTS ?=
 # execution data is on disk. Off by default: the agent slows every fork down,
 # and the existing test lanes have to stay able to run without it.
 COVERAGE ?= false
-ifeq ($(filter true 1,$(COVERAGE)),)
+# Spellings are normalised, and anything outside the two lists below is an
+# error rather than a silent "off": COVERAGE=TRUE used to run without the
+# agent, and the miss only surfaced much later, when `make coverage-report`
+# said to run with COVERAGE=true -- the thing you thought you had just done.
+_COVERAGE_NORM := $(or $(shell printf '%s' '$(COVERAGE)' | tr '[:upper:]' '[:lower:]'),false)
+ifneq ($(filter $(_COVERAGE_NORM),true 1 yes on),)
+	MVN_COVERAGE := -Pcoverage
+	COVERAGE_PREREQ := .clean-coverage-data
+else ifneq ($(filter $(_COVERAGE_NORM),false 0 no off),)
 	MVN_COVERAGE :=
 	COVERAGE_PREREQ :=
 else
-	MVN_COVERAGE := -Pcoverage
-	COVERAGE_PREREQ := .clean-coverage-data
+# Not tab-indented, unlike the assignments above: make reads a tab-indented
+# line that is not an assignment as a recipe line.
+$(error COVERAGE must be one of true/1/yes/on or false/0/no/off, got '$(COVERAGE)')
 endif
 COVERAGE_REPORT_DIR := coverage-report/target/site/jacoco-aggregate
+COVERAGE_MAVEN_LOG_DIR := coverage-report/target
+COVERAGE_MAVEN_LOG := ${COVERAGE_MAVEN_LOG_DIR}/coverage-maven.log
 
 ifeq (${CCM_CONFIG_DIR},)
 	CCM_CONFIG_DIR = ~/.ccm
@@ -438,13 +449,28 @@ test-integration-cassandra: .install-all-modules .prepare-scylla-ccm resolve-cas
 # so make would otherwise treat the target as already up to date and skip it.
 .PHONY: coverage-report clean-coverage
 coverage-report: .install-guava-shaded
-	@if [[ -z "$$(find . -name 'jacoco*.exec' -not -path './coverage-report/*' -print -quit)" ]]; then
+	@# Without this the recipe's exit status is that of the tee on its last
+	@# line, not of the python that feeds it, so the empty-report check would
+	@# print its complaint and let the target pass anyway.
+	set -o pipefail
+	if [[ -z "$$(find . -name 'jacoco*.exec' -not -path './coverage-report/*' -print -quit)" ]]; then
 		echo 'No JaCoCo execution data found.'
 		echo "Run the tests with COVERAGE=true first, e.g. 'make test-unit COVERAGE=true'."
 		exit 1
 	fi
 	rm -rf '${COVERAGE_REPORT_DIR}'
-	$(MVNCMD) verify -Pcoverage -pl coverage-report -am -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	mkdir -p '${COVERAGE_MAVEN_LOG_DIR}'
+	$(MVNCMD) verify -Pcoverage -pl coverage-report -am -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true 2>&1 | tee '${COVERAGE_MAVEN_LOG}'
+	# JaCoCo matches execution data to classes by checksum and only warns when
+	# it does not match, dropping that class's data; the report still renders,
+	# just quietly short. Nothing else in this target can see that -- the
+	# percentage is simply lower -- so fail on the warning itself.
+	if grep -q 'Execution data for class .* does not match' '${COVERAGE_MAVEN_LOG}'; then
+		echo 'Execution data does not match the compiled classes, so the report below understates coverage.'
+		echo 'The data has to come from the same build of the classes the report is rendered against.'
+		grep 'Execution data for class .* does not match' '${COVERAGE_MAVEN_LOG}' | sort -u
+		exit 1
+	fi
 	if [[ ! -f '${COVERAGE_REPORT_DIR}/jacoco.xml' ]]; then
 		echo 'Maven produced no report at ${COVERAGE_REPORT_DIR}/jacoco.xml.'
 		exit 1
@@ -460,7 +486,7 @@ coverage-report: .install-guava-shaded
 clean-coverage:
 	find . -name 'jacoco*.exec' -delete
 	find . -type d -path '*/target/site/jacoco*' -exec rm -rf {} +
-	rm -rf coverage-report/target/site
+	rm -rf coverage-report/target/site '${COVERAGE_MAVEN_LOG}'
 
 check-no-compile-warnings:
 	@$(MAKE) compile-all | grep WARNING >/tmp/all-compile-warnings.log || true

--- a/README-dev.md
+++ b/README-dev.md
@@ -27,4 +27,57 @@ Most day-to-day tasks are wrapped in the top-level `Makefile` so you do not have
 - `make fix` executes `mvn fmt:format` to format the code.
 - `make clean` removes Maven targets, shaded artifacts, and release backups to reset the tree.
 
+### Measuring code coverage
+
+Coverage is measured with [JaCoCo](https://www.jacoco.org/jacoco/) and is off by default: the agent
+slows every forked test JVM down, so it is opt-in through the `coverage` Maven profile. Pass
+`COVERAGE=true` to any of the `test-*` Make targets to enable it, then aggregate:
+
+```
+make test-unit COVERAGE=true
+make coverage-report
+```
+
+`make coverage-report` reads whatever execution data is already on disk, so several lanes can be
+combined into one number -- which is the point of the separate `coverage-report` module: it
+attributes the coverage `core` gets *through* the integration suite back to `core`'s own source,
+which each module's own report cannot see. A `COVERAGE=true` run truncates `jacoco.exec` before it
+starts, so rename the previous lane's data out of the way to keep it:
+
+```
+make test-unit COVERAGE=true
+find . -name jacoco.exec -execdir mv jacoco.exec jacoco-unit.exec \;
+make test-integration-scylla COVERAGE=true
+make coverage-report
+```
+
+The report lands in `coverage-report/target/site/jacoco-aggregate` (HTML, XML and CSV), and
+`make clean-coverage` removes it along with the execution data. `make coverage-report` fails rather
+than rendering a confident-looking but empty report if it finds no execution data, or if the data
+matches none of the classes.
+
+In CI, the unit and integration jobs in `tests@v1.yml` run with `COVERAGE=true` and upload their
+execution data; the "Coverage report" job aggregates it, prints the percentage to its job summary
+and attaches the HTML report as an artifact. That job is `continue-on-error`, so a flaky
+integration test costs the metric some data rather than adding a second failure to the pull
+request. Collecting from the existing lanes rather than a dedicated workflow keeps the Scylla suite
+from being run twice.
+
+JaCoCo matches execution data to classes by checksum, so the data has to come from the same build
+of the classes the report is rendered against. If a report shows code you know was exercised as
+uncovered, look for `Execution data for class ... does not match` in the Maven log; the usual cause
+is stale execution data from before a recompile, which `make clean-coverage` clears.
+
+Note: the surefire/failsafe configs in `core` and `integration-tests` previously set `<argLine>` to
+just their own JVM flags (e.g. `${mockitoopens.argline}`), which silently discarded the
+`-javaagent` flag `jacoco:prepare-agent` injects into the `argLine` property -- coverage was being
+collected for every *other* module, but not these two. They now combine both via Maven's
+deferred-property syntax: `<argLine>@{argLine} ${mockitoopens.argline}</argLine>` (`@{...}` is
+necessary rather than `${...}` because `jacoco:prepare-agent` sets `argLine` at build-execution
+time, after the POM's own `${...}` references would already have been resolved). `argLine` itself
+is declared, empty, as a root `pom.xml` property so that combination resolves to something even
+outside the `coverage` profile, where `jacoco:prepare-agent` never runs to give it a real value.
+(`distribution-tests` has no `src` of its own, so surefire never forks there either way; it was
+left out of this.)
+
 The Makefile automatically installs the shaded Guava dependency and, for integration tests, bootstraps the appropriate CCM toolchain and raises kernel `aio-max-nr` when required. If a target fails because the toolchain is missing, rerun after installing the prerequisites highlighted in the target output.

--- a/README-dev.md
+++ b/README-dev.md
@@ -56,17 +56,22 @@ The report lands in `coverage-report/target/site/jacoco-aggregate` (HTML, XML an
 than rendering a confident-looking but empty report if it finds no execution data, or if the data
 matches none of the classes.
 
+`COVERAGE` accepts `true`/`1`/`yes`/`on` and `false`/`0`/`no`/`off`, in any case; anything else is
+an error rather than a silent "off", because a run that quietly skipped the agent only shows up
+much later, when `make coverage-report` finds nothing to aggregate.
+
 In CI, the unit and integration jobs in `tests@v1.yml` run with `COVERAGE=true` and upload their
-execution data; the "Coverage report" job aggregates it, prints the percentage to its job summary
-and attaches the HTML report as an artifact. That job is `continue-on-error`, so a flaky
-integration test costs the metric some data rather than adding a second failure to the pull
-request. Collecting from the existing lanes rather than a dedicated workflow keeps the Scylla suite
-from being run twice.
+execution data; the "Coverage report" job aggregates it and writes both the lanes it actually
+received data from and the resulting percentage to its job summary, then attaches the HTML report
+as an artifact. That job is `continue-on-error`, so a flaky integration test costs the metric some
+data rather than adding a second failure to the pull request. Collecting from the existing lanes
+rather than a dedicated workflow keeps the Scylla suite from being run twice.
 
 JaCoCo matches execution data to classes by checksum, so the data has to come from the same build
-of the classes the report is rendered against. If a report shows code you know was exercised as
-uncovered, look for `Execution data for class ... does not match` in the Maven log; the usual cause
-is stale execution data from before a recompile, which `make clean-coverage` clears.
+of the classes the report is rendered against. When they diverge it only warns and drops that
+class's data, leaving a report that renders happily and reads low, so `make coverage-report` greps
+its own Maven log for `Execution data for class ... does not match` and fails on it. The usual
+cause is stale execution data from before a recompile, which `make clean-coverage` clears.
 
 Note: the surefire/failsafe configs in `core` and `integration-tests` previously set `<argLine>` to
 just their own JVM flags (e.g. `${mockitoopens.argline}`), which silently discarded the

--- a/README-dev.md
+++ b/README-dev.md
@@ -60,18 +60,31 @@ matches none of the classes.
 an error rather than a silent "off", because a run that quietly skipped the agent only shows up
 much later, when `make coverage-report` finds nothing to aggregate.
 
-In CI, the unit and integration jobs in `tests@v1.yml` run with `COVERAGE=true` and upload their
+In CI, the unit and integration lanes in `tests@v1.yml` run with `COVERAGE=true` and upload their
 execution data; the "Coverage report" job aggregates it and writes both the lanes it actually
 received data from and the resulting percentage to its job summary, then attaches the HTML report
 as an artifact. That job is `continue-on-error`, so a flaky integration test costs the metric some
 data rather than adding a second failure to the pull request. Collecting from the existing lanes
 rather than a dedicated workflow keeps the Scylla suite from being run twice.
 
-JaCoCo matches execution data to classes by checksum, so the data has to come from the same build
-of the classes the report is rendered against. When they diverge it only warns and drops that
-class's data, leaving a report that renders happily and reads low, so `make coverage-report` greps
+Only the lanes on `COVERAGE_JAVA_VERSION` (a workflow-level variable, JDK 17) are instrumented.
+javac 11 and javac 17 do not emit the same bytes for the same source even under `--release 11` --
+they order the constant pool differently -- so the class ids differ, and a report rendered against
+one compiler's classes cannot see the other's execution data. Instrumenting the JDK 11 lanes would
+not have added anything to the number; it would only have slowed them down. Each lane records the
+JDK it ran on alongside its execution data and the aggregating job refuses anything that does not
+match its own, so a future matrix change cannot quietly reintroduce the mismatch.
+
+JaCoCo matches execution data to classes by an id derived from the compiled bytes, so the data has
+to come from the same build of the classes the report is rendered against. When they diverge it
+drops that class's data and the report renders happily, just short, so `make coverage-report` greps
 its own Maven log for `Execution data for class ... does not match` and fails on it. The usual
 cause is stale execution data from before a recompile, which `make clean-coverage` clears.
+
+That warning only covers the case where JaCoCo finds no data at all under a class's id. When two
+builds of the same class are represented -- one matching, one not -- the matching one wins and the
+other is dropped in silence, which is why the JDK the data was recorded on is checked separately
+rather than left to the warning.
 
 Note: the surefire/failsafe configs in `core` and `integration-tests` previously set `<argLine>` to
 just their own JVM flags (e.g. `${mockitoopens.argline}`), which silently discarded the

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -261,7 +261,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <jvm>${testing.jvm}/bin/java</jvm>
-          <argLine>${mockitoopens.argline}</argLine>
+          <argLine>@{argLine} ${mockitoopens.argline}</argLine>
           <threadCount>1</threadCount>
           <properties>
             <property>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+    Copyright (C) 2026 ScyllaDB
+
+    Modified by ScyllaDB
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.scylladb</groupId>
+    <artifactId>java-driver-parent</artifactId>
+    <version>4.19.2.2-SNAPSHOT</version>
+  </parent>
+  <artifactId>java-driver-coverage-report</artifactId>
+  <packaging>pom</packaging>
+  <name>Java driver for Scylla and Apache Cassandra(R) - coverage report</name>
+  <!--
+      Not a real artifact: this module exists only to run jacoco:report-aggregate
+      over its dependencies below. The parent pom's default prepare-agent/report
+      executions are disabled below (not via jacoco.skip, which would also
+      disable report-aggregate itself) since this module has no tests or
+      classes of its own for them to act on.
+
+      scope=compile is explicit on mapper-runtime/mapper-processor/metrics-*
+      below because the root pom's dependencyManagement pins them to
+      scope=test (correct for their other consumers, like integration-tests,
+      which only need them for testing); report-aggregate only aggregates
+      compile/runtime-scoped reactor dependencies, so without this override
+      these 4 modules' classes are silently excluded from the aggregate
+      report even though their jacoco.exec data is loaded (confirmed by
+      comparing the loaded-execution-data-file log lines against the
+      Analyzed-bundle log lines: all 7 files load, only 3 modules get
+      analyzed). That's real, substantial coverage lost from these modules'
+      own integration tests (MicrometerMetricsIT, MicroProfileMetricsIT).
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-query-builder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-mapper-runtime</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-mapper-processor</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-metrics-micrometer</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-metrics-microprofile</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.scylladb</groupId>
+      <artifactId>java-driver-integration-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <!-- Override the parent's default prepare-agent/report executions: this
+               module has nothing of its own for them to do. -->
+          <execution>
+            <id>default</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <!--
+        report-aggregate is bound inside the "coverage" profile rather than
+        the default build: this module sits in the default reactor (root
+        pom's <modules>), so an unconditional binding would render a report
+        during any plain `mvn install` / `mvn verify` across the whole
+        reactor, before any test had run. A bare `jacoco:report-aggregate`
+        goal on the command line was the other option, but that runs
+        against every project an -am reactor pulls in (all eleven here,
+        including a report over guava-shaded's relocated classes) and never
+        sees this execution's own configuration.
+    -->
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>report-aggregate</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <title>Java Driver for Scylla and Apache Cassandra 4.x</title>
+                  <formats>
+                    <format>HTML</format>
+                    <format>XML</format>
+                    <format>CSV</format>
+                  </formats>
+                  <outputDirectory>${project.build.directory}/site/jacoco-aggregate</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -283,7 +283,7 @@
               <threadCountClasses>${test.parallel.threads}</threadCountClasses>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
               <skipITs>${skipParallelizableITs}</skipITs>
-              <argLine>${blockhound.argline}</argLine>
+              <argLine>@{argLine} ${blockhound.argline}</argLine>
               <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
@@ -296,7 +296,7 @@
               <excludedGroups>com.datastax.oss.driver.categories.ParallelizableTests, com.datastax.oss.driver.categories.IsolatedTests</excludedGroups>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
               <skipITs>${skipSerialITs}</skipITs>
-              <argLine>${blockhound.argline}</argLine>
+              <argLine>@{argLine} ${blockhound.argline}</argLine>
               <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
@@ -312,7 +312,7 @@
               <reuseForks>false</reuseForks>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-isolated.xml</summaryFile>
               <skipITs>${skipIsolatedITs}</skipITs>
-              <argLine>${blockhound.argline}</argLine>
+              <argLine>@{argLine} ${blockhound.argline}</argLine>
               <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,20 @@
     <module>distribution-tests</module>
     <module>examples</module>
     <module>bom</module>
+    <module>coverage-report</module>
   </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!--
+        Must be declared even though only the "coverage" profile's
+        jacoco:prepare-agent ever gives it a real value: surefire/failsafe
+        configs that combine it via @{argLine} (core, integration-tests)
+        need Maven to resolve that reference to something, or it is left
+        as the literal string "@{argLine}", which the forked JVM then
+        rejects as an option.
+    -->
+    <argLine/>
     <config.version>1.4.8</config.version>
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.2.2</hdrhistogram.version>
@@ -101,6 +111,17 @@
     <release.autopublish>false</release.autopublish>
     <pushChanges>false</pushChanges>
     <mockitoopens.argline/>
+    <!--
+        Declared empty for the same reason as argLine above: the JDK
+        profiles below only set this from JDK 14 onwards, so on JDK 11 it
+        is otherwise undefined, and integration-tests' failsafe argLine
+        combines it with @{argLine} rather than referencing it alone. A
+        lone ${...} to an undefined property resolves to nothing, but in a
+        composite value Maven leaves the literal text, which the forked
+        JVM then rejects ("Could not find or load main class
+        ${blockhound.argline}").
+    -->
+    <blockhound.argline/>
     <api.plumber.skip>false</api.plumber.skip>
   </properties>
   <dependencyManagement>
@@ -712,7 +733,7 @@
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
-          <excludeArtifacts>java-driver-distribution-source,java-driver-distribution-tests,java-driver-distribution,java-driver-examples,java-driver-integration-tests,java-driver-osgi-tests</excludeArtifacts>
+          <excludeArtifacts>java-driver-distribution-source,java-driver-distribution-tests,java-driver-distribution,java-driver-examples,java-driver-integration-tests,java-driver-osgi-tests,java-driver-coverage-report</excludeArtifacts>
           <autoPublish>${release.autopublish}</autoPublish>
           <waitUntil>validated</waitUntil>
         </configuration>
@@ -770,24 +791,16 @@
           </excludes>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      <!--
+          jacoco-maven-plugin's prepare-agent/report executions live in the
+          "coverage" profile below, not here. Bound unconditionally, they
+          instrumented every module's build (all IT lanes across every CI
+          job, not just the coverage workflow), with no way to opt out:
+          -Djacoco.skip=true skipped prepare-agent but left the modules
+          that combine argLine via @{argLine} (core, integration-tests)
+          trying to fork with that literal, unresolved string as a JVM
+          argument.
+      -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -1033,6 +1046,39 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!--
+          Opt-in instrumentation/reporting for code coverage measurement
+          (see Makefile's test-unit-coverage/test-integration-scylla/
+          coverage-report targets and .github/workflows/coverage.yml).
+          Kept out of the default build so it doesn't add -javaagent
+          overhead, or a jacoco.skip escape hatch, to every other build and
+          test job.
+      -->
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -793,13 +793,11 @@
       </plugin>
       <!--
           jacoco-maven-plugin's prepare-agent/report executions live in the
-          "coverage" profile below, not here. Bound unconditionally, they
-          instrumented every module's build (all IT lanes across every CI
-          job, not just the coverage workflow), with no way to opt out:
-          -Djacoco.skip=true skipped prepare-agent but left the modules
-          that combine argLine via @{argLine} (core, integration-tests)
-          trying to fork with that literal, unresolved string as a JVM
-          argument.
+          "coverage" profile below, not here. Bound unconditionally they
+          would attach the agent to every forked test JVM in every CI job,
+          and the only way back off would be -Djacoco.skip=true on each of
+          them. An opt-in profile puts that cost on the runs that want the
+          number and leaves the existing lanes as they were.
       -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -1055,12 +1053,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </profile>
     <profile>
       <!--
-          Opt-in instrumentation/reporting for code coverage measurement
-          (see Makefile's test-unit-coverage/test-integration-scylla/
-          coverage-report targets and .github/workflows/coverage.yml).
-          Kept out of the default build so it doesn't add -javaagent
-          overhead, or a jacoco.skip escape hatch, to every other build and
-          test job.
+          Opt-in instrumentation and reporting for code coverage
+          measurement. COVERAGE=true on any of the Makefile's test-*
+          targets activates it, which is how the unit and integration
+          lanes in .github/workflows/tests@v1.yml switch it on; `make
+          coverage-report` then aggregates the execution data those lanes
+          leave behind. Kept out of the default build so the -javaagent
+          overhead lands only on the runs that asked for the number.
       -->
       <id>coverage</id>
       <build>


### PR DESCRIPTION
4.x has no coverage number. `jacoco-maven-plugin` was declared in the parent pom but nothing consumed it, and no module's execution data was ever combined with another's. DRIVER-887 asks for the metric on both drivers, and this is the 4.x half.

- Opt-in `coverage` Maven profile carrying `prepare-agent` and `report`, kept out of the default build: the agent slows every forked test JVM down, and the existing test lanes have to stay able to run without it.
- `argLine` and `blockhound.argline` declared empty in `<properties>`. `core`'s surefire and `integration-tests`' failsafe compose the agent flag with their own JVM flags through `@{argLine}`, and a composite value referencing an undeclared property reaches the fork as a literal `@{...}` token instead. `blockhound.argline` in particular is only set from JDK 14 onwards.
- New `coverage-report` module whose dependencies *are* the report's scope — `core`, `query-builder`, `mapper-runtime`, `mapper-processor`, `metrics-micrometer`, `metrics-microprofile`, `integration-tests`. Four of them carry an explicit `scope=compile`, because the root pom's `dependencyManagement` pins them to `scope=test` and `report-aggregate` only aggregates compile/runtime-scoped reactor dependencies. `report-aggregate` is bound inside the profile, so the default reactor renders nothing.
- `COVERAGE=true` on any `make test-*` target, plus `make coverage-report` and `make clean-coverage`. A `COVERAGE=true` run truncates `jacoco.exec` first, since the agent appends and data surviving a recompile is reported uncovered once checksums stop matching; only that file is removed, so data renamed aside to hold one lane's results while another runs is kept.
- The existing unit and integration lanes upload their execution data and one `continue-on-error` job aggregates it, rather than a dedicated workflow re-running the 90-minute Scylla suite. Data is flattened to one file per module on upload so the artifact layout does not depend on which modules produced any, and placed back under a per-lane name on download.
- Developer docs in `README-dev.md`, which already covers this fork's Makefile-based workflow; the upstream `CONTRIBUTING.md` predates it and is left alone.

`integration-tests` contributes no classes of its own — it is in the aggregate for the coverage it drives in the other modules, which is the reason a combined report exists at all rather than each module's own.

Sibling of #1018 (3.x), whose structure this follows.

No `jacoco:check` gate: the first runs establish a baseline, and a ratchet before there is one to ratchet against would mostly produce false failures. Worth adding once the number is known to be stable.

## One compiler for the whole report

JaCoCo matches execution data to classes by an id derived from the compiled bytes, and javac 11 and javac 17 do not emit the same bytes for the same source even under `--release 11` — they order the constant pool differently. Execution data recorded against one compiler's output is therefore invisible to a report rendered against the other's, and invisible is literal: JaCoCo warns only about a class name it has no id for *at all*, so data that loses to a matching id from another lane is dropped without a word.

Only the lanes on `COVERAGE_JAVA_VERSION` (JDK 17, a workflow-level variable) are instrumented, and the aggregating job compiles on it. Each lane records the JDK it ran on next to its execution data and the aggregating job fails on any lane that does not match its own, so a change to the test matrix cannot quietly reintroduce the mismatch.

The alternative — analysing each compiler's data against matching class artifacts — gives one report per JDK, and JaCoCo merges execution data but not reports, so there would be no single number. What the JDK 11 lanes uniquely exercise is server-version-conditional paths against the same driver source the JDK 17 lanes cover.

## Verification

CI run 34409812210 on this head: all 23 jobs green, and the aggregate reports **29512/36439 lines (80.99%)** from the seven instrumented lanes — `unit-17` (7 modules) and the Cassandra 4-LATEST and Scylla LATEST integration lanes (3 test groups each). Twelve execution-data files load, all seven bundles are analysed (`core` 954 classes, `query-builder` 174, `mapper-processor` 93, `mapper-runtime` 17, `metrics-micrometer` 5, `metrics-microprofile` 5, `integration-tests` 0 of its own), zero mismatch warnings. The aggregating job takes 2m49s against its 20-minute cap.

That number is the check on the section above. The previous head measured 29528/36457 (80.99%) with all seventeen lanes instrumented; dropping the ten JDK 11 lanes moved it by sixteen covered lines out of 29.5k, and not at all to two decimal places. Had those lanes been contributing, removing them would have cost far more than that. (Both totals also shifted slightly because the base merge changed source.)

`make coverage-report` fails rather than publishing a number it cannot stand behind: no execution data on disk, no report produced, a report with zero covered lines, or a `Execution data for class ... does not match` anywhere in its own Maven log. All four paths exercised against a stubbed Maven. The recipe sets `pipefail`, without which the exit status of its last line was `tee`'s and the zero-coverage check passed silently — as did a missing `python3`.

`COVERAGE` is normalised (`true/1/yes/on`, `false/0/no/off`, any case) and an unrecognised value is a `$(error)`, so `COVERAGE=TRUE` no longer runs without the agent.

The cross-compiler behaviour was measured, not assumed. Same source through javac 11 and javac 17, both `--release 11`: identical file size, different constant pool ordering, and different JaCoCo class ids (`bfbd0cfa0a12e9e8` vs `cce73e4995e3d875`). Running the class under both JDKs and analysing the javac-17 classes with `org.jacoco.core` 0.8.14 directly — 12 covered lines and 0 `noMatch` classes from the JDK 17 data alone, 0 covered and 2 `noMatch` from the JDK 11 data alone, and **12 covered and 0 `noMatch` from both together**: the JDK 11 data changes nothing and warns about nothing.

Locally on JDK 17: `mvn test -pl core -Pcoverage` writes `core/target/jacoco.exec`, and the same command without the profile writes none and starts its fork cleanly; `mvn verify` on the default reactor renders no report; and `report-aggregate` under the profile produces exactly one report directory, against the eleven a bare `jacoco:report-aggregate` CLI goal produced under `-am`.

Refs: https://scylladb.atlassian.net/browse/DRIVER-891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxW9fzmwwpSLvzcHEr5MRa