### PR TITLE
fix: stop mutating the control reconnection query plan (DRIVER-201)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -27,6 +27,9 @@ import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.util.ArrayUtils;
+import com.datastax.oss.driver.internal.core.util.collection.CompositeQueryPlan;
+import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.driver.internal.core.util.concurrent.ReplayingEventFilter;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
@@ -144,7 +147,20 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
   @NonNull
   public Queue<Node> newQueryPlan(
       @Nullable Request request, @NonNull String executionProfileName, @Nullable Session session) {
-    switch (stateRef.get()) {
+    return newQueryPlan(stateRef.get(), request, executionProfileName, session);
+  }
+
+  /**
+   * Builds a query plan for a state that the caller has already read, so that a caller taking more
+   * than one decision from the state takes them all from the same value.
+   */
+  @NonNull
+  private Queue<Node> newQueryPlan(
+      @NonNull State state,
+      @Nullable Request request,
+      @NonNull String executionProfileName,
+      @Nullable Session session) {
+    switch (state) {
       case BEFORE_INIT:
       case DURING_INIT:
         // The contact points are not stored in the metadata yet:
@@ -164,20 +180,27 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
 
   @NonNull
   public Queue<Node> newControlReconnectionQueryPlan() {
-    Queue<Node> regularQueryPlan = newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
+    // One read, shared by the plan below and the guard after it: init() flips the state on the
+    // session's admin thread while this method runs on the control connection's, so reading twice
+    // could see DURING_INIT here and RUNNING in newQueryPlan(), and drop the fallback from a plan
+    // that was built by the policy.
+    State state = stateRef.get();
+    Queue<Node> regularQueryPlan =
+        newQueryPlan(state, null, DriverExecutionProfile.DEFAULT_NAME, null);
 
-    if (context
-        .getConfig()
-        .getDefaultProfile()
-        .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)) {
-      Set<DefaultNode> originalNodes = context.getMetadataManager().getContactPoints();
-      List<Node> contactNodes = new ArrayList<>();
-      for (DefaultNode node : originalNodes) {
-        contactNodes.add(DefaultNode.newContactPoint(node.getEndPoint(), context));
-      }
-      Collections.shuffle(contactNodes);
-      // Append contact points to the end of the regular query plan so they serve as a fallback
-      regularQueryPlan.addAll(contactNodes);
+    // Before RUNNING, newQueryPlan() already built the plan from the contact points, so appending
+    // them again would only duplicate every entry. Once RUNNING, the plan comes from the policy and
+    // is an immutable QueryPlan (add()/addAll() throw), so concatenate rather than mutate. The
+    // nodes retained by MetadataManager are appended, not fresh copies: their identity stays stable
+    // across reconnection rounds, and no throwaway node is minted per round.
+    if (state == State.RUNNING
+        && context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)) {
+      Object[] contactNodes = context.getMetadataManager().getContactPoints().toArray();
+      ArrayUtils.shuffleHead(contactNodes, contactNodes.length);
+      return new CompositeQueryPlan(regularQueryPlan, new SimpleQueryPlan(contactNodes));
     }
 
     return regularQueryPlan;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -21,6 +21,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,17 +34,17 @@ import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy.DistanceReporter;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
-import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
+import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
+import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
-import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
@@ -108,7 +109,9 @@ public class LoadBalancingPolicyWrapperTest {
     when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
         .thenReturn(false);
 
-    defaultPolicyQueryPlan = Lists.newLinkedList(ImmutableList.of(node3, node2, node1));
+    // A real built-in QueryPlan, not a mutable LinkedList: its add()/addAll() throw, so the
+    // control-reconnection plan must compose rather than mutate it.
+    defaultPolicyQueryPlan = new SimpleQueryPlan(node3, node2, node1);
     when(policy1.newQueryPlan(null, null)).thenReturn(defaultPolicyQueryPlan);
 
     eventBus = spy(new EventBus("test"));
@@ -161,29 +164,29 @@ public class LoadBalancingPolicyWrapperTest {
     }
 
     // When
-    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+    Queue<Node> queryPlan = wrapper.newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
 
     // Then
-    // no-arg newQueryPlan() uses the default profile
     verify(policy1).newQueryPlan(null, null);
-    assertThat(queryPlan).isEqualTo(defaultPolicyQueryPlan);
+    assertThat(queryPlan).isSameAs(defaultPolicyQueryPlan);
   }
 
   @Test
   public void should_fetch_control_connection_query_plan_from_policy_after_init() {
     // Given
+    // the reconnect-contact-points flag defaults to false in the test setup (see @Before)
     wrapper.init();
     for (LoadBalancingPolicy policy : ImmutableList.of(policy1, policy2, policy3)) {
       verify(policy).init(anyMap(), any(DistanceReporter.class));
     }
 
     // When
-    Queue<Node> queryPlan = wrapper.newQueryPlan(null, DriverExecutionProfile.DEFAULT_NAME, null);
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
 
     // Then
-    // no-arg newQueryPlan() uses the default profile
+    // the policy's own plan is returned as is; nothing is appended or wrapped
     verify(policy1).newQueryPlan(null, null);
-    assertThat(queryPlan).isEqualTo(defaultPolicyQueryPlan);
+    assertThat(queryPlan).isSameAs(defaultPolicyQueryPlan);
   }
 
   @Test
@@ -204,17 +207,9 @@ public class LoadBalancingPolicyWrapperTest {
     assertThat(queryPlan.poll()).isEqualTo(node3);
     assertThat(queryPlan.poll()).isEqualTo(node2);
     assertThat(queryPlan.poll()).isEqualTo(node1);
-    // Remaining nodes are contact points appended at the end.
-    // They are new DefaultNode instances created via newContactPoint, so compare by endpoint.
-    Set<EndPoint> remainingEndpoints = new java.util.HashSet<>();
-    for (Node n : queryPlan) {
-      remainingEndpoints.add(n.getEndPoint());
-    }
-    Set<EndPoint> contactEndpoints = new java.util.HashSet<>();
-    for (DefaultNode n : contactPoints) {
-      contactEndpoints.add(n.getEndPoint());
-    }
-    assertThat(remainingEndpoints).isEqualTo(contactEndpoints);
+    // Remaining nodes are the retained contact-point instances appended at the end. DefaultNode
+    // does not override equals, so this is an identity check.
+    assertThat(queryPlan).containsExactlyInAnyOrderElementsOf(contactPoints);
   }
 
   @Test
@@ -223,24 +218,54 @@ public class LoadBalancingPolicyWrapperTest {
     when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
         .thenReturn(true);
     wrapper.init();
-    // Make the policy return an empty query plan
-    when(policy1.newQueryPlan(null, null)).thenReturn(Lists.newLinkedList(ImmutableList.of()));
+    // Make the policy return an empty query plan (QueryPlan.EMPTY, as the real policies do)
+    when(policy1.newQueryPlan(null, null)).thenReturn(QueryPlan.EMPTY);
 
     // When
     Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
 
     // Then
-    // Should get the contact points (compare by endpoint since they are new instances)
-    assertThat(queryPlan.size()).isEqualTo(contactPoints.size());
-    Set<EndPoint> resultEndpoints = new java.util.HashSet<>();
-    for (Node n : queryPlan) {
-      resultEndpoints.add(n.getEndPoint());
-    }
-    Set<EndPoint> contactEndpoints = new java.util.HashSet<>();
-    for (DefaultNode n : contactPoints) {
-      contactEndpoints.add(n.getEndPoint());
-    }
-    assertThat(resultEndpoints).isEqualTo(contactEndpoints);
+    // Should get the retained contact-point instances themselves.
+    assertThat(queryPlan).containsExactlyInAnyOrderElementsOf(contactPoints);
+  }
+
+  @Test
+  public void should_reuse_the_retained_contact_point_nodes_rather_than_minting_copies() {
+    // Given
+    when(defaultProfile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(true);
+    wrapper.init();
+    when(policy1.newQueryPlan(null, null)).thenReturn(QueryPlan.EMPTY);
+
+    // When — two rounds, as a reconnection sequence would produce.
+    Queue<Node> firstPlan = wrapper.newControlReconnectionQueryPlan();
+    Queue<Node> secondPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then — both plans hand out the very objects MetadataManager retains, not per-plan copies, so
+    // a contact point keeps one identity across reconnection rounds. DefaultNode does not override
+    // equals, so these are identity checks.
+    assertThat(firstPlan).containsExactlyInAnyOrder(node1, node2);
+    assertThat(secondPlan).containsExactlyInAnyOrder(node1, node2);
+  }
+
+  @Test
+  public void should_not_duplicate_contact_points_before_init() {
+    // Given — the flag is on, but the wrapper is not init()-ed yet (BEFORE_INIT), so newQueryPlan()
+    // already builds the plan from the contact points; appending them again would duplicate every
+    // entry. Lenient: the flag is never read before RUNNING, so on the fixed code this stub goes
+    // deliberately unused.
+    lenient()
+        .when(
+            defaultProfile.getBoolean(
+                DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS))
+        .thenReturn(true);
+
+    // When
+    Queue<Node> queryPlan = wrapper.newControlReconnectionQueryPlan();
+
+    // Then — the contact points are read once and appear once.
+    verify(metadataManager, times(1)).getContactPoints();
+    assertThat(queryPlan).containsExactlyInAnyOrder(node1, node2);
   }
 
   @Test


### PR DESCRIPTION
With `advanced.control-connection.reconnection.fallback-to-original-contact-points = true`, every control reconnection after init throws `UnsupportedOperationException` (#1058): once the load balancing policy is running, its plan is an immutable `QueryPlan`, and `newControlReconnectionQueryPlan` appended the contact points to it with `addAll`. The existing unit test stubbed that plan with a mutable Guava list, which is why it never caught this; it now stubs a real `SimpleQueryPlan` / `QueryPlan.EMPTY`.

- Return a `CompositeQueryPlan` of the policy's plan and a `SimpleQueryPlan` of the contact points instead of mutating.
- Append only once the wrapper is `RUNNING`. Before that, `newQueryPlan()` already builds the plan from the contact points, and the old code appended them a second time during init.
- Read the wrapper state once and pass it into `newQueryPlan`, so `init()` flipping it on the session's admin thread cannot make this method drop the fallback.
- Append the nodes `MetadataManager` retains rather than fresh `newContactPoint` copies: one stable identity per contact point across rounds, no throwaway node per round.

Two behaviour deltas worth naming. Pre-`RUNNING` with the flag on, each contact point used to be listed twice — two connect attempts and, with `resolve-contact-points = false`, two DNS resolutions; it is one now. And in `CLOSING` the flag-on path now returns an empty plan instead of the contact points, which is benign because `ControlConnection.close()` stops the reconnection.

The option's default stays `false`, so default users see no change. A later PR in this series flips the default and adds the topology-monitor gate.

Verified: `mvn -pl core test -Dtest=LoadBalancingPolicyWrapperTest,ControlConnectionTest` (13 + 29 tests) and `javadoc:javadoc` on JDK 11; against the pristine wrapper four wrapper tests go red, three of them with the `UnsupportedOperationException`. Not covered: integration tests.

Fixes #1058
Refs: #215, #890
