### PR TITLE
Fix flaky PeersV2NodeRefreshIT: retry on Simulacron port-bind race

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.protocol.internal.request.Query;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
+import com.datastax.oss.simulacron.server.BindNodeException;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.Server;
 import java.util.concurrent.ExecutionException;
@@ -36,13 +37,59 @@ import org.junit.Test;
 /** Test for JAVA-2654. */
 public class PeersV2NodeRefreshIT {
 
+  // Simulacron's "multiple nodes per IP" mode (needed here to emulate several nodes sharing a
+  // single address, as system.peers_v2 distinguishes nodes by (peer, peer_port)) always binds
+  // nodes to consecutive ports on a loopback address starting at port 49152 -- the first port of
+  // the OS ephemeral/dynamic port range on both Linux (/proc/sys/net/ipv4/ip_local_port_range,
+  // typically 32768-60999) and macOS (49152-65535). That range is also what the kernel hands out
+  // as the *source* port for any outbound client socket opened by any process on the machine,
+  // including other integration tests' driver connections running concurrently in this same
+  // build. When the kernel happens to allocate 49152 as an ephemeral source port at the exact
+  // moment this test tries to bind it as a *listening* socket, Simulacron fails with
+  // BindNodeException ("Failed to bind ... to /127.0.0.1:49152"). This is a real,
+  // previously-reported flake (see https://github.com/scylladb/java-driver/issues/951, which was
+  // closed after an unrelated fix for a different flaky test happened to land around the same
+  // time as a CI re-run that passed -- the actual Simulacron port race was never fixed).
+  //
+  // Ideally this test would sidestep the collision entirely by binding to a fixed, non-ephemeral
+  // starting port via Server.Builder#withAddressResolver(...). However, the vendored
+  // com.scylladb.oss.simulacron:simulacron-native-server:0.14.0.0 unconditionally re-creates a
+  // brand-new `new NodePerPortResolver()` (hardcoded to port 49152) inside build() whenever
+  // withMultipleNodesPerIp(true) is set, silently discarding any resolver configured via
+  // withAddressResolver(...) -- confirmed by decompiling the actual jar (this is a deviation
+  // from the upstream datastax/simulacron behavior, where withAddressResolver called after
+  // withMultipleNodesPerIp is honored). Since the starting port can't be changed through the
+  // public API, the only effective mitigation available here is to retry the whole
+  // register-and-bind attempt with a fresh Server/resolver and a short backoff, which gives the
+  // OS a chance to move its ephemeral allocator away from port 49152 before the next attempt.
+  private static final int MAX_BIND_ATTEMPTS = 5;
+
   private static Server peersV2Server;
   private static BoundCluster cluster;
 
   @BeforeClass
-  public static void setup() {
-    peersV2Server = Server.builder().withMultipleNodesPerIp(true).build();
-    cluster = peersV2Server.register(ClusterSpec.builder().withNodes(2));
+  public static void setup() throws InterruptedException {
+    RuntimeException lastFailure = null;
+    for (int attempt = 1; attempt <= MAX_BIND_ATTEMPTS; attempt++) {
+      Server server = Server.builder().withMultipleNodesPerIp(true).build();
+      try {
+        cluster = server.register(ClusterSpec.builder().withNodes(2));
+        peersV2Server = server;
+        return;
+      } catch (RuntimeException e) {
+        // Always tear down the server we just created, whether or not we're going to retry, to
+        // avoid leaking its event loop threads.
+        server.close();
+        boolean isBindRace = e.getCause() instanceof BindNodeException;
+        if (!isBindRace || attempt == MAX_BIND_ATTEMPTS) {
+          throw e;
+        }
+        lastFailure = e;
+        Thread.sleep(200L * attempt);
+      }
+    }
+    // Unreachable, but keeps the compiler happy about a definite return/throw.
+    throw lastFailure;
   }
 
   @AfterClass


### PR DESCRIPTION
## Summary

`PeersV2NodeRefreshIT` occasionally fails in CI with:

```
java.lang.RuntimeException: com.datastax.oss.simulacron.server.BindNodeException: Failed to bind NodeSpec{id=0, name='node1', address=null} to /127.0.0.1:49152
	at com.datastax.oss.simulacron.server.CompletableFutures.getUninterruptibly(CompletableFutures.java:41)
	at com.datastax.oss.simulacron.server.Server.register(Server.java:189)
	at com.datastax.oss.driver.core.PeersV2NodeRefreshIT.setup(PeersV2NodeRefreshIT.java:45)
```

Re-running the same job with no code changes typically makes it pass, which is what makes this "just flaky" -- but it's a real, reproducible race, not test infra noise.

## Root cause

`PeersV2NodeRefreshIT.setup()` builds its own Simulacron `Server` with `withMultipleNodesPerIp(true)` (needed because it emulates several nodes sharing one IP, since `system.peers_v2` distinguishes nodes by `(peer, peer_port)`). That mode binds its nodes starting at `127.0.0.1:49152` -- which is the *first port* of the OS ephemeral/dynamic port range on both Linux (`ip_local_port_range`, typically `32768-60999`) and macOS (`49152-65535`).

That same range is what the kernel hands out as the **source port for any outbound client socket** on the machine -- including other integration tests' driver connections running concurrently in the same build (this module's failsafe config runs up to 16 test classes in parallel via `<parallel>classes</parallel>` / `<threadCountClasses>16</threadCountClasses>`, generating a lot of concurrent socket churn). When the kernel happens to hand out `49152` as an ephemeral source port at the exact moment this test tries to `bind()` it as a *listening* socket, the bind fails and Simulacron surfaces it as `BindNodeException`.

This was reported before in #951 and closed as "fixed by #942 and #943" -- but those two PRs only address the unrelated `TupleTest.simpleWriteReadTest` flake that was bundled into the same issue. Neither touches Simulacron or port binding. The Simulacron race was never actually fixed; the issue was closed because a CI re-run happened to pass, exactly like the case that prompted this PR.

I also tried to just fix the starting port directly (`Server.builder().withMultipleNodesPerIp(true).withAddressResolver(new NodePerPortResolver(nonEphemeralPort))`), which is what the public Simulacron API is meant to support. It doesn't work with the version this repo depends on: decompiling the vendored `com.scylladb.oss.simulacron:simulacron-native-server:0.14.0.0` jar shows that `Server.Builder#build()` unconditionally replaces the configured resolver with a **brand new** `new NodePerPortResolver()` (hardcoded to port 49152) whenever `multipleNodesPerIp` is `true`, discarding anything passed to `withAddressResolver(...)`. Upstream `datastax/simulacron` does not do this (there, `withMultipleNodesPerIp(true)` only sets the resolver as a default that a later `withAddressResolver(...)` call can still override) -- this looks like a behavior regression specific to the Scylla fork of Simulacron used here. I didn't have access to that fork's source repo to fix it there, so this PR works around it at the call site instead.

## Fix

Since the starting port can't be changed through the public API in the vendored Simulacron version, `setup()` now retries the whole register-and-bind attempt (fresh `Server` + fresh resolver state each time) with a short backoff (up to 5 attempts, 200ms * attempt) whenever the failure is specifically a `BindNodeException`. This gives the OS's ephemeral port allocator a chance to move off of `49152` before the next attempt. Any other exception is rethrown immediately (no masking of real failures), and each failed `Server` is closed before retrying so its event-loop threads aren't leaked.

## Testing

Since this doesn't require CCM/a real cluster (just Simulacron), I verified it directly against the compiled test class:

- **Reproduced the exact reported failure**: with the original code, holding `127.0.0.1:49152` with an external socket for 1s causes `setup()` to fail immediately with the identical `BindNodeException` stack trace shown above.
- **Confirmed the fix recovers**: with the patched code, the same external hold on port 49152 causes `setup()` to retry and pass once the port frees up (observed total time increases proportionally to the hold duration, confirming the retry path is actually exercised, not just a lucky timing coincidence).
- **Confirmed no regression in the normal case**: with no port collision, the patched test passes in the same time as before (single attempt, no retry overhead).
- Ran `PeersV2NodeRefreshIT` directly via `org.junit.runner.JUnitCore` (JDK 17) after `mvn -pl integration-tests -am install -DskipTests`, both with and without the artificial port collision.
- Ran the project's `fmt-maven-plugin` formatter on the changed file; no reformatting was needed.

**Not verified**: the full CCM/Docker-backed integration suite (`make test-integration-scylla`) -- this sandbox doesn't have Docker/CCM available. The change is scoped to a single test's `@BeforeClass`, doesn't touch any shared test-infra code, and compiles cleanly with the rest of the `integration-tests` module, so this risk is low, but a full CI run is the last remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)