### PR TITLE
CI: change base branch to `rs`

### DIFF
--- a/.github/workflows/tests@v1.yml
+++ b/.github/workflows/tests@v1.yml
@@ -2,7 +2,7 @@ name: 'Tests (Driver 4.x)'
 
 on:
   push:
-    branches: [ scylla-4.*x ]
+    branches: [ rs ]
     paths-ignore:
       - "docs/**"
       - .github/workflows/docs-pages.yml
@@ -14,7 +14,7 @@ on:
       - ".snyk"
       - ".gitignore"
   pull_request:
-    branches: [ scylla-4.*x ]
+    branches: [ rs ]
     paths-ignore:
       - "docs/**"
       - .github/workflows/docs-pages.yml


### PR DESCRIPTION
This is going to be the main branch for development of ScyllaDB Java RS Driver. CI must run on pushes and PRs to `rs`.