### PR TITLE
ci: build docs javadoc with JDK 8 again

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -36,10 +36,21 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Set up JDK 11
+      # Pinned to JDK 8 on purpose, and not the same choice as docs-pr.yml.
+      # That workflow runs `make -C docs test`, which builds only the current
+      # branch -- scylla-4.x, which is post "build: drop Java 8 support" and so
+      # is fine on 11. This one runs `make -C docs multiversion`, which builds
+      # EVERY version in conf.py's BRANCHES, LATEST_VERSION included. All of
+      # them are frozen release branches that predate that commit and compile
+      # via error-prone's javac 9 shim; it cannot read JDK 11 class files and
+      # fails with "class file has wrong version 55.0, should be 53.0".
+      # scylla-4.x is not itself in BRANCHES, so nothing built here needs a
+      # newer JDK. Do not raise this without building the newest branch in
+      # BRANCHES on the new JDK first.
+      - name: Set up JDK 8.0
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
 
       - name: Install uv
@@ -53,11 +64,6 @@ jobs:
 
       - name: Build docs
         run: make -C docs multiversion
-        env:
-          # Old release branches (e.g. scylla-4.15.0.x) have javadoc
-          # comments that only pass doclint on JDK 8.
-          # Don't fail their multiversion javadoc builds on JDK 11.
-          MAVEN_OPTS: -Dmaven.javadoc.failOnError=false
 
       - name: Deploy docs to GitHub Pages
         run: ./docs/_utils/deploy.sh

--- a/docs/_utils/multiversion.sh
+++ b/docs/_utils/multiversion.sh
@@ -1,5 +1,11 @@
 #! /bin/bash	
 
+# javadoc.sh comes from each version's own tree and runs a full Maven build, so
+# it can break on a frozen release branch for reasons unrelated to the docs.
+# sphinx-multiversion's run_commands() only rescues OSError, so an exit code
+# there aborts the whole multiversion run and the site publishes nothing -- that
+# is how every build between 2026-05-26 and 2026-08-31 was lost. Degrade to a
+# missing /api/ for the one version instead, and say so in the log.
 cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
     --pre-build "bash -c \"(find . -mindepth 2 -name README.md -execdir mv '{}' index.md ';'; find . -mindepth 2 -name README.rst -execdir mv '{}' index.rst ';')\"" \
-    --post-build './docs/_utils/javadoc.sh'
+    --post-build "bash -c './docs/_utils/javadoc.sh || echo \"::warning::javadoc build failed for \$SPHINX_MULTIVERSION_NAME - its api pages will be missing\"'"


### PR DESCRIPTION
The docs site is stale. `Docs / Publish` has failed on **every run since 2026-05-26**, so
`java-driver.docs.scylladb.com` is frozen at the 2026-05-22 build and nothing merged in the last
three months has reached it — including the 3.x deprecation banner from #997.

Last green run: 2026-05-22 (`707f7cfb3d`). `gh-pages`, the only thing that moves the live site,
last deployed the same day. Failures since: 05-26, 06-23, 06-24, 06-30, 07-29, 08-05, 08-12 and
both 08-31 runs.

### Not to be confused with `Docs / Build PR`

These are two different workflows, and green runs of the second say nothing about the first:

| | `Docs / Build PR` | `Docs / Publish` |
|---|---|---|
| file | `docs-pr.yml` | `docs-pages.yml` |
| build | `make -C docs test` — **one** version, the PR's own branch | `make -C docs multiversion` — **all 16** |
| deploys? | no deploy step | `Deploy docs to GitHub Pages` |

`docs-pr.yml` is green on JDK 11 precisely because it only ever builds `scylla-4.x`, the one tree
that is *post* `deaeb1c442`. It never runs `sphinx-multiversion`, so it never checks out a frozen
release branch or runs its `javadoc.sh`. JDK 11 is right there and wrong only here.

### What breaks

`make -C docs multiversion` builds the javadoc of every version in `conf.py`'s `BRANCHES` —
**`LATEST_VERSION` included**. All of them are frozen release branches that compile through
error-prone's `javac:9+181` shim, which cannot read JDK 11 class files:

```
guava-shaded/src/main/java/com/google/common/primitives/LexicographicalComparatorHolderSubstitution.java:[24,17]
    cannot access java.util.Comparator
  class file has wrong version 55.0, should be 53.0
```

`deaeb1c442` ("build: drop Java 8 support") raised this workflow to JDK 11 in a blanket sweep. No
published doc version needs JDK 11 — `scylla-4.x` is not in `BRANCHES` — so this is a restore of
the last known-good configuration, not a step backwards. `BRANCHES` today is byte-identical to
`BRANCHES` at the last green run, so JDK 8 is proven for exactly this version set.

### Changes

- `docs-pages.yml`: back to JDK 8, with a comment explaining why *and* why it differs from
  `docs-pr.yml`, so the next sweep does not redo this.
- `docs/_utils/multiversion.sh`: make the post-build tolerant. `sphinx-multiversion`'s
  `run_commands()` rescues only `OSError`, so one branch's exit code aborted the entire run and the
  site published *nothing* instead of publishing with one gap — which is why this went unnoticed for
  three months. A failure now degrades to a missing `/api/` for that version plus a `::warning::`.
- Drops `3111d6e8fc`'s `MAVEN_OPTS: -Dmaven.javadoc.failOnError=false`. @dgarcia360 — that aimed at
  exactly the resilience above, but it keys on javadoc doclint and the failure is `javac` refusing
  to compile, so it never took effect. Superseded, not reverted.

### Verification

Reproduced and fixed on a `scylla-4.19.0.x` worktree — `LATEST_VERSION`, i.e. what `/stable/`
serves, so this is not a stale-branch-only problem:

- `mvn install -DskipTests -pl core -am -Dmaven.javadoc.failOnError=false` under JDK 11 → fails
  with the error above, confirming the current flag is a no-op.
- The same command under JDK 8 → `BUILD SUCCESS`.
- `docs/_utils/javadoc.sh` under JDK 8 → exit 0, full 15-entry `api/` tree.
- Separately, a two-version `make -C docs multiversion` under JDK 11 confirmed the tolerant
  post-build: the javadoc failure became `::warning::javadoc build failed for scylla-4.19.0.x` and
  the multiversion build **completed** instead of aborting.

`scylla-4.15.0.x` is where the CI log happens to abort, but only because `javadoc.sh` has no
`set -e`: 4.10–4.14 also fail to compile and still exit 0 because their trailing `mv` succeeds.
That abort point reflects script structure, not scope.

Not covered: the full 16-version publish (~66 min in CI).

**Note on merging:** this workflow triggers on `paths: docs/**, faq/**, manual/**, changelog/**,
upgrade_guide/**`. The `docs/_utils/multiversion.sh` change is inside `docs/**`, so merging this
does trigger a publish. Please check that run goes green — a green run is what proves the fix.

Separately, and **not fixed by this PR**: `/stable/` is `scylla-4.19.0.x`, which sits at tag
`4.19.0.1`, while the released driver is `4.19.2.1`. That is a missing docs branch, filed
separately.

Fixes DRIVER-1034
Refs: https://scylladb.atlassian.net/browse/DRIVER-854
