### PR TITLE
fix: stop depending on synthesized bind-variable names (DRIVER-903)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -73,13 +74,17 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
     this.byName = new HashMap<String, int[]>(defs.length);
 
     for (int i = 0; i < defs.length; i++) {
+      // Fold with ROOT rather than the default locale: a name such as IN(v) would be indexed as
+      // ın(v) in a Turkish JVM, and no lookup for in(v) could then find it. Computed once so that
+      // the two puts below cannot drift apart.
+      String key = defs[i].name.toLowerCase(Locale.ROOT);
       // Be optimistic, 99% of the time, previous will be null.
-      int[] previous = this.byName.put(defs[i].name.toLowerCase(), new int[] {i});
+      int[] previous = this.byName.put(key, new int[] {i});
       if (previous != null) {
         int[] indexes = new int[previous.length + 1];
         System.arraycopy(previous, 0, indexes, 0, previous.length);
         indexes[indexes.length - 1] = i;
-        this.byName.put(defs[i].name.toLowerCase(), indexes);
+        this.byName.put(key, indexes);
       }
     }
   }
@@ -247,7 +252,7 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
       caseSensitive = true;
     }
 
-    int[] indexes = byName.get(name.toLowerCase());
+    int[] indexes = byName.get(name.toLowerCase(Locale.ROOT));
     if (!caseSensitive || indexes == null) return indexes;
 
     // First, optimistic and assume all are matching
@@ -255,6 +260,9 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
     for (int i = 0; i < indexes.length; i++) if (name.equals(byIdx[indexes[i]].name)) nbMatch++;
 
     if (nbMatch == indexes.length) return indexes;
+    // Report the name as absent rather than returning an empty array: callers distinguish "no such
+    // name" by a null return, and an unquoted name that matches nothing already lands there.
+    if (nbMatch == 0) return null;
 
     int[] result = new int[nbMatch];
     int j = 0;

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -115,7 +116,10 @@ public abstract class DataType {
 
     @Override
     public String toString() {
-      return super.toString().toLowerCase();
+      // ROOT, not the default locale: this string is spliced into generated CQL by the schema
+      // builder, so in a Turkish JVM INT would render as ınt, spelled with a dotless i, and the
+      // server would reject the statement as a syntax error.
+      return super.toString().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -295,7 +296,9 @@ public class Metadata {
       return id;
     }
     if (isAlphanumeric) {
-      return id.toLowerCase();
+      // ROOT, not the default locale: this branch is only reached for ASCII-alphanumeric ids, which
+      // is exactly where a Turkish JVM would fold I to the dotless ı and make the id unmatchable.
+      return id.toLowerCase(Locale.ROOT);
     }
 
     // Check if it's enclosed in quotes. If it is, remove them and unescape internal double quotes

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -55,7 +56,10 @@ abstract class Utils {
     // Shouldn't really happen for this method, but no reason to fail here
     if (id == null) return null;
 
-    if (alphanumeric.matcher(id).matches()) return id.toLowerCase();
+    // ROOT, not the default locale: only ASCII-alphanumeric ids reach this branch, which is exactly
+    // where a Turkish JVM would fold I to the dotless ı. maybeAddRoutingKey compares the result
+    // against the partition key name, so a locale-dependent fold silently drops the routing key.
+    if (alphanumeric.matcher(id).matches()) return id.toLowerCase(Locale.ROOT);
 
     // Check if it's enclosed in quotes. If it is, remove them and unescape internal double quotes
     if (!id.isEmpty() && id.charAt(0) == '"' && id.charAt(id.length() - 1) == '"')

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
@@ -15,8 +15,12 @@
  */
 package com.datastax.driver.core;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import java.util.Locale;
 import org.testng.annotations.Test;
 
 public class ColumnDefinitionsTest {
@@ -77,5 +81,91 @@ public class ColumnDefinitionsTest {
             CodecRegistry.DEFAULT_INSTANCE);
 
     assertTrue(defs.getType("column").equals(DataType.text()));
+  }
+
+  /**
+   * A hand-built lookup fixture, not a real server response: a server names the marker of an IN
+   * relation after the operator and the column, as in "SELECT * FROM t WHERE pk = ? AND v IN ?",
+   * and the definition is repeated here so that a name matching more than one variable is
+   * reachable. (No server would send both at once — CQL rejects a column restricted by two IN
+   * relations.)
+   *
+   * <p>The synthesized spelling differs between ScyllaDB release lines rather than along a single
+   * version sequence: 2024.1 emits in(v), 2026.1.8 emits IN(v), and the lowercase spelling is
+   * restored in 2026.1.12 and 2026.2.6 (CUSTOMER-583 / SCYLLADB-3454). An application must
+   * therefore not depend on either spelling.
+   */
+  private static ColumnDefinitions synthesizedInMarkerDefinitions() {
+    return new ColumnDefinitions(
+        new ColumnDefinitions.Definition[] {
+          new ColumnDefinitions.Definition("ks", "cf", "pk", DataType.cint()),
+          new ColumnDefinitions.Definition("ks", "cf", "IN(v)", DataType.list(DataType.cint())),
+          new ColumnDefinitions.Definition("ks", "cf", "IN(v)", DataType.list(DataType.cint())),
+        },
+        CodecRegistry.DEFAULT_INSTANCE);
+  }
+
+  @Test(groups = "unit")
+  public void synthesizedMarkerNameIsMatchedWhateverTheServerSpelling() {
+    ColumnDefinitions defs = synthesizedInMarkerDefinitions();
+
+    assertTrue(defs.contains("IN(v)"));
+    assertTrue(defs.contains("in(v)"));
+    assertTrue(defs.contains("In(V)"));
+    assertEquals(defs.getFirstIdx("in(v)"), 1);
+  }
+
+  /**
+   * The letter that flipped in CUSTOMER-583 is {@code I}, and lowercasing it in the Turkish locale
+   * yields a dotless {@code ı}. Matching must not depend on the JVM's default locale, or a Turkish
+   * deployment would fail to resolve the name that works everywhere else.
+   */
+  @Test(groups = "unit")
+  public void synthesizedMarkerNameIsMatchedInAnyDefaultLocale() {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+      ColumnDefinitions defs = synthesizedInMarkerDefinitions();
+      // Probe both spellings. The definitions are built inside the locale override, so the
+      // lowercase probe covers the fold applied while indexing; but "in(v)" is left alone by every
+      // locale, so it would not catch a lookup that stopped pinning ROOT — the uppercase probe
+      // covers that side.
+      assertTrue(defs.contains("in(v)"));
+      assertEquals(defs.getFirstIdx("in(v)"), 1);
+      assertTrue(defs.contains("IN(v)"));
+      assertEquals(defs.getFirstIdx("IN(v)"), 1);
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /** A named setter writes every matching variable, so repeating a column makes names ambiguous. */
+  @Test(groups = "unit")
+  public void synthesizedMarkerNameMatchesEveryOccurrence() {
+    assertEquals(synthesizedInMarkerDefinitions().getAllIdx("in(v)"), new int[] {1, 2});
+  }
+
+  /**
+   * Double-quoting opts into exact matching, which the synthesized spelling can then break. A name
+   * that survives the case-insensitive lookup but no exact comparison must be reported absent, the
+   * same way an unquoted name that matches nothing is — otherwise contains() claims the name is
+   * there, getIndexOf() throws instead of returning -1, and a setter silently leaves the variable
+   * unset, which the server then rejects with "Unexpected unset value for bind variable N".
+   */
+  @Test(groups = "unit")
+  public void doubleQuotedSynthesizedMarkerNameOfDifferentCaseIsNotMatched() {
+    ColumnDefinitions defs = synthesizedInMarkerDefinitions();
+
+    assertTrue(defs.contains("\"IN(v)\""));
+    assertEquals(defs.getIndexOf("\"IN(v)\""), 1);
+
+    assertFalse(defs.contains("\"in(v)\""));
+    assertEquals(defs.getIndexOf("\"in(v)\""), -1);
+    try {
+      defs.getType("\"in(v)\"");
+      fail("expected an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -405,6 +406,30 @@ public class DataTypeTest {
       fail("This should not have worked");
     } catch (InvalidTypeException e) {
       /* That's what we want */
+    }
+  }
+
+  /**
+   * {@code Name.toString()} lower-cases the enum constant, and the schema builder splices the
+   * result straight into generated CQL — {@code Alter.type()} and {@code NativeColumnType}, so
+   * every ALTER TYPE, ADD column and CREATE TABLE column. Every type name holding an I is affected,
+   * so an unpinned fold makes a Turkish JVM emit {@code TYPE ınt} and the server reject the
+   * statement.
+   */
+  @Test(groups = "unit")
+  public void toStringIsIndependentOfDefaultLocaleTest() {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+      assertThat(DataType.cint().toString()).isEqualTo("int");
+      assertThat(DataType.ascii().toString()).isEqualTo("ascii");
+      assertThat(DataType.timestamp().toString()).isEqualTo("timestamp");
+      // The collection name and its arguments each fold separately.
+      assertThat(DataType.list(DataType.cint()).toString()).isEqualTo("list<int>");
+      assertThat(DataType.map(DataType.text(), DataType.timestamp()).toString())
+          .isEqualTo("map<text, timestamp>");
+    } finally {
+      Locale.setDefault(def);
     }
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -20,6 +20,7 @@ import static com.datastax.driver.core.CreateCCM.TestMode.PER_METHOD;
 import static com.datastax.driver.core.TestUtils.waitForUp;
 
 import com.google.common.collect.Maps;
+import java.util.Locale;
 import java.util.Map;
 import org.testng.annotations.Test;
 
@@ -125,6 +126,23 @@ public class MetadataTest extends CCMTestsSupport {
     assertThat(Metadata.handleId("FooBar1")).isEqualTo("foobar1");
     assertThat(Metadata.handleId("Foo_Bar_1")).isEqualTo("foo_bar_1");
     assertThat(Metadata.handleId("foo_bar_1")).isEqualTo("foo_bar_1");
+  }
+
+  /**
+   * Identifier folding must not depend on the JVM's default locale: in a Turkish locale {@code I}
+   * lowercases to the dotless {@code ı}, so {@code getTable("ID_TABLE")} would look up {@code
+   * ıd_table} and never match the {@code id_table} the server reported.
+   */
+  @Test(groups = "unit")
+  public void handleId_should_lowercase_unquoted_alphanumeric_identifiers_in_any_default_locale() {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+      assertThat(Metadata.handleId("ID_TABLE")).isEqualTo("id_table");
+      assertThat(Metadata.handleId("FooBar1")).isEqualTo("foobar1");
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -42,11 +42,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -864,5 +867,67 @@ public class PreparedStatementTest extends CCMTestsSupport {
     bound = prepared.bind(1);
 
     assertThat(bound.isIdempotent()).isTrue();
+  }
+
+  /**
+   * The driver resolves prepared-statement variable names locally, so it must not depend on the
+   * name the server synthesizes for an anonymous marker. That name differs between ScyllaDB release
+   * lines rather than along a single version sequence: 2024.1 spells the marker of an IN relation
+   * {@code in(k)}, 2026.1.8 spells it {@code IN(k)}, and the lowercase spelling is restored in
+   * 2026.1.12 and 2026.2.6 (CUSTOMER-583 / SCYLLADB-3454); Apache Cassandra spells it {@code
+   * in(k)}. This test therefore reads the name back from the metadata instead of hardcoding a
+   * spelling, and asserts that both cases of it resolve to the same variable — as well as the
+   * positional binding that the manual recommends applications use instead.
+   */
+  @Test(groups = "short")
+  public void should_bind_anonymous_in_marker_by_position_and_by_either_synthesized_case() {
+    for (int i = 1; i <= 3; i++) {
+      session()
+          .execute(String.format("INSERT INTO %s (k, i) VALUES ('key%d', %d)", SIMPLE_TABLE, i, i));
+    }
+
+    PreparedStatement ps = session().prepare("SELECT i FROM " + SIMPLE_TABLE + " WHERE k IN ?");
+
+    ColumnDefinitions variables = ps.getVariables();
+    assertThat(variables.size()).isEqualTo(1);
+    String synthesized = variables.getName(0);
+
+    // Skip rather than fail if the server ever names the marker plainly "k": everything below still
+    // passes then, but it no longer covers the synthesized-name mechanism at all, and the spelling
+    // is precisely what this test refuses to treat as a contract.
+    if ("k".equals(synthesized) || !synthesized.contains("(")) {
+      throw new SkipException(
+          "server named the marker " + synthesized + ", so there is no synthesized name to cover");
+    }
+
+    // Whatever the server sent, the case of the name must not decide whether it resolves.
+    assertThat(variables.getIndexOf(synthesized)).isEqualTo(0);
+    assertThat(variables.getIndexOf(synthesized.toLowerCase(Locale.ROOT))).isEqualTo(0);
+    assertThat(variables.getIndexOf(synthesized.toUpperCase(Locale.ROOT))).isEqualTo(0);
+
+    List<String> keys = Arrays.asList("key1", "key3");
+
+    // What applications should do: fill anonymous markers by position.
+    assertThat(selectedInts(ps.bind().setList(0, keys))).containsOnly(1, 3);
+
+    // What CUSTOMER-583 did. It works here because the name setters ignore case, but the manual
+    // steers applications away from it: the spelling is not part of any contract.
+    for (String name :
+        Arrays.asList(
+            synthesized,
+            synthesized.toLowerCase(Locale.ROOT),
+            synthesized.toUpperCase(Locale.ROOT))) {
+      assertThat(selectedInts(ps.bind().setList(name, keys)))
+          .as("bound by name " + name)
+          .containsOnly(1, 3);
+    }
+  }
+
+  private List<Integer> selectedInts(BoundStatement bound) {
+    List<Integer> values = new ArrayList<Integer>();
+    for (Row row : session().execute(bound)) {
+      values.add(row.getInt("i"));
+    }
+    return values;
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -1635,6 +1636,27 @@ public class QueryBuilderTest {
         .isEqualTo("SELECT * FROM foo ALLOW FILTERING;");
     assertThat(select().all().from("foo").where(eq("x", 42)).allowFiltering().toString())
         .isEqualTo("SELECT * FROM foo WHERE x=42 ALLOW FILTERING;");
+  }
+
+  /**
+   * The query builder folds a column name before comparing it with the partition key name, in
+   * {@code BuiltStatement.maybeAddRoutingKey}. That fold must not depend on the JVM's default
+   * locale: in a Turkish locale {@code I} lowercases to the dotless {@code ı}, so a clause on
+   * {@code ID} would stop matching a partition key called {@code id} and the statement would
+   * silently lose its routing key, costing it token-aware routing.
+   *
+   * @test_category queries:builder
+   */
+  @Test(groups = "unit")
+  public void should_handle_id_in_any_default_locale() {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+      assertThat(Utils.handleId("ID")).isEqualTo("id");
+      assertThat(Utils.handleId("Id_1")).isEqualTo("id_1");
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   /** @test_category queries:builder */

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -78,17 +79,23 @@ class AnnotationParser {
               entityClass));
     }
 
+    // ROOT, not the default locale: this name is handed to the schema metadata lookup below, so
+    // @Table(name = "ID_TABLE") would fold to a dotless id_table in a Turkish JVM and never match.
     String tableName =
-        table.caseSensitiveTable() ? Metadata.quote(table.name()) : table.name().toLowerCase();
+        table.caseSensitiveTable()
+            ? Metadata.quote(table.name())
+            : table.name().toLowerCase(Locale.ROOT);
 
+    // ROOT, not the default locale: a Turkish JVM upper-cases "serial" to SERIAL with a dotted I,
+    // which is not a ConsistencyLevel constant, so valueOf would throw.
     ConsistencyLevel writeConsistency =
         table.writeConsistency().isEmpty()
             ? null
-            : ConsistencyLevel.valueOf(table.writeConsistency().toUpperCase());
+            : ConsistencyLevel.valueOf(table.writeConsistency().toUpperCase(Locale.ROOT));
     ConsistencyLevel readConsistency =
         table.readConsistency().isEmpty()
             ? null
-            : ConsistencyLevel.valueOf(table.readConsistency().toUpperCase());
+            : ConsistencyLevel.valueOf(table.readConsistency().toUpperCase(Locale.ROOT));
 
     KeyspaceMetadata keyspaceMetadata =
         mappingManager.getSession().getCluster().getMetadata().getKeyspace(keyspaceName);
@@ -178,8 +185,10 @@ class AnnotationParser {
               udtClass));
     }
 
+    // ROOT, not the default locale: keyspaceMetadata.getUserType below matches on this name, so
+    // @UDT(name = "ID_TYPE") would fold to a dotless id_type in a Turkish JVM and never resolve.
     String udtName =
-        udt.caseSensitiveType() ? Metadata.quote(udt.name()) : udt.name().toLowerCase();
+        udt.caseSensitiveType() ? Metadata.quote(udt.name()) : udt.name().toLowerCase(Locale.ROOT);
 
     KeyspaceMetadata keyspaceMetadata =
         mappingManager.getSession().getCluster().getMetadata().getKeyspace(keyspaceName);
@@ -277,7 +286,7 @@ class AnnotationParser {
         cl =
             options.consistency().isEmpty()
                 ? null
-                : ConsistencyLevel.valueOf(options.consistency().toUpperCase());
+                : ConsistencyLevel.valueOf(options.consistency().toUpperCase(Locale.ROOT));
         fetchSize = options.fetchSize();
         tracing = options.tracing();
         if (options.idempotent().length > 1) {

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultPropertyMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultPropertyMapper.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -391,8 +392,11 @@ public class DefaultPropertyMapper implements PropertyMapper {
     if (setter == null) {
       // JAVA-984: look for a "relaxed" setter, ie. a setter whose return type may be anything
       String propertyName = property.getName();
+      // ROOT, not the default locale: this builds a Java method name, and in a Turkish JVM a
+      // property named id would yield setId spelled with a dotted I. getMethod would then miss and
+      // the NoSuchMethodException below is swallowed, so the setter would go silently undetected.
       String setterName =
-          "set" + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+          "set" + propertyName.substring(0, 1).toUpperCase(Locale.ROOT) + propertyName.substring(1);
       try {
         Method m = mappedClass.getMethod(setterName, property.getPropertyType());
         if (!Modifier.isStatic(m.getModifiers())) setter = m;
@@ -447,7 +451,10 @@ public class DefaultPropertyMapper implements PropertyMapper {
       if (!udtMappedField.name().isEmpty()) mappedName = udtMappedField.name();
     }
     if (mappedName != null) {
-      return caseSensitive ? Metadata.quote(mappedName) : mappedName.toLowerCase();
+      // ROOT, not the default locale: this is the column name the mapper reads and writes, so
+      // @Column(name = "ID") would fold to a dotless id in a Turkish JVM and the property would
+      // silently fail to bind against a column the server calls id.
+      return caseSensitive ? Metadata.quote(mappedName) : mappedName.toLowerCase(Locale.ROOT);
     }
 
     // Otherwise delegate to the naming strategy

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConventions.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConventions.java
@@ -19,9 +19,17 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
-/** Implementations of industry common naming conventions. */
+/**
+ * Implementations of industry common naming conventions.
+ *
+ * <p>Every case fold below pins {@link Locale#ROOT} rather than using the JVM default locale. The
+ * result becomes a CQL identifier (see {@code DefaultPropertyMapper#getMappedName}), so under a
+ * Turkish default locale a property named {@code id} would map to a column spelled with a dotless
+ * {@code ı} or a dotted {@code İ}, and every lookup for {@code id} would miss.
+ */
 public class NamingConventions {
 
   /**
@@ -142,13 +150,13 @@ public class NamingConventions {
         Word word = input.get(i);
         String value;
         if (i == 0) {
-          value = word.getValue().toLowerCase();
+          value = word.getValue().toLowerCase(Locale.ROOT);
         } else if (upperCaseAbbreviations && word.isAbbreviation()) {
-          value = word.getValue().toUpperCase();
+          value = word.getValue().toUpperCase(Locale.ROOT);
         } else {
           value =
-              word.getValue().substring(0, 1).toUpperCase()
-                  + word.getValue().substring(1).toLowerCase();
+              word.getValue().substring(0, 1).toUpperCase(Locale.ROOT)
+                  + word.getValue().substring(1).toLowerCase(Locale.ROOT);
         }
         builder.append(value);
       }
@@ -213,11 +221,11 @@ public class NamingConventions {
       for (Word word : input) {
         String value;
         if (upperCaseAbbreviations && word.isAbbreviation()) {
-          value = word.getValue().toUpperCase();
+          value = word.getValue().toUpperCase(Locale.ROOT);
         } else {
           value =
-              word.getValue().substring(0, 1).toUpperCase()
-                  + word.getValue().substring(1).toLowerCase();
+              word.getValue().substring(0, 1).toUpperCase(Locale.ROOT)
+                  + word.getValue().substring(1).toLowerCase(Locale.ROOT);
         }
         builder.append(value);
       }
@@ -303,7 +311,7 @@ public class NamingConventions {
         builder.append(input.get(i).getValue());
       }
       String result = builder.toString();
-      return isUpperCase ? result.toUpperCase() : result.toLowerCase();
+      return isUpperCase ? result.toUpperCase(Locale.ROOT) : result.toLowerCase(Locale.ROOT);
     }
   }
 
@@ -329,7 +337,7 @@ public class NamingConventions {
         builder.append(word.getValue());
       }
       String result = builder.toString();
-      return isUpperCase ? result.toUpperCase() : result.toLowerCase();
+      return isUpperCase ? result.toUpperCase(Locale.ROOT) : result.toLowerCase(Locale.ROOT);
     }
   }
 }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationParserTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationParserTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.annotations.Accessor;
+import com.datastax.driver.mapping.annotations.Query;
+import com.datastax.driver.mapping.annotations.QueryParameters;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.UDT;
+import java.util.Locale;
+import org.testng.annotations.Test;
+
+/**
+ * {@link AnnotationParser} folds case in five places: the {@code @Table} and {@code @UDT} names it
+ * hands to the schema metadata, and the three consistency levels it parses out of annotation
+ * strings. None of them may depend on the JVM's default locale. In a Turkish locale an upper-case I
+ * folds to a dotless {@code ı} and a lower-case i to a dotted {@code İ}, so {@code @Table(name =
+ * "ID_TABLE")} would look up a table no server ever reported, and {@code writeConsistency =
+ * "serial"} would fail {@code ConsistencyLevel.valueOf}.
+ *
+ * <p>Every one of those folds happens before the parser needs anything a live cluster provides, so
+ * the tests drive it with a mocked manager and read the folded name back out of the failure the
+ * metadata lookup raises. That keeps them in the unit group: the CCM mapper tests that do reach
+ * this class never change the default locale, which is what left these five call sites uncovered.
+ */
+public class AnnotationParserTest {
+
+  private static final Locale TURKISH = new Locale("tr", "TR");
+  private static final String KEYSPACE = "ks";
+
+  @Table(name = "ID_TABLE")
+  static class IdTable {}
+
+  @Table(name = "t", writeConsistency = "serial", readConsistency = "serial")
+  static class SerialConsistencyTable {}
+
+  @UDT(name = "ID_TYPE")
+  static class IdType {}
+
+  @Accessor
+  interface SerialConsistencyAccessor {
+    @Query("SELECT * FROM ks.t")
+    @QueryParameters(consistency = "serial")
+    ResultSet all();
+  }
+
+  /**
+   * The {@code @Table} name is folded and then handed straight to {@code getTable}, so an unpinned
+   * fold makes the mapper query a dotless table name that cannot match the schema.
+   */
+  @Test(groups = "unit")
+  public void should_fold_table_name_in_any_default_locale() {
+    MappingManager manager = managerReporting(mock(KeyspaceMetadata.class));
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      assertThat(parseEntityFailure(IdTable.class, manager))
+          .contains("Table or materialized view id_table does not exist");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /**
+   * Both {@code @Table} consistency levels are upper-cased before {@code valueOf}. Unpinned, a
+   * Turkish locale turns "serial" into SERİAL, which is not a constant — reaching the table lookup
+   * at all is what proves the two parses survived.
+   */
+  @Test(groups = "unit")
+  public void should_parse_table_consistency_levels_in_any_default_locale() {
+    MappingManager manager = managerReporting(mock(KeyspaceMetadata.class));
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      assertThat(parseEntityFailure(SerialConsistencyTable.class, manager))
+          .contains("Table or materialized view t does not exist");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /** The {@code @UDT} name reaches {@code getUserType} the same way the table name does. */
+  @Test(groups = "unit")
+  public void should_fold_udt_name_in_any_default_locale() {
+    MappingManager manager = managerReporting(mock(KeyspaceMetadata.class));
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      assertThat(parseUdtFailure(IdType.class, manager))
+          .contains("User type id_type does not exist");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /**
+   * The accessor's {@code @QueryParameters} consistency is a third, independent {@code valueOf}
+   * call site, and it is reached without touching the session at all.
+   */
+  @Test(groups = "unit")
+  public void should_parse_accessor_consistency_in_any_default_locale() {
+    MappingManager manager = mock(MappingManager.class);
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      assertThat(AnnotationParser.parseAccessor(SerialConsistencyAccessor.class, manager))
+          .isNotNull();
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /** A manager whose cluster reports the given keyspace, and no tables or user types in it. */
+  private static MappingManager managerReporting(KeyspaceMetadata keyspace) {
+    Metadata metadata = mock(Metadata.class);
+    when(metadata.getKeyspace(KEYSPACE)).thenReturn(keyspace);
+    Cluster cluster = mock(Cluster.class);
+    when(cluster.getMetadata()).thenReturn(metadata);
+    Session session = mock(Session.class);
+    when(session.getCluster()).thenReturn(cluster);
+    MappingManager manager = mock(MappingManager.class);
+    when(manager.getSession()).thenReturn(session);
+    return manager;
+  }
+
+  /** Returns the message of the failure the missing table raises, which carries the folded name. */
+  private static String parseEntityFailure(Class<?> entityClass, MappingManager manager) {
+    try {
+      AnnotationParser.parseEntity(entityClass, KEYSPACE, manager);
+      throw new AssertionError("expected the parse to fail on the missing table");
+    } catch (IllegalArgumentException e) {
+      return e.getMessage();
+    }
+  }
+
+  /** As above, for the missing user type. */
+  private static String parseUdtFailure(Class<?> udtClass, MappingManager manager) {
+    try {
+      AnnotationParser.parseUDT(udtClass, KEYSPACE, manager);
+      throw new AssertionError("expected the parse to fail on the missing user type");
+    } catch (IllegalArgumentException e) {
+      return e.getMessage();
+    }
+  }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/DefaultPropertyMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/DefaultPropertyMapperTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.mapping.annotations.Column;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * The mapper derives both CQL column names and Java accessor names by folding case, so neither may
+ * depend on the JVM's default locale. In a Turkish locale an upper-case I folds to a dotless {@code
+ * ı} and a lower-case i to a dotted {@code İ}, which is exactly the letter that broke CUSTOMER-583
+ * one layer up in {@code ColumnDefinitions}.
+ */
+public class DefaultPropertyMapperTest {
+
+  private static final Locale TURKISH = new Locale("tr", "TR");
+
+  static class Entity {
+    @Column(name = "ID")
+    int id;
+  }
+
+  /** A property whose setter is "relaxed" (it returns the entity rather than void). */
+  static class RelaxedSetterEntity {
+    private int id;
+
+    public int getId() {
+      return id;
+    }
+
+    public RelaxedSetterEntity setId(int id) {
+      this.id = id;
+      return this;
+    }
+  }
+
+  /**
+   * An explicit, non-case-sensitive {@code @Column(name = "ID")} is folded to the name the server
+   * holds. Under a Turkish default locale an unpinned fold yields a dotless id, and every read and
+   * write of the property would then miss the column.
+   */
+  @Test(groups = "unit")
+  public void should_fold_explicit_column_name_in_any_default_locale() throws Exception {
+    Field field = Entity.class.getDeclaredField("id");
+    Map<Class<? extends Annotation>, Annotation> annotations =
+        Collections.<Class<? extends Annotation>, Annotation>singletonMap(
+            Column.class, field.getAnnotation(Column.class));
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      String mappedName =
+          new DefaultPropertyMapper().inferMappedName(Entity.class, "id", annotations);
+      assertThat(mappedName).isEqualTo("id");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  /**
+   * The relaxed-setter lookup builds a Java method name from the property name. Under a Turkish
+   * default locale an unpinned fold looks for setId spelled with a dotted I; the resulting
+   * NoSuchMethodException is swallowed, so the setter would go silently undetected rather than
+   * failing loudly.
+   */
+  @Test(groups = "unit")
+  public void should_locate_relaxed_setter_in_any_default_locale() throws Exception {
+    PropertyDescriptor descriptor = null;
+    for (PropertyDescriptor candidate :
+        Introspector.getBeanInfo(RelaxedSetterEntity.class).getPropertyDescriptors()) {
+      if ("id".equals(candidate.getName())) {
+        descriptor = candidate;
+      }
+    }
+    assertThat(descriptor).isNotNull();
+    // Precondition for the branch under test: a relaxed setter is not a bean write method.
+    assertThat(descriptor.getWriteMethod()).isNull();
+
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(TURKISH);
+      Method setter =
+          new DefaultPropertyMapper().locateSetter(RelaxedSetterEntity.class, descriptor);
+      assertThat(setter).isNotNull();
+      assertThat(setter.getName()).isEqualTo("setId");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/NamingConventionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/NamingConventionsTest.java
@@ -17,6 +17,7 @@ package com.datastax.driver.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Locale;
 import org.testng.annotations.Test;
 
 /** Test for JAVA-1316 - test combinations of different {@link NamingConventions} implementation. */
@@ -481,6 +482,61 @@ public class NamingConventionsTest {
         new NamingConventions.LowerCamelCase(true),
         "MyXMLParser",
         "myXMLParser");
+  }
+
+  /**
+   * The conventions fold case to produce a CQL identifier, so the JVM's default locale must not
+   * decide the result. In a Turkish locale a lower-case i upper-cases to a dotted I and an
+   * upper-case I lower-cases to a dotless one, so every name below would come out unmatchable
+   * against the column the server actually holds. Each input deliberately carries an i.
+   *
+   * <p>The abbreviation branches of the two camel-case joins are pinned as well, but no input
+   * discriminates them, which was checked by reverting each one in turn: the splitter only marks an
+   * all-upper-case word as an abbreviation, so the fold applied there is a no-op in any locale.
+   */
+  @Test(groups = "unit")
+  public void should_apply_conventions_in_any_default_locale() {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+      test(NamingConventions.LOWER_CAMEL_CASE, NamingConventions.UPPER_CASE, "id", "ID");
+      test(NamingConventions.LOWER_CAMEL_CASE, NamingConventions.LOWER_CASE, "ID", "id");
+      test(
+          NamingConventions.LOWER_CAMEL_CASE,
+          NamingConventions.UPPER_SNAKE_CASE,
+          "minPrice",
+          "MIN_PRICE");
+      test(
+          NamingConventions.LOWER_CAMEL_CASE,
+          NamingConventions.UPPER_CAMEL_CASE,
+          "itemId",
+          "ItemId");
+      // The three below drive the lower-camel join, one per fold it applies: the first word, the
+      // leading letter of a later word, and that word's tail.
+      test(
+          NamingConventions.UPPER_SNAKE_CASE,
+          NamingConventions.LOWER_CAMEL_CASE,
+          "ITEM_ID",
+          "itemId");
+      test(
+          NamingConventions.LOWER_SNAKE_CASE,
+          NamingConventions.LOWER_CAMEL_CASE,
+          "item_id",
+          "itemId");
+      test(
+          NamingConventions.UPPER_SNAKE_CASE,
+          NamingConventions.LOWER_CAMEL_CASE,
+          "ITEM_XID",
+          "itemXid");
+      // Drives the upper-camel join's tail fold, which the itemId case above leaves untouched.
+      test(
+          NamingConventions.UPPER_SNAKE_CASE,
+          NamingConventions.UPPER_CAMEL_CASE,
+          "ITEM_XID",
+          "ItemXid");
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   private void test(

--- a/manual/statements/prepared/README.md
+++ b/manual/statements/prepared/README.md
@@ -96,18 +96,54 @@ BoundStatement bound = ps2.bind()
   .setString("d", "LCD screen");
 ```
 
-You can use named setters even if the query uses anonymous parameters;
-Cassandra will name the parameters after the column they apply to:
+#### Anonymous markers and server-synthesized names
+
+Named setters also work when the query uses anonymous `?` markers: the
+server synthesizes a name for each one, usually after the column it
+applies to.
 
 ```java
+// Works, but relies on a name the server made up:
 BoundStatement bound = ps1.bind()
   .setString("sku", "324378")
   .setString("description", "LCD screen");
 ```
 
-This can be ambiguous if the query uses the same column multiple times,
-for example: `select * from sales where sku = ? and date > ? and date <
-?`. In these situations, use positional setters or named parameters.
+**Avoid relying on this.** Synthesized names are not part of any API
+contract, and their spelling differs between server release lines, not
+just between successive versions. For
+`SELECT ... WHERE application_id IN ?`, ScyllaDB's 2024.1 releases name
+the marker `in(application_id)`, while 2026.1.8 names it
+`IN(application_id)`; the lowercase spelling is restored in 2026.1.12 and
+2026.2.6. Apache Cassandra names it `in(application_id)`. The regression
+was reported against a driver that matches these names exactly: the
+hardcoded lowercase spelling stopped resolving, the variable went out
+unset, and the server rejected the request with `Unexpected unset value
+for bind variable 1`. This driver is more forgiving, but only on some of
+its lookup paths — see below. The spelling can even vary from node to
+node during a rolling upgrade, because the driver keeps whichever
+metadata the node that served the `PREPARE` sent back.
+
+The rule of thumb: **bind `?` markers positionally, and use named setters
+only for markers you named yourself with `:name`.**
+
+If you address a synthesized name anyway, note that the name setters match
+case-insensitively, so `setList("in(pk)", ...)` still finds a variable the
+server called `IN(pk)` — a change of case alone is survivable. Double
+quoting the name, as in `setList("\"in(pk)\"", ...)`, opts into an exact
+match instead: it does not resolve, and the setter throws
+`IllegalArgumentException` rather than quietly leaving the variable unset.
+Note that the exception comes from the setter — querying the metadata
+directly, with `ps.getVariables().getIndexOf(...)`, reports the same miss
+as `-1`.
+
+Finally, a named setter writes **every** variable that matches the name,
+not just the first one. Names are therefore ambiguous whenever a query
+mentions the same column more than once, for example: `select * from sales
+where sku = ? and date > ? and date < ?`, where both range markers are
+named `date`. Use positional setters in those cases.
+
+#### Unset values
 
 For native protocol V3 or below, all variables must be bound.  With native
 protocol V4 or above, variables can be left unset, in which case they
@@ -127,6 +163,8 @@ bound.unset(1);
 // Named setter:
 bound.unset("description");
 ```
+
+#### Reading and reusing bound statements
 
 A bound statement also has getters to retrieve the values. Note that
 this has a small performance overhead since values are stored in their

--- a/manual/statements/simple/README.md
+++ b/manual/statements/simple/README.md
@@ -64,6 +64,14 @@ Instead of sending a raw query string, you can use bind markers and provide valu
         ImmutableMap.<String, Object>of("n", paramName));
     ```
 
+Unlike a prepared statement, a simple statement is not parsed by the driver, so named values are
+resolved by the **coordinator**, not locally: the driver sends the names along with the query and
+does not check them against anything. Name them yourself with `:name` markers, and fill anonymous
+`?` markers positionally. Leaning on the names the server synthesizes for anonymous markers (see
+[prepared statements](../prepared/#anonymous-markers-and-server-synthesized-names)) is an even worse
+idea here than with a prepared statement: nothing on the client side can tell you the name is wrong,
+so the query simply fails on the coordinator.
+
 This syntax has a few advantages:
 
 * if the values already come from some other part of your code, it looks cleaner than doing the concatenation yourself;

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -12,17 +12,37 @@ versions of the Java driver.
 
     * `contains()` returns `false` where it returned `true`;
     * `getIndexOf()` returns `-1` where it threw `ArrayIndexOutOfBoundsException`;
-    * the name-based getters and setters on `Row` and `BoundStatement` throw
-        `IllegalArgumentException`, where a getter threw `ArrayIndexOutOfBoundsException` and a setter
-        silently did nothing — leaving the variable unset, which the server then rejected with
-        `Unexpected unset value for bind variable N`;
+    * the name-based getters on `Row`, and the getters and setters on `BoundStatement`, throw
+        `IllegalArgumentException`. A getter previously threw `ArrayIndexOutOfBoundsException`; a
+        setter silently did nothing — leaving the variable unset, which the server then rejected
+        with `Unexpected unset value for bind variable N`;
     * the object mapper leaves the corresponding property unset instead of failing with
         `ArrayIndexOutOfBoundsException`. Watch for this if you use `@Column(caseSensitive = true)`
-        with a name whose case does not match the column: the mismatch is now silent, in the same way
-        it already was for an unquoted name that matches nothing.
+        with a name whose case does not match the column: the mismatch is now silent, in the
+        same way it already was for an unquoted name that matches nothing.
 
     An unquoted name that matches no definition already behaved this way; this change makes the
     quoted form consistent with it.
+
+2.  Identifier case folding now pins `Locale.ROOT`, so it no longer depends on the JVM's default
+    locale. This affects bind-variable names, schema metadata lookups such as
+    `KeyspaceMetadata.getTable()`, the column names the query builder matches against a table's
+    partition key, and the type names the schema builder renders. Previously an unquoted ASCII
+    identifier containing an uppercase `I` was folded with the default locale, so on a
+    Turkish-locale JVM it became the dotless `ı`: `getTable("ID_TABLE")` looked up `ıd_table` and
+    found nothing; a query-builder clause on `ID` no longer matched a partition key named `id`,
+    silently costing the statement its routing key and with it token-aware routing; and
+    `DataType.cint()` rendered itself as `ınt`, so a `CREATE TABLE`, `CREATE TYPE`,
+    `ALTER ... TYPE` or `ADD` clause naming a type that contains an `I` produced CQL the server
+    rejected outright.
+
+    The object mapper is affected in the same way: an explicit `@Table`, `@UDT`, `@Column` or
+    `@Field` name, and every name the built-in `NamingConventions` derive, are now folded with
+    `Locale.ROOT`. A custom `NamingStrategy` is unaffected: the mapper never folded its result, it
+    only passes it to `Metadata.quoteIfNecessary()`, so choosing a locale remains the strategy's own
+    business. Two further consequences were mapper-specific — `@Table(writeConsistency = "serial")`
+    failed to parse as a `ConsistencyLevel`, and the relaxed-setter lookup searched for a method
+    name spelled with a dotted `I` and silently found none, leaving the property without a setter.
 
 ### 3.6.0
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -3,6 +3,27 @@
 The purpose of this guide is to detail changes made by successive
 versions of the Java driver.
 
+### 3.11.5.19
+
+1.  `ColumnDefinitions` now reports a double-quoted name whose case matches no definition as absent,
+    rather than as present with no indexes. This affects only a name that survives the
+    case-insensitive lookup but matches nothing exactly, for example `"\"in(v)\""` against a
+    definition named `IN(v)`. For such a name:
+
+    * `contains()` returns `false` where it returned `true`;
+    * `getIndexOf()` returns `-1` where it threw `ArrayIndexOutOfBoundsException`;
+    * the name-based getters and setters on `Row` and `BoundStatement` throw
+        `IllegalArgumentException`, where a getter threw `ArrayIndexOutOfBoundsException` and a setter
+        silently did nothing — leaving the variable unset, which the server then rejected with
+        `Unexpected unset value for bind variable N`;
+    * the object mapper leaves the corresponding property unset instead of failing with
+        `ArrayIndexOutOfBoundsException`. Watch for this if you use `@Column(caseSensitive = true)`
+        with a name whose case does not match the column: the mismatch is now silent, in the same way
+        it already was for an unquoted name that matches nothing.
+
+    An unquoted name that matches no definition already behaved this way; this change makes the
+    quoted form consistent with it.
+
 ### 3.6.0
 
 1.  `ConsistencyLevel.LOCAL_SERIAL.isDCLocal()` now returns true. In driver


### PR DESCRIPTION
Driver-side follow-up to [CUSTOMER-583](https://scylladb.atlassian.net/browse/CUSTOMER-583) /
[SCYLLADB-3454](https://scylladb.atlassian.net/browse/SCYLLADB-3454), tracked as
[DRIVER-903](https://scylladb.atlassian.net/browse/DRIVER-903) under epic DRIVER-898. The 4.x
counterpart is #1020.

ScyllaDB synthesizes a name for each anonymous `?` marker, and that spelling is not a contract: it
varies by release line rather than along one version sequence — 2024.1 emits `in(col)`, 2026.1.8
emits `IN(col)`, and SCYLLADB-3454 restores `in(col)` in 2026.1.12 / 2026.2.6. CUSTOMER-583 broke on
upgrade because the application bound by that name. Writing the coverage turned up two real defects
on the 3.x lookup path that 4.x lacks.

* `ColumnDefinitions` folded case with the JVM's default locale on both the index and the lookup
  side, so a Turkish-locale JVM indexed `IN(v)` as `ın(v)` and never resolved `in(v)`.
* A case-sensitive miss returned an empty array where callers read `null` as "no such name" — so
  `contains()` reported the name present, `getIndexOf()` threw instead of returning `-1`, and a name
  setter silently left the variable unset, which the server rejects with `Unexpected unset value for
  bind variable N`.
* The same unpinned fold ran through `Metadata.handleId`, `querybuilder.Utils.handleId`,
  `DataType.Name.toString()` — which the schema builder splices into generated CQL — and throughout
  `driver-mapping`. All now pin `Locale.ROOT`.
* The manual now recommends positional binding for `?` and named binding only for explicit `:name`,
  and `upgrade_guide/README.md` records the observable change.

Verified with `mvn test -pl driver-core,driver-mapping -Dtest.groups=unit` — 715 and 68 green — and
every new unit test confirmed red with its own fix reverted, one site at a time. The CCM test ran
against Scylla 2024.1.21, which sends `in(k)`, and 2026.1.10, which sends `IN(k)`. The 3.x docs
build needs poetry, which isn't available locally; left to CI.

Open question: this is the fork's first entry in `upgrade_guide/README.md` — say the word if
fork-version sections don't belong there.

Refs: https://scylladb.atlassian.net/browse/DRIVER-903

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CUSTOMER-583]: https://scylladb.atlassian.net/browse/CUSTOMER-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCYLLADB-3454]: https://scylladb.atlassian.net/browse/SCYLLADB-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DRIVER-903]: https://scylladb.atlassian.net/browse/DRIVER-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ