### PR TITLE
fix: return "Session is closed" instead of NoNodeAvailableException during shutdown

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousRequestHandlerBase.java
@@ -25,7 +25,6 @@ import com.datastax.dse.driver.internal.core.DseProtocolFeature;
 import com.datastax.dse.driver.internal.core.cql.DseConversions;
 import com.datastax.dse.protocol.internal.request.Revise;
 import com.datastax.dse.protocol.internal.response.result.DseRowsMetadata;
-import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException.NodeDiagnostics;
@@ -366,7 +365,7 @@ public abstract class ContinuousRequestHandlerBase<StatementT extends Request, R
       // We've reached the end of the query plan without finding any node to write to; abort the
       // continuous paging session.
       if (activeExecutionsCount.decrementAndGet() == 0) {
-        abortGlobalRequestOrChosenCallback(AllNodesFailedException.fromErrors(errors));
+        abortGlobalRequestOrChosenCallback(DefaultSession.queryPlanExhaustedError(session, errors));
       }
     } else if (!chosenCallback.isDone()) {
       boolean writeSubmitted = false;

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -25,7 +25,6 @@ import com.datastax.dse.driver.api.core.graph.GraphStatement;
 import com.datastax.dse.driver.api.core.metrics.DseNodeMetric;
 import com.datastax.dse.driver.api.core.metrics.DseSessionMetric;
 import com.datastax.dse.driver.internal.core.graph.binary.GraphBinaryModule;
-import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException.NodeDiagnostics;
@@ -297,7 +296,7 @@ public class GraphRequestHandler implements Throttled {
         // We're the last execution so fail the result
         setFinalError(
             statement,
-            AllNodesFailedException.fromErrors(this.errors),
+            DefaultSession.queryPlanExhaustedError(session, this.errors),
             null,
             NO_SUCCESSFUL_EXECUTION);
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -19,7 +19,6 @@ package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.api.core.DriverTimeoutException.UNAVAILABLE;
 
-import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException.NodeDiagnostics;
@@ -227,7 +226,7 @@ public class CqlPrepareHandler implements Throttled {
       }
     }
     if (channel == null) {
-      setFinalError(AllNodesFailedException.fromErrors(this.errors));
+      setFinalError(DefaultSession.queryPlanExhaustedError(session, this.errors));
     } else {
       boolean writeSubmitted = false;
       try {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -25,7 +25,6 @@ package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.api.core.DriverTimeoutException.UNAVAILABLE;
 
-import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
@@ -406,7 +405,8 @@ public class CqlRequestHandler implements Throttled {
       // We've reached the end of the query plan without finding any node to write to
       if (!result.isDone() && activeExecutionsCount.decrementAndGet() == 0) {
         // We're the last execution so fail the result
-        setFinalError(statement, AllNodesFailedException.fromErrors(this.errors), null, -1);
+        setFinalError(
+            statement, DefaultSession.queryPlanExhaustedError(session, this.errors), null, -1);
       }
     } else {
       boolean writeSubmitted = false;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -23,6 +23,7 @@
  */
 package com.datastax.oss.driver.internal.core.session;
 
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -99,6 +100,19 @@ public class DefaultSession implements CqlSession {
     return new DefaultSession(context, contactPoints).init(keyspace);
   }
 
+  /**
+   * Returns {@code IllegalStateException("Session is closed")} for an empty plan during shutdown
+   * (scylladb/java-driver#846); otherwise delegates to {@link AllNodesFailedException#fromErrors}.
+   */
+  @NonNull
+  public static Throwable queryPlanExhaustedError(
+      @NonNull DefaultSession session, @Nullable List<Map.Entry<Node, Throwable>> errors) {
+    if ((errors == null || errors.isEmpty()) && (session.isClosing() || session.isClosed())) {
+      return new IllegalStateException("Session is closed");
+    }
+    return AllNodesFailedException.fromErrors(errors);
+  }
+
   private final InternalDriverContext context;
   private final EventExecutor adminExecutor;
   private final String logPrefix;
@@ -107,6 +121,10 @@ public class DefaultSession implements CqlSession {
   private final RequestProcessorRegistry processorRegistry;
   private final PoolManager poolManager;
   private final SessionMetricUpdater metricUpdater;
+
+  // Flipped before scheduling close on adminExecutor so handlers see shutdown before closeFuture
+  // completes.
+  private volatile boolean closing;
 
   private DefaultSession(InternalDriverContext context, Set<EndPoint> contactPoints) {
     int instanceCount = INSTANCE_COUNT.incrementAndGet();
@@ -296,13 +314,20 @@ public class DefaultSession implements CqlSession {
   @NonNull
   @Override
   public CompletionStage<Void> closeAsync() {
+    closing = true;
     return closeSafely(singleThreaded::close);
   }
 
   @NonNull
   @Override
   public CompletionStage<Void> forceCloseAsync() {
+    closing = true;
     return closeSafely(singleThreaded::forceClose);
+  }
+
+  /** Whether close has been initiated; flips before {@link #isClosed()} does. */
+  public boolean isClosing() {
+    return closing;
   }
 
   private CompletionStage<Void> closeSafely(Runnable action) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
@@ -119,6 +119,55 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
     }
   }
 
+  // scylladb/java-driver#846: post-shutdown branch (closeFuture already completed).
+  @Test
+  public void should_fail_with_session_closed_when_query_plan_empty_and_session_is_closed() {
+    // no withResponse/withEmptyPool calls => empty query plan
+    try (RequestHandlerTestHarness harness = RequestHandlerTestHarness.builder().build()) {
+      when(harness.getSession().isClosed()).thenReturn(true);
+
+      CompletionStage<AsyncResultSet> resultSetFuture =
+          new CqlRequestHandler(
+                  UNDEFINED_IDEMPOTENCE_STATEMENT,
+                  harness.getSession(),
+                  harness.getContext(),
+                  "test")
+              .handle();
+
+      assertThatStage(resultSetFuture)
+          .isFailed(
+              error -> {
+                assertThat(error).isInstanceOf(IllegalStateException.class);
+                assertThat(error).hasMessage("Session is closed");
+              });
+    }
+  }
+
+  // scylladb/java-driver#846: shutdown-in-progress branch (closeAsync called, closeFuture not yet
+  // done).
+  @Test
+  public void should_fail_with_session_closed_when_query_plan_empty_and_session_is_closing() {
+    // no withResponse/withEmptyPool calls => empty query plan
+    try (RequestHandlerTestHarness harness = RequestHandlerTestHarness.builder().build()) {
+      when(harness.getSession().isClosing()).thenReturn(true);
+
+      CompletionStage<AsyncResultSet> resultSetFuture =
+          new CqlRequestHandler(
+                  UNDEFINED_IDEMPOTENCE_STATEMENT,
+                  harness.getSession(),
+                  harness.getContext(),
+                  "test")
+              .handle();
+
+      assertThatStage(resultSetFuture)
+          .isFailed(
+              error -> {
+                assertThat(error).isInstanceOf(IllegalStateException.class);
+                assertThat(error).hasMessage("Session is closed");
+              });
+    }
+  }
+
   @Test
   public void should_fail_if_nodes_unavailable() {
     RequestHandlerTestHarness.Builder harnessBuilder = RequestHandlerTestHarness.builder();


### PR DESCRIPTION
## Motivation

`CqlSession` request handlers currently surface `NoNodeAvailableException` when a request happens to be in flight while the session is shutting down. This is misleading — no node was even attempted; the load balancing policy simply returned an empty query plan because it had already transitioned to `CLOSING`. See #846 for the report and the exact stack trace.

The existing `DefaultSession.execute()` and the request handler's timer path already surface `IllegalStateException("Session is closed")` for this situation. The shutdown-race path should match.

## Modifications

- Added `DefaultSession.queryPlanExhaustedError(session, errors)` — when the errors list is empty and the session is either closing or already closed, returns `IllegalStateException("Session is closed")`; otherwise delegates to `AllNodesFailedException.fromErrors(errors)` as before.
- Added `DefaultSession.isClosing()`, backed by a `volatile boolean closing` flipped synchronously at the top of `closeAsync()` / `forceCloseAsync()`. `isClosed()` alone would miss the window between close initiation and `closeFuture` completion — exactly when the LB policy starts returning empty plans.
- Routed `CqlRequestHandler`, `CqlPrepareHandler`, `GraphRequestHandler`, and `ContinuousRequestHandlerBase` through the helper at their "query plan exhausted" branches.
- Two new unit tests in `CqlRequestHandlerTest` pin down each branch of the helper: `isClosed()` (post-shutdown-complete) and `isClosing()` (shutdown-in-progress).

## Result

- Requests that reach a handler with an empty query plan during shutdown now fail with `IllegalStateException("Session is closed")`, matching the error already produced elsewhere for the same condition.
- Genuine "no node available" outages on a healthy session remain unchanged (non-empty per-node errors still produce `AllNodesFailedException`).
- No public API changes on `CqlSession` / `AsyncAutoCloseable`; `isClosing()` is a new method on the internal `DefaultSession` only.

Fixes #846