### PR TITLE
refactor: remove dead local-DC contact-point check (DRIVER-201)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/helper/OptionalLocalDcHelper.java
@@ -26,7 +26,6 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,73 +67,34 @@ public class OptionalLocalDcHelper implements LocalDcHelper {
   @Override
   @NonNull
   public Optional<String> discoverLocalDc(@NonNull Map<UUID, Node> nodes) {
-    String localDcStr = context.getLocalDatacenter(profile.getName());
-    Optional<String> localDc;
-    if (localDcStr != null) {
-      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDcStr);
-      localDc = Optional.of(localDcStr);
+    String localDc = context.getLocalDatacenter(profile.getName());
+    if (localDc != null) {
+      LOG.debug("[{}] Local DC set programmatically: {}", logPrefix, localDc);
     } else if (profile.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)) {
-      localDcStr = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
-      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDcStr);
-      localDc = Optional.of(localDcStr);
-    } else {
-      localDc = Optional.empty();
-    }
-    if (localDc.isPresent()) {
-      checkLocalDatacenterCompatibility(
-          localDc.get(), context.getMetadataManager().getContactPoints());
-      // Also warn if the configured DC doesn't match any node in the cluster
-      if (!nodes.isEmpty()) {
-        boolean found = false;
-        for (Node node : nodes.values()) {
-          if (localDc.get().equals(node.getDatacenter())) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          LOG.warn(
-              "[{}] Configured local DC '{}' does not match any node's datacenter"
-                  + " (available DCs: {}); please verify your configuration",
-              logPrefix,
-              localDc.get(),
-              formatDcs(nodes.values()));
-        }
-      }
+      localDc = profile.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
+      LOG.debug("[{}] Local DC set from configuration: {}", logPrefix, localDc);
     } else {
       LOG.debug("[{}] Local DC not set, DC awareness will be disabled", logPrefix);
+      return Optional.empty();
     }
-    return localDc;
-  }
-
-  /**
-   * Checks if the contact points are compatible with the local datacenter specified either through
-   * configuration, or programmatically.
-   *
-   * <p>The default implementation logs a warning when a contact point reports a datacenter
-   * different from the local one, and only for the default profile.
-   *
-   * @param localDc The local datacenter, as specified in the config, or programmatically.
-   * @param contactPoints The contact points provided when creating the session.
-   */
-  protected void checkLocalDatacenterCompatibility(
-      @NonNull String localDc, Set<? extends Node> contactPoints) {
-    if (profile.getName().equals(DriverExecutionProfile.DEFAULT_NAME)) {
-      Set<Node> badContactPoints = new LinkedHashSet<>();
-      for (Node node : contactPoints) {
-        if (!Objects.equals(localDc, node.getDatacenter())) {
-          badContactPoints.add(node);
+    if (!nodes.isEmpty()) {
+      boolean found = false;
+      for (Node node : nodes.values()) {
+        if (localDc.equals(node.getDatacenter())) {
+          found = true;
+          break;
         }
       }
-      if (!badContactPoints.isEmpty()) {
+      if (!found) {
         LOG.warn(
-            "[{}] You specified {} as the local DC, but some contact points are from a different DC: {}; "
-                + "please provide the correct local DC, or check your contact points",
+            "[{}] Configured local DC '{}' does not match any node's datacenter"
+                + " (available DCs: {}); please verify your configuration",
             logPrefix,
             localDc,
-            formatNodesAndDcs(badContactPoints));
+            formatDcs(nodes.values()));
       }
     }
+    return Optional.of(localDc);
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -148,8 +148,10 @@ public class MetadataManager implements AsyncAutoCloseable {
 
   public void addContactPoints(Set<EndPoint> providedContactPoints) {
     // Convert the EndPoints to Nodes, but we can't put them into the Metadata yet, because we
-    // don't know their host_id. So store them in a volatile field instead, they will get copied
-    // during the first node refresh.
+    // don't know their host_id. So store them in a volatile field instead, exposed through
+    // getContactPoints(). These placeholders are never copied into the Metadata: the first node
+    // refresh matches nodes by host_id (InitialNodeListRefresh) and registerNode builds fresh Node
+    // objects, so a placeholder's datacenter, rack and version stay null for its whole life.
     ImmutableSet.Builder<DefaultNode> contactPointsBuilder = ImmutableSet.builder();
     if (providedContactPoints == null || providedContactPoints.isEmpty()) {
       LOG.info(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicyInitTest.java
@@ -93,7 +93,8 @@ public class BasicLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestBas
 
     // Then
     assertThat(policy.getLocalDatacenter()).isNull();
-    // should not warn about contact points not being in the same DC
+    // no local DC is configured, so discoverLocalDc() returns empty before it checks any
+    // node's datacenter
     verify(appender, never()).doAppend(loggingEventCaptor.capture());
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
@@ -19,6 +19,7 @@ package com.datastax.oss.driver.internal.core.loadbalancing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,9 +30,13 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
+import com.datastax.oss.driver.internal.core.loadbalancing.helper.OptionalLocalDcHelper;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetSocketAddress;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -208,6 +213,39 @@ public class DefaultLoadBalancingPolicyInitTest extends LoadBalancingPolicyTestB
                 .anyMatch(
                     e -> e.getFormattedMessage().contains("does not match any node's datacenter")))
         .isTrue();
+  }
+
+  @Test
+  public void should_not_warn_about_dc_mismatch_when_the_only_real_node_matches_configured_dc() {
+    // Given — CUSTOMER-588. Until the first node refresh, a contact point is represented by an
+    // ephemeral placeholder Node (MetadataManager#addContactPoints via
+    // DefaultNode#newContactPoint) whose datacenter is always null: the refresh keys nodes by
+    // host_id and never reuses these objects. The removed
+    // OptionalLocalDcHelper#checkLocalDatacenterCompatibility compared the configured local DC
+    // against *those* placeholders, so it warned whenever a local DC was configured, wherever the
+    // contact points actually were. The stub below is what makes this test fail against the
+    // pristine helper, so keep it even though the fixed code never reads it.
+    DefaultNode ephemeralContactPointNode =
+        DefaultNode.newContactPoint(
+            new DefaultEndPoint(new InetSocketAddress("127.0.0.9", 9042)), context);
+    when(metadataManager.getContactPoints()).thenReturn(ImmutableSet.of(ephemeralContactPointNode));
+    DefaultLoadBalancingPolicy policy = createPolicy();
+
+    // When
+    policy.init(ImmutableMap.of(UUID.randomUUID(), node1), distanceReporter);
+
+    // Then — DC discovery must not consult contact points at all; node1, the only node carrying
+    // real metadata, is in the configured DC ("dc1", per base setup). Asserting on the absence of
+    // any WARN from the helper, rather than on one message, also catches the false positive coming
+    // back under different wording.
+    verify(metadataManager, never()).getContactPoints();
+    verify(appender, never())
+        .doAppend(
+            argThat(
+                event ->
+                    event.getLevel() == Level.WARN
+                        && event.getLoggerName().equals(OptionalLocalDcHelper.class.getName())));
+    assertThat(policy.getLocalDatacenter()).isEqualTo("dc1");
   }
 
   @NonNull

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -19,6 +19,16 @@ under the License.
 
 ## Upgrade guide
 
+### 4.19.2.2
+
+#### The local-DC check no longer inspects contact points
+
+`OptionalLocalDcHelper` no longer logs "you specified X as the local DC, but some contact points are
+from a different DC". It compared the configured DC against contact-point placeholder nodes, whose
+datacenter is never populated, so it fired on every session that configured a local DC, wherever the
+contact points actually were. The warning for a configured DC that matches no node in the cluster is
+unchanged. `checkLocalDatacenterCompatibility` is removed, so drop any override of it.
+
 ### 4.19.2.1
 
 #### The driver reports a session identifier, and its configuration, at connection time


### PR DESCRIPTION
`OptionalLocalDcHelper.checkLocalDatacenterCompatibility` warns on every session init that configures a local DC, wherever the contact points actually are (CUSTOMER-588). It compares the configured DC against the contact-point placeholder nodes, whose datacenter has been `null` since 12e6acb90b switched node matching to host ids. The 4.19.2 upstream merge (707f7cfb3d) brought the method back, so the dead check and the real one ran side by side.

- Remove `checkLocalDatacenterCompatibility`, a `protected` method with no override in this repo. `formatNodesAndDcs` stays for `InferringLocalDcHelper`.
- Keep the "configured local DC does not match any node" warning, which inspects the resolved node map.
- Add a regression test asserting that DC discovery never reads `getContactPoints()` and that the helper's logger emits no WARN. Both assertions fail independently against the pristine helper.
- Correct the `addContactPoints` comment claiming the placeholders "will get copied during the first node refresh" — they never are, which is what kept the dead check looking alive.
- Note the removed warning and the removed hook in the upgrade guide.

Nothing replaces the *intended* diagnostic: flagging contact points that sit in a remote DC needs endpoint matching against resolved nodes, which this PR does not add.

Verified: `mvn -pl core test -Dtest=DefaultLoadBalancingPolicyInitTest,BasicLoadBalancingPolicyInitTest,DcInferringLoadBalancingPolicyInitTest,MetadataManagerTest` (47 tests); `javadoc:javadoc` on JDK 11; `cd docs && make test`. Not covered: integration tests.

#1062 adds a `4.19.2.2` upgrade-guide section too, so whichever merges second needs a trivial heading merge. First of a series that splits #890 into small PRs. Refs: #890
