### PR TITLE
build: resolve four-component Revapi baselines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ export PATH := $(MAKEFILE_PATH)/bin:$(PATH)
 	$(MVNCMD) install -pl guava-shaded
 
 .install-all-modules:
-	$(MVNCMD) install -DskipTests -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
+	$(MVNCMD) install -DskipTests -Drevapi.skip=true -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true
 
 .download-test-dependencies:
 	$(MVNCMD) test -Dtest=TestThatDoesNotExists -Dfmt.skip=true -Dclirr.skip=true -Danimal.sniffer.skip=true || true

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -15,6 +15,1968 @@
     },
     "ignore": [
       {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.DeserializationConfig",
+        "new": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.DeserializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.DeserializationConfig com.fasterxml.jackson.databind.DeserializationConfig::withoutFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.DeserializationConfig",
+        "new": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.DeserializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.Module.SetupContext::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "new": "method void com.fasterxml.jackson.databind.Module.SetupContext::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.Module.SetupContext::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void com.fasterxml.jackson.databind.Module.SetupContext::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.databind.MapperFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::disable(com.fasterxml.jackson.databind.MapperFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.databind.MapperFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectMapper com.fasterxml.jackson.databind.ObjectMapper::enable(com.fasterxml.jackson.databind.MapperFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.ObjectMapper::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void com.fasterxml.jackson.databind.ObjectMapper::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectReader com.fasterxml.jackson.databind.ObjectReader::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method com.fasterxml.jackson.databind.ObjectWriter com.fasterxml.jackson.databind.ObjectWriter::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.SerializationConfig",
+        "new": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.SerializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "new": "method com.fasterxml.jackson.databind.SerializationConfig com.fasterxml.jackson.databind.SerializationConfig::withoutFeatures(com.fasterxml.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.SerializationConfig",
+        "new": "method T com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG extends com.fasterxml.jackson.databind.cfg.ConfigFeature, T extends com.fasterxml.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(com.fasterxml.jackson.databind.cfg.DatatypeFeature[]) @ com.fasterxml.jackson.databind.SerializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "new": "method void com.fasterxml.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(com.fasterxml.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void com.fasterxml.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void com.fasterxml.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, com.fasterxml.jackson.databind.JavaType[])",
+        "new": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, com.fasterxml.jackson.databind.JavaType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, java.lang.Class<?>[])",
+        "new": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, com.fasterxml.jackson.databind.JavaType[])",
+        "new": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, com.fasterxml.jackson.databind.JavaType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, java.lang.Class<?>[])",
+        "new": "method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(T[])",
+        "new": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(T[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(java.util.Map.Entry<T, org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>>[])",
+        "new": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(java.util.Map.Entry<T, org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig",
+        "new": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig",
+        "new": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.DeserializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.Module.SetupContext::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.Module.SetupContext::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.Module.SetupContext::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.Module.SetupContext::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.databind.MapperFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::disable(org.apache.tinkerpop.shaded.jackson.databind.MapperFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.databind.MapperFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::enable(org.apache.tinkerpop.shaded.jackson.databind.MapperFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonParser.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.DeserializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectReader org.apache.tinkerpop.shaded.jackson.databind.ObjectReader::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter org.apache.tinkerpop.shaded.jackson.databind.ObjectWriter::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig",
+        "new": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.FormatFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.core.JsonGenerator.Feature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.SerializationFeature[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig",
+        "new": "method T org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG extends org.apache.tinkerpop.shaded.jackson.databind.cfg.ConfigFeature, T extends org.apache.tinkerpop.shaded.jackson.databind.cfg.MapperConfigBase<CFG, T>>::withoutFeatures(org.apache.tinkerpop.shaded.jackson.databind.cfg.DatatypeFeature[]) @ org.apache.tinkerpop.shaded.jackson.databind.SerializationConfig",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.shaded.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "new": "method void org.apache.tinkerpop.shaded.jackson.databind.jsontype.SubtypeResolver::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule::registerSubtypes(java.lang.Class<?>[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule::registerSubtypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule org.apache.tinkerpop.shaded.jackson.databind.module.SimpleModule::registerSubtypes(org.apache.tinkerpop.shaded.jackson.databind.jsontype.NamedType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, java.lang.Class<?>[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, org.apache.tinkerpop.shaded.jackson.databind.JavaType[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametricType(java.lang.Class<?>, org.apache.tinkerpop.shaded.jackson.databind.JavaType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, java.lang.Class<?>[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, org.apache.tinkerpop.shaded.jackson.databind.JavaType[])",
+        "new": "method org.apache.tinkerpop.shaded.jackson.databind.JavaType org.apache.tinkerpop.shaded.jackson.databind.type.TypeFactory::constructParametrizedType(java.lang.Class<?>, java.lang.Class<?>, org.apache.tinkerpop.shaded.jackson.databind.JavaType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<?> reactor.blockhound.shaded.net.bytebuddy.ByteBuddy::makeInterface(java.lang.reflect.Type[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<?> reactor.blockhound.shaded.net.bytebuddy.ByteBuddy::makeInterface(java.lang.reflect.Type[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<?> reactor.blockhound.shaded.net.bytebuddy.ByteBuddy::makeInterface(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<?> reactor.blockhound.shaded.net.bytebuddy.ByteBuddy::makeInterface(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Identified.Extendable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Ignored",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy.ForClassLoader::withFallbackTo(reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy.ForClassLoader::withFallbackTo(reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy.ForClassLoader::withFallbackTo(reactor.blockhound.shaded.net.bytebuddy.dynamic.ClassFileLocator[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy.ForClassLoader::withFallbackTo(reactor.blockhound.shaded.net.bytebuddy.dynamic.ClassFileLocator[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithImplicitDiscoveryStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithResubmissionSpecification",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable.WithoutBatchStrategy",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[]) @ reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.RedefinitionListenable",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice::include(java.lang.ClassLoader[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice::include(java.lang.ClassLoader[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice::include(reactor.blockhound.shaded.net.bytebuddy.dynamic.ClassFileLocator[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice::include(reactor.blockhound.shaded.net.bytebuddy.dynamic.ClassFileLocator[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeFromAndTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder reactor.blockhound.shaded.net.bytebuddy.agent.builder.AgentBuilder::assureReadEdgeTo(java.lang.instrument.Instrumentation, reactor.blockhound.shaded.net.bytebuddy.utility.JavaModule[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, boolean[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, boolean[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, byte[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, byte[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, char[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, char[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, double[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, double[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, float[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, float[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, int[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, int[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, java.lang.String[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, long[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, long[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, short[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineArray(java.lang.String, short[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineEnumerationArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription, java.lang.String[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineEnumerationArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription, java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineEnumerationArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription, reactor.blockhound.shaded.net.bytebuddy.description.enumeration.EnumerationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineEnumerationArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription, reactor.blockhound.shaded.net.bytebuddy.description.enumeration.EnumerationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineTypeArray(java.lang.String, java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineTypeArray(java.lang.String, java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineTypeArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription.Builder::defineTypeArray(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForField> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForField[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForField> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForField[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForMethod> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForMethod[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForMethod> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForMethod[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForParameter> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForParameter[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForParameter> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForParameter[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForType> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForType[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForType> reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.Resolver<T extends reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor>::of(reactor.blockhound.shaded.net.bytebuddy.description.modifier.ModifierContributor.ForType[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::annotate(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::annotate(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::annotate(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::annotate(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardLowerBound(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardLowerBound(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardLowerBound(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardLowerBound(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardUpperBound(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardUpperBound(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardUpperBound(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::asWildcardUpperBound(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::build(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::build(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::build(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::build(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::unboundWildcard(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::unboundWildcard(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::unboundWildcard(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription.Generic.Builder::unboundWildcard(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional.Valuable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Valuable<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Valuable<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Valuable<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition<S>::annotateField(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.FieldDefinition.Valuable<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition.ForType<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.InnerTypeDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>::annotateParameter(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>::annotateParameter(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>::annotateParameter(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>::annotateParameter(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>::withParameters(java.lang.reflect.Type[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>::withParameters(java.lang.reflect.Type[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>::withParameters(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<V>::withParameters(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>::annotateParameter(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>::annotateParameter(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>::annotateParameter(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>::annotateParameter(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ExceptionDefinition<U>::throwing(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ParameterDefinition.Simple.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ReceiverTypeDefinition<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>::annotateTypeVariable(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>::annotateTypeVariable(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>::annotateTypeVariable(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>::annotateTypeVariable(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<U> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition<U>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.TypeVariableDefinition.Annotatable<V>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateMethod(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>::annotateParameter(int, reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<U>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition.Optional<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.RecordComponentDefinition<S>::annotateRecordComponent(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>::annotateTypeVariable(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>::annotateTypeVariable(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>::annotateTypeVariable(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>::annotateTypeVariable(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[]) @ reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<S>",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(java.lang.annotation.Annotation[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::annotateType(reactor.blockhound.shaded.net.bytebuddy.description.annotation.AnnotationDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::declaredTypes(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(java.lang.reflect.Type[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.MethodDefinition.ImplementationDefinition.Optional<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::implement(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::nestMembers(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(java.lang.Class<?>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::permittedSubclass(reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDescription[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, java.lang.reflect.Type[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "new": "method reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder.TypeVariableDefinition<T> reactor.blockhound.shaded.net.bytebuddy.dynamic.DynamicType.Builder<T>::typeVariable(java.lang.String, reactor.blockhound.shaded.net.bytebuddy.description.type.TypeDefinition[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
         "code": "java.method.removed",
         "old": "method com.datastax.oss.driver.api.core.cql.BatchStatementBuilder com.datastax.oss.driver.api.core.cql.BatchStatementBuilder::withKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
         "justification": "JAVA-2164: Rename statement builder methods to setXxx"
@@ -7399,10 +9361,6 @@
       },
       {
         "code": "java.class.externalClassExposedInAPI",
-        "justification": "CASSJAVA-102: Migrate revapi config into dedicated config files, ported from pom.xml"
-      },
-      {
-        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
         "justification": "CASSJAVA-102: Migrate revapi config into dedicated config files, ported from pom.xml"
       },
       {

--- a/pom.xml
+++ b/pom.xml
@@ -662,9 +662,10 @@
           <version>0.15.1</version>
           <configuration>
             <outputNonIdentifyingDifferenceInfo>false</outputNonIdentifyingDifferenceInfo>
-            <versionFormat>\d+\.\d+\.\d+</versionFormat>
+            <versionFormat>\d+(?:\.\d+)+</versionFormat>
+            <failOnUnresolvedArtifacts>true</failOnUnresolvedArtifacts>
+            <failOnUnresolvedDependencies>true</failOnUnresolvedDependencies>
             <oldArtifacts>
-              <!-- The previous release used DataStax groupId, remove this after the next release -->
               <artifact>${project.groupId}:${project.artifactId}:RELEASE</artifact>
             </oldArtifacts>
             <analysisConfiguration>

--- a/query-builder/revapi.json
+++ b/query-builder/revapi.json
@@ -17,6 +17,102 @@
     },
     "ignore": [
       {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumnEnd com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumn::dropColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumnEnd com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumn::dropColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumnEnd com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumn::dropColumns(java.lang.String[])",
+        "new": "method com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumnEnd com.datastax.dse.driver.api.querybuilder.schema.AlterDseTableDropColumn::dropColumns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereColumns(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereColumns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereToken(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereToken(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereToken(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<SelfT> com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT extends com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause<SelfT>>::whereToken(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::columns(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.MultiColumnRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::columns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::token(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::token(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::token(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.relation.TokenRelationBuilder<com.datastax.oss.driver.api.querybuilder.relation.Relation> com.datastax.oss.driver.api.querybuilder.relation.Relation::token(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumnEnd com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumn::dropColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumnEnd com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumn::dropColumns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumnEnd com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumn::dropColumns(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumnEnd com.datastax.oss.driver.api.querybuilder.schema.AlterTableDropColumn::dropColumns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelectionWithColumns com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelection::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelectionWithColumns com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelection::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelectionWithColumns com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelection::columns(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelectionWithColumns com.datastax.oss.driver.api.querybuilder.schema.CreateMaterializedViewSelection::columns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.select.Select com.datastax.oss.driver.api.querybuilder.select.OngoingSelection::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.select.Select com.datastax.oss.driver.api.querybuilder.select.OngoingSelection::columns(com.datastax.oss.driver.api.core.CqlIdentifier[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method com.datastax.oss.driver.api.querybuilder.select.Select com.datastax.oss.driver.api.querybuilder.select.OngoingSelection::columns(java.lang.String[])",
+        "new": "method com.datastax.oss.driver.api.querybuilder.select.Select com.datastax.oss.driver.api.querybuilder.select.OngoingSelection::columns(java.lang.String[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
         "code": "java.method.addedToInterface",
         "new": "method <T> com.datastax.oss.driver.api.querybuilder.insert.JsonInsert com.datastax.oss.driver.api.querybuilder.insert.InsertInto::json(T, com.datastax.oss.driver.api.core.type.codec.TypeCodec<T>)",
         "justification": "JAVA-2182: Add insertInto().json() variant that takes an object in QueryBuilder"
@@ -2780,10 +2876,6 @@
         "code": "java.method.addedToInterface",
         "new": "method com.datastax.oss.driver.api.querybuilder.select.Select com.datastax.oss.driver.api.querybuilder.select.Select::orderByAnnOf(com.datastax.oss.driver.api.core.CqlIdentifier, com.datastax.oss.driver.api.core.data.CqlVector<?>)",
         "justification": "JAVA-3118: Add support for vector data type in Schema Builder, QueryBuilder"
-      },
-      {
-        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
-        "justification": "CASSJAVA-102: Suppress newly-supported varargs check"
       }
     ]
   }

--- a/test-infra/revapi.json
+++ b/test-infra/revapi.json
@@ -18,6 +18,66 @@
     },
     "ignore": [
       {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method <T> org.assertj.core.api.Condition<T> org.assertj.core.api.Assertions::allOf(org.assertj.core.api.Condition<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "new": "method <T> org.assertj.core.api.Condition<T> org.assertj.core.api.Assertions::allOf(org.assertj.core.api.Condition<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method <T> org.assertj.core.api.ThrowingConsumer<T> org.assertj.core.api.Assertions::allOf(org.assertj.core.api.ThrowingConsumer<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "new": "method <T> org.assertj.core.api.ThrowingConsumer<T> org.assertj.core.api.Assertions::allOf(org.assertj.core.api.ThrowingConsumer<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method <T> org.assertj.core.api.Condition<T> org.assertj.core.api.Assertions::anyOf(org.assertj.core.api.Condition<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "new": "method <T> org.assertj.core.api.Condition<T> org.assertj.core.api.Assertions::anyOf(org.assertj.core.api.Condition<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method <T> org.assertj.core.api.ThrowingConsumer<T> org.assertj.core.api.Assertions::anyOf(org.assertj.core.api.ThrowingConsumer<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "new": "method <T> org.assertj.core.api.ThrowingConsumer<T> org.assertj.core.api.Assertions::anyOf(org.assertj.core.api.ThrowingConsumer<? super T>[]) @ com.datastax.oss.driver.assertions.Assertions",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfies(java.util.function.Consumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "new": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfies(java.util.function.Consumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfies(org.assertj.core.api.ThrowingConsumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "new": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfies(org.assertj.core.api.ThrowingConsumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfiesAnyOf(java.util.function.Consumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "new": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfiesAnyOf(java.util.function.Consumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfiesAnyOf(org.assertj.core.api.ThrowingConsumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "new": "method SELF org.assertj.core.api.AbstractAssert<SELF extends org.assertj.core.api.AbstractAssert<SELF, ACTUAL>, ACTUAL>::satisfiesAnyOf(org.assertj.core.api.ThrowingConsumer<? super ACTUAL>[]) @ com.datastax.oss.driver.assertions.NodeMetadataAssert",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(T[])",
+        "new": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(T[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
+        "code": "java.method.varargOverloadsOnlyDifferInVarargParameter",
+        "old": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(java.util.Map.Entry<T, org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>>[])",
+        "new": "method void org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>::<init>(java.util.Map.Entry<T, org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree<T>>[])",
+        "justification": "Legacy ambiguity retained for compatibility; new vararg overloads are still checked."
+      },
+      {
         "code": "java.method.returnTypeTypeParametersChanged",
         "old": "method java.util.Set<java.net.InetSocketAddress> com.datastax.oss.driver.api.testinfra.CassandraResourceRule::getContactPoints()",
         "new": "method java.util.Set<com.datastax.oss.driver.api.core.metadata.EndPoint> com.datastax.oss.driver.api.testinfra.CassandraResourceRule::getContactPoints()",


### PR DESCRIPTION
Revapi previously filtered releases with a three-component version pattern. Scylla Java Driver publishes four-component versions, so `RELEASE` resolved no old artifact and compatibility checks could pass without a baseline.

This change:
- accepts release versions with two or more numeric components;
- makes unresolved baseline artifacts and dependencies fatal;
- replaces blanket `java.method.varargOverloadsOnlyDifferInVarargParameter` ignores with `reportUnchanged: false`, so unchanged legacy findings are suppressed while new or changed overloads remain enforced;
- skips redundant Revapi execution during integration-test prerequisite installs.

Verification:
- Revapi resolves published `4.19.2.1` artifacts for core, query builder, mapper runtime, and test infra;
- all four focused Revapi checks pass;
- parent and BOM POM modules remain no-op Revapi checks.

Closes #1052