### PR TITLE
build: bump simulacron to 0.14.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <felix.version>7.0.5</felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>
     <pax-url.version>2.6.17</pax-url.version>
-    <simulacron.version>0.14.0.0</simulacron.version>
+    <simulacron.version>0.14.0.1</simulacron.version>
     <jsr353-api.version>1.1.4</jsr353-api.version>
     <jersey.version>2.47</jersey.version>
     <hk2.version>2.6.1</hk2.version>


### PR DESCRIPTION
`<simulacron.version>` is still `0.14.0.0`, so the `Server.Builder` fix this repo
asked for in #1017 has never reached us. That fix shipped as
scylladb/java-simulacron#11 and was released in `0.14.0.1` on 2026-08-27, with a
commitment on #1017 to open this bump once it was released.

- Bump `<simulacron.version>` from `0.14.0.0` to `0.14.0.1`
- Picks up `withMultipleNodesPerIp(true)` no longer silently overriding an
  explicit `withAddressResolver(...)` (scylladb/java-simulacron#11)
- Picks up releasing only resolver-generated node addresses
  (scylladb/java-simulacron#14)
- `4.x` is untouched — it tracks upstream on `com.datastax.oss.simulacron:0.8.9`

**This does not by itself fix the `PeersV2NodeRefreshIT` flake from #1017.** That
test calls `Server.builder().withMultipleNodesPerIp(true).build()` with no
explicit resolver, so it still binds from `127.0.0.1:49152` and still races the OS
ephemeral port range. The bump is what makes the fix *possible*; passing a
collision-safe resolver after `withMultipleNodesPerIp(true)` is the follow-up.

Verified: `make compile-all` and `make test-unit` green, and all 38
simulacron-only IT classes run green — 257 tests, 0 failures, 5 pre-existing
skips — including `PeersV2NodeRefreshIT`. Not covered: `make
test-integration-scylla` / `test-integration-cassandra`, which need CCM and a live
server, so CCM-backed ITs are only exercised by CI here.

Refs: https://github.com/scylladb/java-simulacron/releases/tag/0.14.0.1
