### PR TITLE
ci: exclude failsafe summaries from JUnit reports

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           check_name: Unit tests report (JDK ${{ matrix.java-version }})
           require_tests: true
-          report_paths: "*/**/target/*-reports/*.xml"
+          report_paths: "*/**/target/*-reports/TEST-*.xml"
           follow_symlink: true
           detailed_summary: true
           updateComment: false
@@ -292,7 +292,7 @@ jobs:
         with:
           check_name: Integration tests report for Cassandra ${{ steps.cassandra-version.outputs.value }} (${{ matrix.test-group }}, JDK ${{ matrix.java-version }})
           require_tests: true
-          report_paths: "*/**/target/*-reports/*.xml"
+          report_paths: "*/**/target/*-reports/TEST-*.xml"
           follow_symlink: true
           detailed_summary: true
           updateComment: false
@@ -412,7 +412,7 @@ jobs:
         with:
           check_name: Integration tests report for Scylla ${{ steps.scylla-version.outputs.value }} (${{ matrix.test-group }}, JDK ${{ matrix.java-version }})
           require_tests: true
-          report_paths: "*/**/target/*-reports/*.xml"
+          report_paths: "*/**/target/*-reports/TEST-*.xml"
           follow_symlink: true
           detailed_summary: true
           updateComment: false

--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -135,13 +135,6 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
-      - name: Copy test results
-        if: always()
-        run: |
-          shopt -s globstar
-          mkdir unit
-          cp --parents ./**/target/*-reports/*.xml unit/
-
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
@@ -265,15 +258,8 @@ jobs:
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
         run: make test-integration-cassandra
 
-      - name: Copy test results
-        if: steps.run-integration-tests.outcome == 'failure'
-        run: |
-          shopt -s globstar
-          mkdir cassandra-${{ matrix.cassandra-version }}-${{ matrix.test-group }}
-          cp --parents ./**/target/*-reports/*.xml cassandra-${{ matrix.cassandra-version }}-${{ matrix.test-group }}/
-
       - name: Upload test results
-        if: steps.run-integration-tests.outcome == 'failure'
+        if: failure() && steps.run-integration-tests.outcome == 'failure'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-results-${{ matrix.java-version }}-${{ matrix.cassandra-version }}-${{ matrix.test-group }}
@@ -385,16 +371,9 @@ jobs:
           MAVEN_EXTRA_ARGS: ${{ steps.test-skip-args.outputs.value }}
         run: make test-integration-scylla
 
-      - name: Copy test results
-        if: steps.run-integration-tests.outcome == 'failure'
-        run: |
-          shopt -s globstar
-          mkdir scylla-${{ matrix.scylla-version }}-${{ matrix.test-group }}
-          cp --parents ./**/target/*-reports/*.xml scylla-${{ matrix.scylla-version }}-${{ matrix.test-group }}/
-
       - name: Upload test results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: steps.run-integration-tests.outcome == 'failure'
+        if: failure() && steps.run-integration-tests.outcome == 'failure'
         with:
           name: test-results-${{ matrix.java-version }}-${{ matrix.scylla-version }}-${{ matrix.test-group }}
           path: "*/**/target/*-reports/*.xml"


### PR DESCRIPTION
Moves the CI-only report filtering change out of #999.

Restricts test report publication to `TEST-*.xml`, excluding Maven Failsafe summary XML files that are not JUnit testcase reports.