### PR TITLE
fix: skip an unusable client-route row, keep the refresh (DRIVER-201)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -88,6 +88,12 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * {@code host_id} alone, so the two coincide only while a single connection ID can produce rows
    * for a given host. Where several can, a cached entry and a returned row for the same host need
    * not be the same route (see #1063), and a refresh keeps only the routes it rebuilt.
+   *
+   * <p>This is a statement about the <em>configured</em> connection IDs, so it holds only because
+   * {@link #allowedConnectionIds} keeps every query's scope inside them. Drop that filter and a
+   * server event can steer a pass at a connection ID this driver never configured, whose rows say
+   * nothing about the routes cached under ours -- at which point carrying a cached route over
+   * because some row named its host is no longer sound.
    */
   private final boolean hostIdIdentifiesRoute;
 
@@ -539,8 +545,40 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
     if (closed) {
       return;
     }
+    List<String> eventConnectionIds = event.getConnectionIds();
+    List<String> allowedConnectionIds = allowedConnectionIds(eventConnectionIds);
+    if (!eventConnectionIds.isEmpty() && allowedConnectionIds.isEmpty()) {
+      // The event named connections, and none of them is ours: whatever changed, it was not a
+      // route this session caches. An event naming none at all is the different case handled by
+      // buildQuery's fallback -- it carries no scope, so it cannot rule this session out.
+      LOG.debug("[{}] Ignoring {}: it names no configured connection ID", logPrefix, event);
+      return;
+    }
     LOG.debug("[{}] Received {}, refreshing routes", logPrefix, event);
-    queryClientRoutesAndCache(event.getConnectionIds(), event.getHostIds());
+    queryClientRoutesAndCache(allowedConnectionIds, event.getHostIds());
+  }
+
+  /**
+   * Returns the connection IDs an event names that this driver actually configured, dropping the
+   * rest. Scylla broadcasts every changed key, so an event routinely names proxies belonging to
+   * other clients, and until they are dropped they reach {@link #buildQuery} and become the query's
+   * scope verbatim -- unlike the host IDs beside them, which are validated there.
+   *
+   * <p>Two things go wrong when they do. A usable row for an unconfigured connection installs a
+   * route through a proxy this client is not configured to use, addressed as that proxy's clients
+   * address it. An unusable one is read as evidence about a host whose cached route was built from
+   * a different connection's row, which is what {@link #hostIdIdentifiesRoute} assumes cannot
+   * happen. Both are the same mistake: a row is only evidence about the connection it belongs to.
+   *
+   * <p>Empty IDs are dropped as well. {@link ClientRouteProxy} rejects a blank connection ID, so
+   * one can never match, and leaving it in would only widen the {@code IN} list.
+   */
+  @NonNull
+  private List<String> allowedConnectionIds(@NonNull List<String> eventConnectionIds) {
+    return eventConnectionIds.stream()
+        .filter(id -> id != null && !id.isEmpty())
+        .filter(configuredConnectionIds::contains)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -595,6 +633,12 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    *       connection IDs when present, otherwise falls back to all configured connection IDs
    *   <li>Neither → full scan with {@code ALLOW FILTERING} (should not occur in practice)
    * </ul>
+   *
+   * <p>{@code eventConnectionIds} has already been reduced to configured IDs by {@link
+   * #allowedConnectionIds}, so the scope this builds is always inside them. The fallback above
+   * therefore covers two arrivals that differ: an event that named no connection at all, and one
+   * whose IDs were all dropped -- and the second never reaches here, because a pass over our own
+   * connections would answer a question that event did not ask.
    */
   @NonNull
   private static String buildQuery(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -355,7 +355,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                     // Skip the record if the required port column is absent.
                     port = row.isNull(portColumn) ? null : row.getInteger(portColumn);
                     if (port == null) {
-                      LOG.warn(
+                      LOG.error(
                           "[{}] Skipping client route for host_id={} ({}): "
                               + "required port column ({}) is not set in client routes table",
                           logPrefix,
@@ -413,11 +413,11 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                       "[{}] Merged {} client routes (targeted refresh)",
                       logPrefix,
                       newRoutes.size());
-                } else if (rowCount == 0 && !resolvedRoutesCache.get().isEmpty()) {
+                } else if (rowCount == 0 && !cachedRoutes.isEmpty()) {
                   int emptyCount = consecutiveEmptyResults.incrementAndGet();
                   if (emptyCount >= MAX_CONSECUTIVE_EMPTY_RESULTS) {
                     // Too many consecutive empties -- routes were likely removed server-side.
-                    int staleSize = resolvedRoutesCache.get().size();
+                    int staleSize = cachedRoutes.size();
                     resolvedRoutesCache.set(Collections.emptyMap());
                     consecutiveEmptyResults.set(0);
                     LOG.warn(
@@ -436,7 +436,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                         logPrefix,
                         emptyCount,
                         MAX_CONSECUTIVE_EMPTY_RESULTS,
-                        resolvedRoutesCache.get().size());
+                        cachedRoutes.size());
                   }
                 } else {
                   // Rows came back, so this is not the eventual-consistency race the counter
@@ -745,14 +745,25 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
       int unattributableRows,
       int rowCount) {
     if (!hostIdIdentifiesRoute) {
-      if (unattributableRows > 0 || hostIdsInResult.size() > newRoutes.size()) {
+      // Only a pass that failed on some row can drop a route it had no evidence about; a host
+      // missing from a clean result really was deleted, and saying so here would be wrong.
+      boolean someRowUnusable = unattributableRows > 0 || hostIdsInResult.size() > newRoutes.size();
+      int droppedRoutes = 0;
+      if (someRowUnusable) {
+        for (UUID cachedHostId : cachedRoutes.keySet()) {
+          if (!newRoutes.containsKey(cachedHostId)) {
+            droppedRoutes++;
+          }
+        }
+      }
+      if (droppedRoutes > 0) {
         LOG.warn(
-            "[{}] Not carrying over cached routes for the {} host(s) this refresh could not rebuild"
+            "[{}] Dropping the cached route for {} host(s) this refresh could not rebuild"
                 + " ({} row(s) named no host_id at all): with {} connection IDs configured a cached"
-                + " route cannot be told from another connection's, and keeping it would preserve a"
-                + " route the server may have deleted",
+                + " route cannot be told from another connection's, so keeping it could preserve a"
+                + " route the server has deleted",
             logPrefix,
-            hostIdsInResult.size() - newRoutes.size(),
+            droppedRoutes,
             unattributableRows,
             configuredConnectionIds.size());
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -37,10 +37,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -79,6 +81,16 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
   private final ClientRoutesConfig config;
   private final List<String> configuredConnectionIds;
   private final Map<String, String> connectionAddrOverrides;
+
+  /**
+   * Whether a cached route's {@code host_id} identifies the table row it was built from. {@code
+   * system.client_routes} is keyed on {@code (connection_id, host_id)} while this cache is keyed on
+   * {@code host_id} alone, so the two coincide only while a single connection ID can produce rows
+   * for a given host. Where several can, a cached entry and a returned row for the same host need
+   * not be the same route (see #1063), and a refresh keeps only the routes it rebuilt.
+   */
+  private final boolean hostIdIdentifiesRoute;
+
   private final String logPrefix;
   private final AtomicReference<Map<UUID, ClientRouteRecord>> resolvedRoutesCache;
   private final boolean useSSL;
@@ -144,6 +156,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                     Collectors.toMap(
                         ClientRouteProxy::getConnectionId,
                         ClientRouteProxy::getConnectionAddrOverride)));
+    this.hostIdIdentifiesRoute = new HashSet<>(configuredConnectionIds).size() == 1;
     this.logPrefix = context.getSessionName();
     this.resolvedRoutesCache = new AtomicReference<>(Collections.emptyMap());
     this.useSSL = context.getSslEngineFactory().isPresent();
@@ -297,53 +310,83 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
           .thenAccept(
               adminResult -> {
                 Map<UUID, ClientRouteRecord> newRoutes = new HashMap<>();
+                // Every host_id this loop manages to read, whatever becomes of the rest of its
+                // row. A host in here but not in newRoutes came back unusable, which is not the
+                // same as the server having deleted it -- keepableHostIds turns that difference
+                // into the one rule both cache writes below apply.
+                Set<UUID> hostIdsInResult = new HashSet<>();
+                // Rows this loop could not attribute to any host at all, because their host_id
+                // was unreadable. They make the set above an incomplete record of what came
+                // back, which is why absence from it stops being proof of a delete -- see
+                // keepableHostIds. Counted rather than derived from rowCount, because two rows
+                // can legitimately share one host_id (several proxies fronting one host).
+                int unattributableRows = 0;
+                int rowCount = 0;
+                String portColumn = useSSL ? "tls_port" : "port";
                 for (AdminRow row : adminResult) {
-                  if (row.isNull("host_id") || row.isNull("address")) {
-                    LOG.warn("[{}] Skipping incomplete client_routes row: {}", logPrefix, row);
-                    continue;
-                  }
-                  UUID hostId = Objects.requireNonNull(row.getUuid("host_id"));
-                  String address = Objects.requireNonNull(row.getString("address"));
+                  rowCount++;
+                  UUID hostId = null;
+                  String address = null;
+                  Integer port = null;
+                  // This loop runs inside thenAccept(), so anything thrown out of it skips the
+                  // cache update and discards every route in the pass, not just the offending
+                  // row -- and the cache then stays stale for as long as that row remains in the
+                  // table. ClientRouteRecord rejects a null or empty hostname and a port outside
+                  // 1..65535, and the column codecs reject a malformed cell; catching here is
+                  // what keeps one bad row costing one route. readHostId handles the row's
+                  // identity itself, so everything reaching the catch below failed on the
+                  // payload, with the host already recorded as present.
+                  try {
+                    hostId = readHostId(row);
+                    if (hostId == null) {
+                      unattributableRows++;
+                      continue;
+                    }
+                    hostIdsInResult.add(hostId);
+                    address = effectiveAddress(row);
 
-                  // Select port based on SSL configuration at record creation time.
-                  // Skip the record if the required port column is absent.
-                  Integer effectivePort;
-                  if (useSSL) {
-                    effectivePort = row.isNull("tls_port") ? null : row.getInteger("tls_port");
-                  } else {
-                    effectivePort = row.isNull("port") ? null : row.getInteger("port");
-                  }
-                  if (effectivePort == null) {
-                    LOG.error(
-                        "[{}] Skipping client route for host_id={} ({}): "
-                            + "required port column ({}) is not set in client routes table",
+                    // Select port based on SSL configuration at record creation time.
+                    // Skip the record if the required port column is absent.
+                    port = row.isNull(portColumn) ? null : row.getInteger(portColumn);
+                    if (port == null) {
+                      LOG.warn(
+                          "[{}] Skipping client route for host_id={} ({}): "
+                              + "required port column ({}) is not set in client routes table",
+                          logPrefix,
+                          hostId,
+                          address,
+                          portColumn);
+                      continue;
+                    }
+
+                    newRoutes.put(hostId, new ClientRouteRecord(hostId, address, port));
+                  } catch (RuntimeException e) {
+                    LOG.warn(
+                        "[{}] Skipping unusable client_routes row (host_id={}, address={}, {}={})",
                         logPrefix,
                         hostId,
                         address,
-                        useSSL ? "tls_port" : "port");
-                    continue;
+                        portColumn,
+                        port,
+                        e);
                   }
-
-                  // Apply connectionAddr override if configured for this connection_id
-                  String connId =
-                      row.contains("connection_id") && !row.isNull("connection_id")
-                          ? row.getString("connection_id")
-                          : null;
-                  if (connId != null) {
-                    String override = connectionAddrOverrides.get(connId);
-                    if (override != null) {
-                      address = override;
-                    }
-                  }
-
-                  newRoutes.put(hostId, new ClientRouteRecord(hostId, address, effectivePort));
                 }
+
+                // One view of the cache for the whole pass, and one rule over it: a cached
+                // route may be evicted only where this pass can prove the server deleted it.
+                Map<UUID, ClientRouteRecord> cachedRoutes = resolvedRoutesCache.get();
+                Set<UUID> keepableHostIds =
+                    keepableHostIds(
+                        hostIdsInResult, newRoutes, cachedRoutes, unattributableRows, rowCount);
 
                 if (isTargetedRefresh) {
                   // Merge: update only the returned host IDs, keep all others unchanged
                   mergeRoutes(newRoutes);
-                  // Remove stale routes: host IDs present in the event but absent from query
-                  // results have been deleted server-side (e.g. node decommission).
+                  // Remove stale routes: a host ID the event named that keepableHostIds does
+                  // not hold has been deleted server-side (e.g. node decommission). Evicting one
+                  // it does hold would drop a working route back to the node's unreachable
+                  // private address, which is why every reason a host is not provably absent
+                  // lives in that one set rather than in a condition here.
                   for (String hostIdStr : eventHostIds) {
                     UUID hostId;
                     try {
@@ -356,7 +399,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                           e);
                       continue;
                     }
-                    if (!newRoutes.containsKey(hostId)) {
+                    if (!keepableHostIds.contains(hostId)) {
                       removeRoute(hostId);
                     }
                   }
@@ -364,7 +407,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                       "[{}] Merged {} client routes (targeted refresh)",
                       logPrefix,
                       newRoutes.size());
-                } else if (newRoutes.isEmpty() && !resolvedRoutesCache.get().isEmpty()) {
+                } else if (rowCount == 0 && !resolvedRoutesCache.get().isEmpty()) {
                   int emptyCount = consecutiveEmptyResults.incrementAndGet();
                   if (emptyCount >= MAX_CONSECUTIVE_EMPTY_RESULTS) {
                     // Too many consecutive empties -- routes were likely removed server-side.
@@ -390,10 +433,18 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                         resolvedRoutesCache.get().size());
                   }
                 } else {
+                  // Rows came back, so this is not the eventual-consistency race the counter
+                  // above tracks, whatever else was wrong with them.
                   consecutiveEmptyResults.set(0);
-                  resolvedRoutesCache.set(Collections.unmodifiableMap(newRoutes));
+                  Map<UUID, ClientRouteRecord> updated =
+                      withRetainedCachedRoutes(cachedRoutes, newRoutes, keepableHostIds);
+                  resolvedRoutesCache.set(Collections.unmodifiableMap(updated));
                   LOG.debug(
-                      "[{}] Updated client routes: {} routes loaded", logPrefix, newRoutes.size());
+                      "[{}] Updated client routes: {} routes loaded"
+                          + " ({} kept from the previous refresh)",
+                      logPrefix,
+                      updated.size(),
+                      updated.size() - newRoutes.size());
                 }
               })
           .exceptionally(
@@ -408,6 +459,59 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
       completeAndDrain(sentinel);
       return sentinel;
     }
+  }
+
+  /**
+   * Returns the row's {@code host_id}, or {@code null} when the row carries no readable identity:
+   * an unset cell, or one the UUID codec rejects. {@code host_id} is the row's identity — the cache
+   * key, the presence bookkeeping and every log line depend on it — so unlike the address and the
+   * port it is read here rather than left to {@link ClientRouteRecord}, and both ways of failing
+   * land in one place. A row this returns {@code null} for cannot be attributed to any host, which
+   * is why the caller stops treating absence from the result as evidence of a delete for the rest
+   * of the pass.
+   *
+   * <p>The {@code requireNonNull} is not redundant: {@link AdminRow#isNull} only tests for a null
+   * {@code ByteBuffer}, while the UUID codec returns {@code null} for a zero-length cell.
+   */
+  @Nullable
+  private UUID readHostId(@NonNull AdminRow row) {
+    if (row.isNull("host_id")) {
+      LOG.warn("[{}] Skipping client_routes row: host_id is not set", logPrefix);
+      return null;
+    }
+    try {
+      return Objects.requireNonNull(row.getUuid("host_id"));
+    } catch (RuntimeException e) {
+      LOG.warn("[{}] Skipping client_routes row: host_id is not readable", logPrefix, e);
+      return null;
+    }
+  }
+
+  /**
+   * Returns the address a row's route should use: the configured {@code connection_addr} override
+   * for the row's {@code connection_id} when one applies, otherwise the table's {@code address}
+   * column. {@link ClientRouteProxy} documents the override as replacing that column outright for a
+   * matching connection ID, without qualifying that on the column holding anything usable — so an
+   * override short-circuits the column, and a cell the text codec rejects cannot defeat one.
+   *
+   * <p>A {@code connection_id} the codec rejects does skip the row, via the caller's {@code catch}.
+   * That is the intended asymmetry: without it the driver cannot know which override applies.
+   *
+   * <p>May return {@code null} or an empty string; {@link ClientRouteRecord} rejects both. Leaving
+   * the verdict there is what keeps "is this address usable" one question with one answer, rather
+   * than one guard for an absent column and another for an empty one.
+   */
+  @Nullable
+  private String effectiveAddress(@NonNull AdminRow row) {
+    String connId =
+        row.contains("connection_id") && !row.isNull("connection_id")
+            ? row.getString("connection_id")
+            : null;
+    String override = connId == null ? null : connectionAddrOverrides.get(connId);
+    if (override != null) {
+      return override;
+    }
+    return row.isNull("address") ? null : row.getString("address");
   }
 
   /**
@@ -552,6 +656,105 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
   @NonNull
   private static String cqlQuoteLiteral(@NonNull String value) {
     return "'" + value.replace("'", "''") + "'";
+  }
+
+  /**
+   * Returns the host IDs whose cached route this refresh may leave in place even though it built no
+   * record for them. Absence from this set is what both cache writers treat as proof that the
+   * server deleted the host, so the whole eviction rule lives here rather than in a condition at
+   * each of them.
+   *
+   * <p>Three cases, least carry-over first.
+   *
+   * <p>Where {@code host_id} is not the whole route identity ({@link #hostIdIdentifiesRoute})
+   * nothing is carried over. Keeping a cached route asks whether <em>that route's</em> row came
+   * back unusable, and a set of host IDs cannot answer a question about one {@code (connection_id,
+   * host_id)} row: the cached entry and the row that failed need not be the same route. Keeping it
+   * anyway would preserve a route the server deleted for as long as some other connection's row
+   * stayed unusable, and no non-empty refresh would ever reset that. So the refresh keeps only what
+   * it rebuilt, as it did before row-level tolerance existed. See #1063, which corrects the cache
+   * key itself; retention by the full key falls out of that fix.
+   *
+   * <p>Otherwise a row that came back and merely failed to parse is not an absent row, so every
+   * host ID the loop read is keepable: the refresh replaces the routes it could rebuild and leaves
+   * the rest alone.
+   *
+   * <p>Unless the loop could not attribute some row to any host at all, which destroys that
+   * evidence for the whole refresh -- the unattributable row may have been the very host now
+   * missing from {@code hostIdsInResult}. Evicting on a guess would send a working node back to its
+   * private address, unreachable in the deployment client routes exist for and permanent until the
+   * table changes, whereas a route kept one refresh too long fails fast on connect. So the whole
+   * cache is keepable, and the next clean refresh evicts.
+   */
+  @NonNull
+  private Set<UUID> keepableHostIds(
+      @NonNull Set<UUID> hostIdsInResult,
+      @NonNull Map<UUID, ClientRouteRecord> newRoutes,
+      @NonNull Map<UUID, ClientRouteRecord> cachedRoutes,
+      int unattributableRows,
+      int rowCount) {
+    if (!hostIdIdentifiesRoute) {
+      if (unattributableRows > 0 || hostIdsInResult.size() > newRoutes.size()) {
+        LOG.warn(
+            "[{}] Not carrying over cached routes for the {} host(s) this refresh could not rebuild"
+                + " ({} row(s) named no host_id at all): with {} connection IDs configured a cached"
+                + " route cannot be told from another connection's, and keeping it would preserve a"
+                + " route the server may have deleted",
+            logPrefix,
+            hostIdsInResult.size() - newRoutes.size(),
+            unattributableRows,
+            configuredConnectionIds.size());
+      }
+      return newRoutes.keySet();
+    }
+    if (unattributableRows == 0) {
+      return hostIdsInResult;
+    }
+    if (hostIdsInResult.isEmpty()) {
+      LOG.error(
+          "[{}] None of the {} client_routes rows named a readable host_id; "
+              + "keeping all {} existing cached routes",
+          logPrefix,
+          rowCount,
+          cachedRoutes.size());
+    } else {
+      LOG.warn(
+          "[{}] {} of {} client_routes rows named no readable host_id; keeping the "
+              + "cached routes this refresh cannot prove deleted",
+          logPrefix,
+          unattributableRows,
+          rowCount);
+    }
+    return cachedRoutes.keySet();
+  }
+
+  /**
+   * Returns the map a full refresh should install: every route it could build, plus the cached
+   * record of each host in {@code keepableHostIds}.
+   *
+   * <p>A full refresh replaces the cache outright, because a host missing from the result has been
+   * deleted server-side. {@link #keepableHostIds} is the exception list -- the hosts this refresh
+   * cannot show the server to have deleted -- and dropping one of those would send a working node
+   * back to its private address, unreachable in the deployment client routes exist for. A
+   * carried-over record outlives the bad row for as long as it stays bad; the per-row {@code WARN}
+   * is the signal that it has.
+   */
+  @NonNull
+  private static Map<UUID, ClientRouteRecord> withRetainedCachedRoutes(
+      @NonNull Map<UUID, ClientRouteRecord> cachedRoutes,
+      @NonNull Map<UUID, ClientRouteRecord> newRoutes,
+      @NonNull Set<UUID> keepableHostIds) {
+    if (cachedRoutes.isEmpty()) {
+      return newRoutes;
+    }
+    Map<UUID, ClientRouteRecord> merged = new HashMap<>(newRoutes);
+    for (Map.Entry<UUID, ClientRouteRecord> entry : cachedRoutes.entrySet()) {
+      if (keepableHostIds.contains(entry.getKey())) {
+        // A host with both a usable and an unusable row keeps the usable one.
+        merged.putIfAbsent(entry.getKey(), entry.getValue());
+      }
+    }
+    return merged;
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -685,6 +685,13 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * private address, unreachable in the deployment client routes exist for and permanent until the
    * table changes, whereas a route kept one refresh too long fails fast on connect. So the whole
    * cache is keepable, and the next clean refresh evicts.
+   *
+   * <p>In that last case the cached keys are not the whole answer, because the two readers of this
+   * set do not read it the same way. {@link #withRetainedCachedRoutes} starts from the routes the
+   * pass rebuilt and takes this set as what to <em>add</em>; the targeted sweep takes it as the
+   * complete keep-list and removes every event host ID outside it. A host this pass rebuilt is
+   * present by construction, so it is unioned in -- without that, a route merged moments earlier is
+   * swept straight back out whenever the cache did not already hold it.
    */
   @NonNull
   private Set<UUID> keepableHostIds(
@@ -725,7 +732,9 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
           unattributableRows,
           rowCount);
     }
-    return cachedRoutes.keySet();
+    Set<UUID> keepable = new HashSet<>(cachedRoutes.keySet());
+    keepable.addAll(newRoutes.keySet());
+    return keepable;
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
@@ -78,27 +78,35 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    */
   private static final int MAX_CONSECUTIVE_EMPTY_RESULTS = 3;
 
+  /**
+   * Consecutive refreshes that may carry a host's cached route over, unconfirmed, before the driver
+   * says so at {@code ERROR}. Deliberately a reporting threshold and not an eviction one: the row
+   * came back, so the route still exists and dropping it would strand the node on an address that
+   * does not work here. Matches {@link #MAX_CONSECUTIVE_EMPTY_RESULTS} so the two backstops read
+   * alike.
+   */
+  private static final int CARRY_OVERS_BEFORE_ESCALATION = 3;
+
   private final ClientRoutesConfig config;
   private final List<String> configuredConnectionIds;
   private final Map<String, String> connectionAddrOverrides;
 
-  /**
-   * Whether a cached route's {@code host_id} identifies the table row it was built from. {@code
-   * system.client_routes} is keyed on {@code (connection_id, host_id)} while this cache is keyed on
-   * {@code host_id} alone, so the two coincide only while a single connection ID can produce rows
-   * for a given host. Where several can, a cached entry and a returned row for the same host need
-   * not be the same route (see #1063), and a refresh keeps only the routes it rebuilt.
-   *
-   * <p>This is a statement about the <em>configured</em> connection IDs, so it holds only because
-   * {@link #allowedConnectionIds} keeps every query's scope inside them. Drop that filter and a
-   * server event can steer a pass at a connection ID this driver never configured, whose rows say
-   * nothing about the routes cached under ours -- at which point carrying a cached route over
-   * because some row named its host is no longer sound.
-   */
-  private final boolean hostIdIdentifiesRoute;
-
   private final String logPrefix;
   private final AtomicReference<Map<UUID, ClientRouteRecord>> resolvedRoutesCache;
+
+  /**
+   * Per host, how many consecutive refreshes returned rows but could not rebuild that host's route,
+   * leaving the cached record in place. Reset the moment a pass rebuilds the route, and dropped
+   * entirely once the host leaves the cache, so this map never outgrows it.
+   *
+   * <p>Refreshes that returned no rows at all are not counted: that is the eventual-consistency
+   * race {@link #consecutiveEmptyResults} already tracks, and it clears the cache on its own.
+   * Counted here is the other thing -- the server keeps returning a row this driver cannot read --
+   * which nothing evicts and which therefore has to be said out loud instead.
+   */
+  private final AtomicReference<Map<UUID, Integer>> carryOverCounts =
+      new AtomicReference<>(Collections.emptyMap());
+
   private final boolean useSSL;
   private volatile boolean closed = false;
   private final AtomicInteger consecutiveEmptyResults = new AtomicInteger(0);
@@ -162,7 +170,6 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                     Collectors.toMap(
                         ClientRouteProxy::getConnectionId,
                         ClientRouteProxy::getConnectionAddrOverride)));
-    this.hostIdIdentifiesRoute = new HashSet<>(configuredConnectionIds).size() == 1;
     this.logPrefix = context.getSessionName();
     this.resolvedRoutesCache = new AtomicReference<>(Collections.emptyMap());
     this.useSSL = context.getSslEngineFactory().isPresent();
@@ -393,6 +400,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                   // it does hold would drop a working route back to the node's unreachable
                   // private address, which is why every reason a host is not provably absent
                   // lives in that one set rather than in a condition here.
+                  Set<UUID> queriedHostIds = new HashSet<>();
                   for (String hostIdStr : eventHostIds) {
                     UUID hostId;
                     try {
@@ -405,10 +413,12 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                           e);
                       continue;
                     }
+                    queriedHostIds.add(hostId);
                     if (!keepableHostIds.contains(hostId)) {
                       removeRoute(hostId);
                     }
                   }
+                  recordCarryOvers(resolvedRoutesCache.get(), newRoutes, queriedHostIds);
                   LOG.debug(
                       "[{}] Merged {} client routes (targeted refresh)",
                       logPrefix,
@@ -440,11 +450,18 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
                   }
                 } else {
                   // Rows came back, so this is not the eventual-consistency race the counter
-                  // above tracks, whatever else was wrong with them.
+                  // above tracks, whatever else was wrong with them. That race returns zero rows;
+                  // keying the guard on newRoutes.isEmpty() instead, as this did before row-level
+                  // tolerance, let a pass whose rows all failed to parse count as empty and clear
+                  // the cache on the third one -- while logging that the query had returned no
+                  // rows, which was untrue. Unusable rows are carried over and reported instead.
                   consecutiveEmptyResults.set(0);
                   Map<UUID, ClientRouteRecord> updated =
                       withRetainedCachedRoutes(cachedRoutes, newRoutes, keepableHostIds);
                   resolvedRoutesCache.set(Collections.unmodifiableMap(updated));
+                  // A full refresh asked about every host, so anything it did not rebuild was in
+                  // scope and genuinely went unconfirmed.
+                  recordCarryOvers(updated, newRoutes, null);
                   LOG.debug(
                       "[{}] Updated client routes: {} routes loaded"
                           + " ({} kept from the previous refresh)",
@@ -567,8 +584,8 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * <p>Two things go wrong when they do. A usable row for an unconfigured connection installs a
    * route through a proxy this client is not configured to use, addressed as that proxy's clients
    * address it. An unusable one is read as evidence about a host whose cached route was built from
-   * a different connection's row, which is what {@link #hostIdIdentifiesRoute} assumes cannot
-   * happen. Both are the same mistake: a row is only evidence about the connection it belongs to.
+   * a different connection's row entirely. Both are the same mistake: a row is only evidence about
+   * the connection it belongs to.
    *
    * <p>Empty IDs are dropped as well. {@link ClientRouteProxy} rejects a blank connection ID, so
    * one can never match, and leaving it in would only widen the {@code IN} list.
@@ -708,20 +725,11 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * server deleted the host, so the whole eviction rule lives here rather than in a condition at
    * each of them.
    *
-   * <p>Three cases, least carry-over first.
-   *
-   * <p>Where {@code host_id} is not the whole route identity ({@link #hostIdIdentifiesRoute})
-   * nothing is carried over. Keeping a cached route asks whether <em>that route's</em> row came
-   * back unusable, and a set of host IDs cannot answer a question about one {@code (connection_id,
-   * host_id)} row: the cached entry and the row that failed need not be the same route. Keeping it
-   * anyway would preserve a route the server deleted for as long as some other connection's row
-   * stayed unusable, and no non-empty refresh would ever reset that. So the refresh keeps only what
-   * it rebuilt, as it did before row-level tolerance existed. See #1063, which corrects the cache
-   * key itself; retention by the full key falls out of that fix.
-   *
-   * <p>Otherwise a row that came back and merely failed to parse is not an absent row, so every
-   * host ID the loop read is keepable: the refresh replaces the routes it could rebuild and leaves
-   * the rest alone.
+   * <p>A row that came back and merely failed to parse is not an absent row: the server still holds
+   * a route for that host, this pass just could not read its current value. So every host ID the
+   * loop read is keepable -- the refresh replaces the routes it could rebuild and leaves the rest
+   * alone. A deletion shows up as an <em>absent</em> row, never as an unusable one, and that case
+   * still evicts.
    *
    * <p>Unless the loop could not attribute some row to any host at all, which destroys that
    * evidence for the whole refresh -- the unattributable row may have been the very host now
@@ -730,12 +738,19 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * table changes, whereas a route kept one refresh too long fails fast on connect. So the whole
    * cache is keepable, and the next clean refresh evicts.
    *
-   * <p>In that last case the cached keys are not the whole answer, because the two readers of this
-   * set do not read it the same way. {@link #withRetainedCachedRoutes} starts from the routes the
-   * pass rebuilt and takes this set as what to <em>add</em>; the targeted sweep takes it as the
-   * complete keep-list and removes every event host ID outside it. A host this pass rebuilt is
-   * present by construction, so it is unioned in -- without that, a route merged moments earlier is
-   * swept straight back out whenever the cache did not already hold it.
+   * <p>Either way the hosts this pass rebuilt are unioned in, because the two readers of this set
+   * do not read it the same way. {@link #withRetainedCachedRoutes} starts from the routes the pass
+   * rebuilt and takes this set as what to <em>add</em>; the targeted sweep takes it as the complete
+   * keep-list and removes every event host ID outside it. Without the union a route merged moments
+   * earlier is swept straight back out whenever the cache did not already hold it.
+   *
+   * <p>The rule does not vary with the number of configured connection IDs. It once did: where
+   * {@code (connection_id, host_id)} can name several rows for one host, a cached entry and the row
+   * that failed need not be the same route, so the refresh kept only what it rebuilt. That traded a
+   * bounded staleness for an unbounded outage -- a route dropped on no evidence falls back to an
+   * unreachable private address -- and it let a pass whose every row was unusable empty the cache
+   * outright. The ambiguity is real, but it belongs to the cache key (#1063), not to retention;
+   * {@link #carryOverCounts} is what keeps the staleness visible until then.
    */
   @NonNull
   private Set<UUID> keepableHostIds(
@@ -744,52 +759,96 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
       @NonNull Map<UUID, ClientRouteRecord> cachedRoutes,
       int unattributableRows,
       int rowCount) {
-    if (!hostIdIdentifiesRoute) {
-      // Only a pass that failed on some row can drop a route it had no evidence about; a host
-      // missing from a clean result really was deleted, and saying so here would be wrong.
-      boolean someRowUnusable = unattributableRows > 0 || hostIdsInResult.size() > newRoutes.size();
-      int droppedRoutes = 0;
-      if (someRowUnusable) {
-        for (UUID cachedHostId : cachedRoutes.keySet()) {
-          if (!newRoutes.containsKey(cachedHostId)) {
-            droppedRoutes++;
-          }
-        }
-      }
-      if (droppedRoutes > 0) {
-        LOG.warn(
-            "[{}] Dropping the cached route for {} host(s) this refresh could not rebuild"
-                + " ({} row(s) named no host_id at all): with {} connection IDs configured a cached"
-                + " route cannot be told from another connection's, so keeping it could preserve a"
-                + " route the server has deleted",
-            logPrefix,
-            droppedRoutes,
-            unattributableRows,
-            configuredConnectionIds.size());
-      }
-      return newRoutes.keySet();
-    }
+    Set<UUID> keepable;
     if (unattributableRows == 0) {
-      return hostIdsInResult;
-    }
-    if (hostIdsInResult.isEmpty()) {
-      LOG.error(
-          "[{}] None of the {} client_routes rows named a readable host_id; "
-              + "keeping all {} existing cached routes",
-          logPrefix,
-          rowCount,
-          cachedRoutes.size());
+      keepable = new HashSet<>(hostIdsInResult);
     } else {
-      LOG.warn(
-          "[{}] {} of {} client_routes rows named no readable host_id; keeping the "
-              + "cached routes this refresh cannot prove deleted",
-          logPrefix,
-          unattributableRows,
-          rowCount);
+      if (hostIdsInResult.isEmpty()) {
+        LOG.error(
+            "[{}] None of the {} client_routes rows named a readable host_id; "
+                + "keeping all {} existing cached routes",
+            logPrefix,
+            rowCount,
+            cachedRoutes.size());
+      } else {
+        LOG.warn(
+            "[{}] {} of {} client_routes rows named no readable host_id; keeping the "
+                + "cached routes this refresh cannot prove deleted",
+            logPrefix,
+            unattributableRows,
+            rowCount);
+      }
+      keepable = new HashSet<>(cachedRoutes.keySet());
     }
-    Set<UUID> keepable = new HashSet<>(cachedRoutes.keySet());
     keepable.addAll(newRoutes.keySet());
     return keepable;
+  }
+
+  /**
+   * Advances the unconfirmed-carry-over count for every cached host this pass had in scope but
+   * could not rebuild, resets it for the ones it did, and forgets every host that is no longer
+   * cached. Then, for any host that has now gone unconfirmed {@value
+   * #CARRY_OVERS_BEFORE_ESCALATION} times or more, says so once at {@code ERROR}.
+   *
+   * <p>Nothing is evicted here, by design. The rows came back; the server still holds a route for
+   * these hosts and this driver simply cannot read it, so the cached value remains the best answer
+   * available and dropping it would send a working node to an address that does not work in the
+   * deployment client routes exist for. What retention cannot do is stay quiet about it, since the
+   * per-row {@code WARN} says a row was unusable but never that a route is still being served on
+   * the strength of an older one.
+   *
+   * @param installedRoutes the cache as this pass left it; hosts outside it are forgotten.
+   * @param newRoutes the routes this pass rebuilt; these are the confirmed ones.
+   * @param queriedHostIds the hosts this pass actually asked about, or {@code null} for a full
+   *     refresh, which asked about all of them. A targeted refresh learns nothing about a host
+   *     outside its scope, so such a host keeps its count rather than advancing it.
+   */
+  private void recordCarryOvers(
+      @NonNull Map<UUID, ClientRouteRecord> installedRoutes,
+      @NonNull Map<UUID, ClientRouteRecord> newRoutes,
+      @Nullable Set<UUID> queriedHostIds) {
+    Map<UUID, Integer> previous = carryOverCounts.get();
+    Map<UUID, Integer> current = new HashMap<>();
+    for (UUID hostId : installedRoutes.keySet()) {
+      if (newRoutes.containsKey(hostId)) {
+        continue;
+      }
+      if (queriedHostIds != null && !queriedHostIds.contains(hostId)) {
+        Integer carried = previous.get(hostId);
+        if (carried != null) {
+          current.put(hostId, carried);
+        }
+        continue;
+      }
+      Integer carried = previous.get(hostId);
+      current.put(hostId, (carried == null ? 0 : carried) + 1);
+    }
+    carryOverCounts.set(Collections.unmodifiableMap(current));
+
+    List<UUID> unconfirmed = new ArrayList<>();
+    for (Map.Entry<UUID, Integer> entry : current.entrySet()) {
+      if (entry.getValue() >= CARRY_OVERS_BEFORE_ESCALATION) {
+        unconfirmed.add(entry.getKey());
+      }
+    }
+    if (!unconfirmed.isEmpty()) {
+      Collections.sort(unconfirmed);
+      LOG.error(
+          "[{}] Serving {} client route(s) that the last {} refreshes could not confirm: {}. "
+              + "system.client_routes still returns a row for each, so the cached route is kept "
+              + "rather than dropped to the node's fallback address, but its value may be stale -- "
+              + "check those rows for an unreadable address or port",
+          logPrefix,
+          unconfirmed.size(),
+          CARRY_OVERS_BEFORE_ESCALATION,
+          unconfirmed);
+    }
+  }
+
+  /** The per-host unconfirmed-carry-over counts, for tests: this class asserts no log output. */
+  @VisibleForTesting
+  Map<UUID, Integer> getCarryOverCounts() {
+    return carryOverCounts.get();
   }
 
   /**
@@ -800,8 +859,13 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    * deleted server-side. {@link #keepableHostIds} is the exception list -- the hosts this refresh
    * cannot show the server to have deleted -- and dropping one of those would send a working node
    * back to its private address, unreachable in the deployment client routes exist for. A
-   * carried-over record outlives the bad row for as long as it stays bad; the per-row {@code WARN}
-   * is the signal that it has.
+   * carried-over record outlives the bad row for as long as it stays bad -- indefinitely, if the
+   * row never becomes readable, because no non-empty refresh resets {@link
+   * #consecutiveEmptyResults}. That is the intended side of the trade rather than an oversight: an
+   * unusable row is evidence the route <em>exists</em>, since a deleted route is absent instead,
+   * and absence still evicts. Keeping a value that may be stale costs a connection attempt that
+   * fails fast; dropping one that was fine costs the node its only reachable address until the
+   * table changes. {@link #recordCarryOvers} is what stops the difference being invisible.
    */
   @NonNull
   private static Map<UUID, ClientRouteRecord> withRetainedCachedRoutes(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -1714,7 +1714,7 @@ public class ClientRoutesTopologyMonitorTest {
     // Scylla broadcasts every changed key, so an event names other clients' proxies too. Those
     // IDs used to become the query's scope verbatim, which reads another client's routes and
     // caches them under our host IDs -- and makes rows arrive that say nothing about the routes
-    // cached under our own connection, which is what hostIdIdentifiesRoute assumes cannot happen.
+    // cached under our own connection, which no row from an unconfigured proxy can speak to.
     // The scope narrows to the event's configured IDs: conn-1 only, not conn-2 as a fallback
     // would give, and never the unconfigured one.
     String connId1 = "conn-1";
@@ -1895,16 +1895,16 @@ public class ClientRoutesTopologyMonitorTest {
   }
 
   @Test
-  public void should_not_keep_cached_route_for_unusable_row_with_several_connection_ids()
+  public void should_keep_cached_route_for_unusable_row_with_several_connection_ids()
       throws Exception {
     // system.client_routes is keyed (connection_id, host_id) while the cache is keyed on host_id
     // alone, so with two connection IDs configured "the cached entry for this host" and "the row
-    // for this host that failed" need not be the same route. Here conn-1's row is gone -- the
-    // route the cache holds was deleted server-side -- and only conn-2's unusable row comes back.
-    // Carrying the entry over would keep the deleted route for as long as conn-2's row stayed
-    // unusable, and no non-empty refresh resets that, so nothing is carried over.
-    // should_keep_cached_route_for_unusable_row_on_full_refresh is the one-connection-ID case,
-    // where absence from the result really does mean the route is gone.
+    // for this host that failed" need not be the same route. That ambiguity is real, but it
+    // belongs to the cache key (#1063) and is not a reason to evict: the row came back, so a route
+    // for this host still exists, and dropping the cached one would strand the node on an address
+    // that does not work in the deployment client routes exist for. The rule is therefore the same
+    // as should_keep_cached_route_for_unusable_row_on_full_refresh, whatever the connection-ID
+    // count; recordCarryOvers is what stops the staleness being silent.
     String connId1 = "conn-1";
     String connId2 = "conn-2";
     ClientRoutesConfig config =
@@ -1924,17 +1924,20 @@ public class ClientRoutesTopologyMonitorTest {
 
     h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    assertThat(h.getRoutes()).isEmpty();
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("nlb1.example.com");
+    assertThat(h.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+    assertThat(h.getCarryOverCounts()).containsEntry(hostId, 1);
   }
 
   @Test
-  public void should_evict_targeted_host_with_unusable_row_with_several_connection_ids()
+  public void should_keep_targeted_host_with_unusable_row_with_several_connection_ids()
       throws Exception {
-    // The same rule on the other cache writer. The removal sweep reads a host ID the event named
-    // but the refresh cannot keep as a server-side delete, and with several connection IDs a row
-    // that came back unusable is no longer a reason to keep the host: it may be a different
-    // route's row than the one cached. should_keep_cached_route_when_targeted_refresh_returns
-    // _unusable_row is the one-connection-ID counterweight.
+    // The same rule on the other cache writer. The removal sweep evicts a host ID the event named
+    // only when the refresh can prove the server deleted it, and an unusable row proves the
+    // opposite -- the row exists. So the host stays, exactly as in
+    // should_keep_cached_route_when_targeted_refresh_returns_unusable_row, and the connection-ID
+    // count does not enter into it.
     String connId1 = "conn-1";
     String connId2 = "conn-2";
     ClientRoutesConfig config =
@@ -1963,17 +1966,18 @@ public class ClientRoutesTopologyMonitorTest {
             Collections.singletonList(connId2),
             Collections.singletonList(hostId.toString())));
 
-    assertThat(h.getRoutes()).isEmpty();
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("nlb1.example.com");
   }
 
   @Test
-  public void should_not_keep_cached_routes_for_unreadable_host_id_with_several_connection_ids()
+  public void should_keep_cached_routes_for_unreadable_host_id_with_several_connection_ids()
       throws Exception {
     // A row whose host_id the driver cannot read makes absence from the result stop being proof of
-    // a delete, so with one connection ID the whole cache is kept -- see
-    // should_keep_all_cached_routes_when_no_row_names_a_readable_host_id. That rests on the same
-    // identity assumption as every other carry-over and goes the same way when it fails: keeping
-    // routes the refresh cannot attribute would keep deleted ones among them, indefinitely.
+    // a delete, so the whole cache is kept -- see
+    // should_keep_all_cached_routes_when_no_row_names_a_readable_host_id, which is the same
+    // assertion with one connection ID. This pass learned nothing at all about which hosts exist,
+    // and evicting on no evidence is what the rule forbids.
     String connId1 = "conn-1";
     String connId2 = "conn-2";
     ClientRoutesConfig config =
@@ -1999,6 +2003,136 @@ public class ClientRoutesTopologyMonitorTest {
 
     h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    assertThat(h.getRoutes()).isEmpty();
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId1, hostId2);
+  }
+
+  // ---- unconfirmed carry-over bookkeeping -------------------------------
+
+  @Test
+  public void should_keep_a_cached_route_for_a_permanently_unusable_row() throws Exception {
+    // Retention is deliberately unbounded. The row keeps coming back, so the server still holds a
+    // route for this host and the driver simply cannot read its current value; the cached one
+    // stays the best answer available. Evicting after N passes would trade a stale route that
+    // fails fast on connect for a node stranded on its private address, unreachable here and
+    // permanent until the table changes. What the count buys is the ERROR at
+    // CARRY_OVERS_BEFORE_ESCALATION, so this is reported rather than silently served.
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(mockRouteRow(hostId, null, 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    for (int i = 0; i < 4; i++) {
+      handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    }
+
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.1");
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+    // Past the threshold, so the escalation path ran on the last two passes.
+    assertThat(handler.getCarryOverCounts()).containsEntry(hostId, 4);
+  }
+
+  @Test
+  public void should_reset_the_carry_over_count_when_a_route_is_rebuilt() throws Exception {
+    // A rebuilt route is a confirmed route: the count has to start again, or a host that goes
+    // unreadable once every few refreshes would eventually be reported as permanently unconfirmed.
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(mockRouteRow(hostId, null, 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    assertThat(handler.getCarryOverCounts()).containsEntry(hostId, 2);
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "127.0.0.9", 9043)));
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getCarryOverCounts()).doesNotContainKey(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.9");
+  }
+
+  @Test
+  public void should_forget_the_carry_over_count_for_an_evicted_host() throws Exception {
+    // The count map is keyed by host and must never outgrow the cache it annotates, so a host the
+    // refresh evicts has to take its entry with it.
+    UUID carriedHostId = UUID.randomUUID();
+    UUID freshHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(carriedHostId, new ClientRouteRecord(carriedHostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(carriedHostId, null, 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    assertThat(handler.getCarryOverCounts()).containsEntry(carriedHostId, 1);
+
+    // A clean pass that does not mention the host at all: absent, therefore provably deleted.
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(freshHostId, "127.0.0.3", 9044)));
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(freshHostId);
+    assertThat(handler.getCarryOverCounts()).isEmpty();
+  }
+
+  @Test
+  public void should_not_count_a_carry_over_for_a_host_outside_a_targeted_refresh()
+      throws Exception {
+    // A targeted refresh only asks about the hosts the event named. Not rebuilding one it never
+    // queried says nothing about that host, so its count must not advance -- otherwise a busy
+    // stream of targeted events would report every untouched route as unconfirmed.
+    UUID queriedHostId = UUID.randomUUID();
+    UUID untouchedHostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(
+        ImmutableMap.of(
+            queriedHostId, new ClientRouteRecord(queriedHostId, "127.0.0.1", 9042),
+            untouchedHostId, new ClientRouteRecord(untouchedHostId, "127.0.0.2", 9042)));
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(queriedHostId, null, 9042)));
+
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(queriedHostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(queriedHostId, untouchedHostId);
+    assertThat(handler.getCarryOverCounts()).containsEntry(queriedHostId, 1);
+    assertThat(handler.getCarryOverCounts()).doesNotContainKey(untouchedHostId);
+  }
+
+  @Test
+  public void should_not_let_an_unusable_pass_advance_the_consecutive_empty_guard()
+      throws Exception {
+    // The consecutive-empty guard exists for the eventual-consistency race, which returns zero
+    // rows. Before row-level tolerance the guard keyed on newRoutes.isEmpty(), so a pass whose
+    // rows all failed to parse counted as empty and cleared the cache on the third one -- while
+    // logging that the query had returned no rows, which was untrue. Keying it on rowCount keeps
+    // the counter for the race it was written for: rows that came back and could not be read are
+    // carried over and reported instead, and they reset the counter like any other non-empty pass.
+    UUID hostId = UUID.randomUUID();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult());
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    // Third pass returns a row, so it is not an empty result however unusable it turns out to be.
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(mockRouteRow(hostId, null, 9042)));
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult());
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -40,6 +40,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.MalformedInputException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -161,6 +162,33 @@ public class ClientRoutesTopologyMonitorTest {
     when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
     handler.init();
+  }
+
+  /**
+   * Mocks a {@code system.client_routes} row. Stubs are lenient because callers use only the
+   * columns their scenario reaches, and the class runs under the strict {@link MockitoJUnitRunner}.
+   * A null {@code hostId} or {@code address} makes the corresponding {@code isNull()} answer true;
+   * a null {@code port} makes {@code portColumn} absent; a null {@code connectionId} makes {@code
+   * contains("connection_id")} answer false.
+   */
+  private static AdminRow mockRouteRow(
+      UUID hostId, String address, String portColumn, Integer port, String connectionId) {
+    AdminRow row = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(row.isNull("host_id")).thenReturn(hostId == null);
+    Mockito.lenient().when(row.getUuid("host_id")).thenReturn(hostId);
+    Mockito.lenient().when(row.isNull("address")).thenReturn(address == null);
+    Mockito.lenient().when(row.getString("address")).thenReturn(address);
+    Mockito.lenient().when(row.isNull(portColumn)).thenReturn(port == null);
+    Mockito.lenient().when(row.getInteger(portColumn)).thenReturn(port);
+    Mockito.lenient().when(row.contains("connection_id")).thenReturn(connectionId != null);
+    Mockito.lenient().when(row.isNull("connection_id")).thenReturn(connectionId == null);
+    Mockito.lenient().when(row.getString("connection_id")).thenReturn(connectionId);
+    return row;
+  }
+
+  /** Shorthand for the non-SSL case with no {@code connection_id}. */
+  private static AdminRow mockRouteRow(UUID hostId, String address, Integer port) {
+    return mockRouteRow(hostId, address, "port", port, null);
   }
 
   // ---- resolve() -------------------------------------------------------
@@ -710,10 +738,16 @@ public class ClientRoutesTopologyMonitorTest {
     UUID hostId = UUID.randomUUID();
     AdminRow row = Mockito.mock(AdminRow.class);
     when(row.isNull("host_id")).thenReturn(false);
-    when(row.isNull("address")).thenReturn(false);
+    // The address column is populated deliberately -- this test means "the override beats a
+    // populated column", not "the override fills in for a missing one". effectiveAddress
+    // short-circuits the column once an override matches, so these stubs go unread; they are
+    // lenient rather than deleted, because deleting them would weaken the test to the latter
+    // claim. should_apply_override_when_table_address_cell_is_malformed pins the short-circuit
+    // itself.
+    Mockito.lenient().when(row.isNull("address")).thenReturn(false);
     when(row.isNull("port")).thenReturn(false);
     when(row.getUuid("host_id")).thenReturn(hostId);
-    when(row.getString("address")).thenReturn("original.example.com");
+    Mockito.lenient().when(row.getString("address")).thenReturn("original.example.com");
     when(row.getInteger("port")).thenReturn(9042);
     when(row.contains("connection_id")).thenReturn(true);
     when(row.isNull("connection_id")).thenReturn(false);
@@ -801,10 +835,12 @@ public class ClientRoutesTopologyMonitorTest {
     UUID hostId1 = UUID.randomUUID();
     AdminRow matchingRow = Mockito.mock(AdminRow.class);
     when(matchingRow.isNull("host_id")).thenReturn(false);
-    when(matchingRow.isNull("address")).thenReturn(false);
+    // Address stubs lenient for the reason given in
+    // should_apply_connection_addr_override_when_connection_id_matches.
+    Mockito.lenient().when(matchingRow.isNull("address")).thenReturn(false);
     when(matchingRow.isNull("port")).thenReturn(false);
     when(matchingRow.getUuid("host_id")).thenReturn(hostId1);
-    when(matchingRow.getString("address")).thenReturn("original-1.example.com");
+    Mockito.lenient().when(matchingRow.getString("address")).thenReturn("original-1.example.com");
     when(matchingRow.getInteger("port")).thenReturn(9042);
     when(matchingRow.contains("connection_id")).thenReturn(true);
     when(matchingRow.isNull("connection_id")).thenReturn(false);
@@ -964,6 +1000,413 @@ public class ClientRoutesTopologyMonitorTest {
 
     // port is null → route must be skipped
     assertThat(handler.getRoutes()).doesNotContainKey(hostId);
+  }
+
+  @Test
+  public void should_skip_zero_port_row_without_losing_the_refresh() throws Exception {
+    // Port 0 passes the null check, but ClientRouteRecord's constructor rejects it. Unguarded,
+    // that IllegalArgumentException escapes the row loop and the whole refresh is discarded, so
+    // the assertion that matters is that the good row survives.
+    UUID badHostId = UUID.randomUUID();
+    UUID goodHostId = UUID.randomUUID();
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(badHostId, "127.0.0.1", 0), mockRouteRow(goodHostId, "127.0.0.2", 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(goodHostId);
+    assertThat(handler.getRoutes().get(goodHostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_skip_empty_address_row_without_losing_the_refresh() throws Exception {
+    // The sibling of the zero-port case: isNull("address") is false for an empty string, and
+    // ClientRouteRecord's constructor rejects it from inside the row loop. No override is
+    // configured for this row, so the empty address is also the effective one.
+    UUID badHostId = UUID.randomUUID();
+    UUID goodHostId = UUID.randomUUID();
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(badHostId, "", 9042), mockRouteRow(goodHostId, "127.0.0.2", 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(goodHostId);
+    assertThat(handler.getRoutes().get(goodHostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_cache_route_when_override_replaces_empty_address() throws Exception {
+    // An empty address column is only unusable if nothing replaces it. ClientRouteProxy documents
+    // the configured address as overriding the table's, and forbids a blank override, so the
+    // effective address here is always valid -- validating before the override would drop a row
+    // that is perfectly routable.
+    String connId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    h.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "", "port", 9042, connId)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("override.example.com");
+  }
+
+  @Test
+  public void should_skip_row_when_host_id_cell_is_malformed() throws Exception {
+    // A non-null host_id blob of the wrong length makes UuidCodec.decode throw before any column
+    // guard can inspect the value. Nothing about that exception is specific to the columns the
+    // loop validates, so only a general per-row catch keeps the rest of the batch.
+    UUID goodHostId = UUID.randomUUID();
+
+    AdminRow badRow = mockRouteRow(UUID.randomUUID(), "127.0.0.1", 9042);
+    Mockito.doThrow(
+            new IllegalArgumentException(
+                "Unexpected number of bytes for a UUID, expected 16, got 4"))
+        .when(badRow)
+        .getUuid("host_id");
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(badRow, mockRouteRow(goodHostId, "127.0.0.2", 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(goodHostId);
+  }
+
+  @Test
+  public void should_skip_row_when_tls_port_is_out_of_range() throws Exception {
+    when(context.getSslEngineFactory())
+        .thenReturn(
+            Optional.of(Mockito.mock(com.datastax.oss.driver.api.core.ssl.SslEngineFactory.class)));
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(UUID.randomUUID().toString(), "host1"))
+            .build();
+    TestableClientRoutesTopologyMonitor sslHandler =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID badHostId = UUID.randomUUID();
+    UUID goodHostId = UUID.randomUUID();
+
+    sslHandler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(badHostId, "127.0.0.1", "tls_port", 0, null),
+            mockRouteRow(goodHostId, "127.0.0.2", "tls_port", 9142, null)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    sslHandler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(sslHandler.getRoutes()).containsOnlyKeys(goodHostId);
+    assertThat(sslHandler.getRoutes().get(goodHostId).getPort()).isEqualTo(9142);
+  }
+
+  @Test
+  public void should_keep_cached_route_when_targeted_refresh_returns_unusable_row()
+      throws Exception {
+    // A targeted refresh removes the host IDs the event named but the query did not return,
+    // reading their absence as a server-side delete. A row that came back and was skipped is not
+    // a delete: evicting it would drop a working route back to the node's private address, which
+    // is unreachable in the very deployment client routes exist for.
+    UUID hostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "127.0.0.2", 0)));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.1");
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_keep_route_named_by_an_unusable_row_but_evict_the_absent_one()
+      throws Exception {
+    // No usable row is not the same as no row: the consecutive-empty guard clears the cache after
+    // MAX_CONSECUTIVE_EMPTY_RESULTS (3) empty results, on the theory that the routes were removed
+    // server-side, and a table of malformed rows must not reach it. Keeping the *whole* cache is
+    // not the answer either -- a host the result never named is genuinely gone, whether or not the
+    // rows it did name were usable.
+    UUID namedHostId = UUID.randomUUID();
+    UUID absentHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(
+            namedHostId,
+            new ClientRouteRecord(namedHostId, "127.0.0.1", 9042),
+            absentHostId,
+            new ClientRouteRecord(absentHostId, "127.0.0.2", 9042)));
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(namedHostId, "127.0.0.3", 0)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    for (int i = 0; i < 4; i++) {
+      handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(namedHostId);
+    assertThat(handler.getRoutes().get(namedHostId).getHostname()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  public void should_keep_all_cached_routes_when_no_row_names_a_readable_host_id()
+      throws Exception {
+    // The extreme of the provable-absence rule: not a single row named a host_id the driver could
+    // read, so the pass learned nothing about which hosts still exist. It must evict nothing, and
+    // must not count towards the consecutive-empty guard either -- that would clear the cache on
+    // the third such pass and strand every node on its private address.
+    UUID cachedHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(cachedHostId, new ClientRouteRecord(cachedHostId, "127.0.0.1", 9042)));
+
+    AdminRow malformedRow = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(malformedRow.isNull("host_id")).thenReturn(false);
+    Mockito.doThrow(
+            new IllegalArgumentException(
+                "Unexpected number of bytes for a UUID, expected 16, got 4"))
+        .when(malformedRow)
+        .getUuid("host_id");
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(malformedRow, mockRouteRow(null, "127.0.0.2", 9042)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    for (int i = 0; i < 4; i++) {
+      handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(cachedHostId);
+    assertThat(handler.getRoutes().get(cachedHostId).getHostname()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  public void should_keep_cached_route_when_targeted_refresh_row_has_no_address() throws Exception {
+    // The sibling of the case above, for the one skip that used to happen before the row's
+    // host_id had been read: an absent address column. The host still has to count as present in
+    // the result, or the removal sweep reads it as a server-side delete.
+    UUID hostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(mockRouteRow(hostId, null, 9042)));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.1");
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_keep_cached_route_when_targeted_refresh_row_has_unreadable_host_id()
+      throws Exception {
+    // A row whose identity the driver cannot read is still a row: something came back for one of
+    // the host IDs this event named, and there is no telling which. So no event ID can be shown
+    // to be absent, and the removal sweep must evict nothing -- otherwise a single malformed
+    // host_id cell drops a working route back to the node's unreachable private address.
+    UUID hostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+
+    AdminRow unreadableRow = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(unreadableRow.isNull("host_id")).thenReturn(false);
+    Mockito.doThrow(
+            new IllegalArgumentException(
+                "Unexpected number of bytes for a UUID, expected 16, got 4"))
+        .when(unreadableRow)
+        .getUuid("host_id");
+
+    handler.setNextQueryResult(AdminResultTestHelper.mockResult(unreadableRow));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.1");
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9042);
+  }
+
+  @Test
+  public void should_keep_cached_route_absent_from_a_refresh_that_saw_an_unreadable_row()
+      throws Exception {
+    // The same rule on the full-refresh writer, in the mixed case: some rows were readable, so
+    // the presence set is non-empty -- but it is incomplete, because the unreadable row could
+    // have been absentHostId's. Absence from an incomplete set is not a delete, so B survives.
+    // should_keep_route_named_by_an_unusable_row_but_evict_the_absent_one is the counterweight:
+    // once every row names a readable host_id, the absent one does get evicted.
+    UUID goodHostId = UUID.randomUUID();
+    UUID absentHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(
+            goodHostId,
+            new ClientRouteRecord(goodHostId, "127.0.0.1", 9042),
+            absentHostId,
+            new ClientRouteRecord(absentHostId, "127.0.0.2", 9042)));
+
+    AdminRow unreadableRow = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(unreadableRow.isNull("host_id")).thenReturn(true);
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(goodHostId, "127.0.0.9", 9043), unreadableRow));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(goodHostId, absentHostId);
+    assertThat(handler.getRoutes().get(goodHostId).getHostname()).isEqualTo("127.0.0.9");
+    assertThat(handler.getRoutes().get(goodHostId).getPort()).isEqualTo(9043);
+    assertThat(handler.getRoutes().get(absentHostId).getHostname()).isEqualTo("127.0.0.2");
+  }
+
+  @Test
+  public void should_apply_override_when_table_address_cell_is_malformed() throws Exception {
+    // ClientRouteProxy documents connection_addr as replacing the table's address column outright
+    // for a matching connection_id, and does not qualify that on the column being decodable. The
+    // text codec rejects malformed UTF-8 with an IllegalArgumentException, so reading the column
+    // before resolving the override would let a cell the driver is about to discard cost the
+    // route. Sibling of should_cache_route_when_override_replaces_absent_address.
+    String connId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    AdminRow row = Mockito.mock(AdminRow.class);
+    when(row.isNull("host_id")).thenReturn(false);
+    when(row.getUuid("host_id")).thenReturn(hostId);
+    when(row.isNull("port")).thenReturn(false);
+    when(row.getInteger("port")).thenReturn(9042);
+    when(row.contains("connection_id")).thenReturn(true);
+    when(row.isNull("connection_id")).thenReturn(false);
+    when(row.getString("connection_id")).thenReturn(connId);
+    // Both stubs are lenient because a passing run never reaches them -- that is the assertion.
+    // The doThrow is the trap: if effectiveAddress read the column before resolving the override,
+    // it would fire, the row would be skipped, and the route below would be missing.
+    Mockito.lenient().when(row.isNull("address")).thenReturn(false);
+    Mockito.lenient()
+        .doThrow(new IllegalArgumentException(new MalformedInputException(1)))
+        .when(row)
+        .getString("address");
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(row));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("override.example.com");
+  }
+
+  @Test
+  public void should_keep_cached_route_for_unusable_row_on_full_refresh() throws Exception {
+    // A full refresh replaces the cache outright because a host missing from the result was
+    // deleted server-side. A host whose row came back unusable is not missing, and one good row
+    // in the same pass must not carry its eviction:
+    // should_replace_non_empty_cache_with_non_empty_query_result pins the other half of the rule.
+    // This holds because one connection ID is configured, so host_id is the whole route identity;
+    // the multi-endpoint tests at the end of this class pin what happens when it is not.
+    UUID unusableHostId = UUID.randomUUID();
+    UUID goodHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(unusableHostId, new ClientRouteRecord(unusableHostId, "127.0.0.1", 9042)));
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(unusableHostId, "127.0.0.2", 0),
+            mockRouteRow(goodHostId, "127.0.0.3", 9043)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(unusableHostId, goodHostId);
+    assertThat(handler.getRoutes().get(unusableHostId).getHostname()).isEqualTo("127.0.0.1");
+    assertThat(handler.getRoutes().get(unusableHostId).getPort()).isEqualTo(9042);
+    assertThat(handler.getRoutes().get(goodHostId).getPort()).isEqualTo(9043);
+  }
+
+  @Test
+  public void should_prefer_usable_row_over_cached_route_for_same_host() throws Exception {
+    // Carrying a cached record over for an unusable row must never shadow a usable row for the
+    // same host: system.client_routes is keyed (connection_id, host_id), so with several proxies
+    // one host_id can appear more than once in a single result.
+    UUID hostId = UUID.randomUUID();
+    UUID otherHostId = UUID.randomUUID();
+    handler.setRoutes(
+        ImmutableMap.of(
+            hostId,
+            new ClientRouteRecord(hostId, "127.0.0.1", 9042),
+            otherHostId,
+            new ClientRouteRecord(otherHostId, "127.0.0.2", 9042)));
+
+    // Two rows for hostId -- one usable, one not -- plus an unusable row for otherHostId, so the
+    // carry-over runs and has to leave the freshly-read record for hostId alone.
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(hostId, "127.0.0.9", 9042),
+            mockRouteRow(hostId, "", 9042),
+            mockRouteRow(otherHostId, "127.0.0.8", 0)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    handler.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId, otherHostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.9");
+    assertThat(handler.getRoutes().get(otherHostId).getHostname()).isEqualTo("127.0.0.2");
+  }
+
+  @Test
+  public void should_cache_route_when_override_replaces_absent_address() throws Exception {
+    // The sibling of should_cache_route_when_override_replaces_empty_address. ClientRouteProxy
+    // documents the configured address as replacing the table's column for a matching
+    // connection_id, without qualification, so an absent column and an empty one have to reach
+    // the same route -- the override is what the driver connects to either way.
+    String connId = "conn-1";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId, "override.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    h.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, null, "port", 9042, connId)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(h.getRoutes().get(hostId).getHostname()).isEqualTo("override.example.com");
+    assertThat(h.getRoutes().get(hostId).getPort()).isEqualTo(9042);
   }
 
   // ---- Empty-result cache guard tests ------------------------------------
@@ -1222,10 +1665,12 @@ public class ClientRoutesTopologyMonitorTest {
     UUID hostId1 = UUID.randomUUID();
     AdminRow row1 = Mockito.mock(AdminRow.class);
     when(row1.isNull("host_id")).thenReturn(false);
-    when(row1.isNull("address")).thenReturn(false);
+    // Address stubs lenient for the reason given in
+    // should_apply_connection_addr_override_when_connection_id_matches.
+    Mockito.lenient().when(row1.isNull("address")).thenReturn(false);
     when(row1.isNull("port")).thenReturn(false);
     when(row1.getUuid("host_id")).thenReturn(hostId1);
-    when(row1.getString("address")).thenReturn("10.0.0.1");
+    Mockito.lenient().when(row1.getString("address")).thenReturn("10.0.0.1");
     when(row1.getInteger("port")).thenReturn(9042);
     when(row1.contains("connection_id")).thenReturn(true);
     when(row1.isNull("connection_id")).thenReturn(false);
@@ -1234,10 +1679,10 @@ public class ClientRoutesTopologyMonitorTest {
     UUID hostId2 = UUID.randomUUID();
     AdminRow row2 = Mockito.mock(AdminRow.class);
     when(row2.isNull("host_id")).thenReturn(false);
-    when(row2.isNull("address")).thenReturn(false);
+    Mockito.lenient().when(row2.isNull("address")).thenReturn(false);
     when(row2.isNull("port")).thenReturn(false);
     when(row2.getUuid("host_id")).thenReturn(hostId2);
-    when(row2.getString("address")).thenReturn("10.0.0.2");
+    Mockito.lenient().when(row2.getString("address")).thenReturn("10.0.0.2");
     when(row2.getInteger("port")).thenReturn(9042);
     when(row2.contains("connection_id")).thenReturn(true);
     when(row2.isNull("connection_id")).thenReturn(false);
@@ -1273,10 +1718,12 @@ public class ClientRoutesTopologyMonitorTest {
 
     AdminRow row1 = Mockito.mock(AdminRow.class);
     when(row1.isNull("host_id")).thenReturn(false);
-    when(row1.isNull("address")).thenReturn(false);
+    // Address stubs lenient for the reason given in
+    // should_apply_connection_addr_override_when_connection_id_matches.
+    Mockito.lenient().when(row1.isNull("address")).thenReturn(false);
     when(row1.isNull("port")).thenReturn(false);
     when(row1.getUuid("host_id")).thenReturn(hostId1);
-    when(row1.getString("address")).thenReturn("10.0.0.1");
+    Mockito.lenient().when(row1.getString("address")).thenReturn("10.0.0.1");
     when(row1.getInteger("port")).thenReturn(9042);
     when(row1.contains("connection_id")).thenReturn(true);
     when(row1.isNull("connection_id")).thenReturn(false);
@@ -1284,10 +1731,10 @@ public class ClientRoutesTopologyMonitorTest {
 
     AdminRow row2 = Mockito.mock(AdminRow.class);
     when(row2.isNull("host_id")).thenReturn(false);
-    when(row2.isNull("address")).thenReturn(false);
+    Mockito.lenient().when(row2.isNull("address")).thenReturn(false);
     when(row2.isNull("port")).thenReturn(false);
     when(row2.getUuid("host_id")).thenReturn(hostId2);
-    when(row2.getString("address")).thenReturn("10.0.0.2");
+    Mockito.lenient().when(row2.getString("address")).thenReturn("10.0.0.2");
     when(row2.getInteger("port")).thenReturn(9043);
     when(row2.contains("connection_id")).thenReturn(true);
     when(row2.isNull("connection_id")).thenReturn(false);
@@ -1295,10 +1742,10 @@ public class ClientRoutesTopologyMonitorTest {
 
     AdminRow row3 = Mockito.mock(AdminRow.class);
     when(row3.isNull("host_id")).thenReturn(false);
-    when(row3.isNull("address")).thenReturn(false);
+    Mockito.lenient().when(row3.isNull("address")).thenReturn(false);
     when(row3.isNull("port")).thenReturn(false);
     when(row3.getUuid("host_id")).thenReturn(hostId3);
-    when(row3.getString("address")).thenReturn("10.0.0.3");
+    Mockito.lenient().when(row3.getString("address")).thenReturn("10.0.0.3");
     when(row3.getInteger("port")).thenReturn(9044);
     when(row3.contains("connection_id")).thenReturn(true);
     when(row3.isNull("connection_id")).thenReturn(false);
@@ -1324,5 +1771,113 @@ public class ClientRoutesTopologyMonitorTest {
         .contains("'" + connId1 + "'")
         .contains("'" + connId2 + "'")
         .contains("'" + connId3 + "'");
+  }
+
+  @Test
+  public void should_not_keep_cached_route_for_unusable_row_with_several_connection_ids()
+      throws Exception {
+    // system.client_routes is keyed (connection_id, host_id) while the cache is keyed on host_id
+    // alone, so with two connection IDs configured "the cached entry for this host" and "the row
+    // for this host that failed" need not be the same route. Here conn-1's row is gone -- the
+    // route the cache holds was deleted server-side -- and only conn-2's unusable row comes back.
+    // Carrying the entry over would keep the deleted route for as long as conn-2's row stayed
+    // unusable, and no non-empty refresh resets that, so nothing is carried over.
+    // should_keep_cached_route_for_unusable_row_on_full_refresh is the one-connection-ID case,
+    // where absence from the result really does mean the route is gone.
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId = UUID.randomUUID();
+    h.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "nlb1.example.com", 9042)));
+
+    h.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "10.0.0.1", "port", 0, connId2)));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).isEmpty();
+  }
+
+  @Test
+  public void should_evict_targeted_host_with_unusable_row_with_several_connection_ids()
+      throws Exception {
+    // The same rule on the other cache writer. The removal sweep reads a host ID the event named
+    // but the refresh cannot keep as a server-side delete, and with several connection IDs a row
+    // that came back unusable is no longer a reason to keep the host: it may be a different
+    // route's row than the one cached. should_keep_cached_route_when_targeted_refresh_returns
+    // _unusable_row is the one-connection-ID counterweight.
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    // init() before the seed: its own full refresh (against the default empty result) would
+    // otherwise run after it, and the empty-result guard would be the thing under test.
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    h.init();
+
+    UUID hostId = UUID.randomUUID();
+    h.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "nlb1.example.com", 9042)));
+    h.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "10.0.0.1", "port", 0, connId2)));
+
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connId2),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(h.getRoutes()).isEmpty();
+  }
+
+  @Test
+  public void should_not_keep_cached_routes_for_unreadable_host_id_with_several_connection_ids()
+      throws Exception {
+    // A row whose host_id the driver cannot read makes absence from the result stop being proof of
+    // a delete, so with one connection ID the whole cache is kept -- see
+    // should_keep_all_cached_routes_when_no_row_names_a_readable_host_id. That rests on the same
+    // identity assumption as every other carry-over and goes the same way when it fails: keeping
+    // routes the refresh cannot attribute would keep deleted ones among them, indefinitely.
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+
+    UUID hostId1 = UUID.randomUUID();
+    UUID hostId2 = UUID.randomUUID();
+    h.setRoutes(
+        ImmutableMap.of(
+            hostId1, new ClientRouteRecord(hostId1, "nlb1.example.com", 9042),
+            hostId2, new ClientRouteRecord(hostId2, "nlb2.example.com", 9042)));
+
+    AdminRow unreadableRow = Mockito.mock(AdminRow.class);
+    when(unreadableRow.isNull("host_id")).thenReturn(true);
+
+    h.setNextQueryResult(AdminResultTestHelper.mockResult(unreadableRow));
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+
+    h.refresh().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+    assertThat(h.getRoutes()).isEmpty();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -1710,6 +1710,67 @@ public class ClientRoutesTopologyMonitorTest {
   }
 
   @Test
+  public void should_query_only_the_configured_connection_ids_an_event_names() {
+    // Scylla broadcasts every changed key, so an event names other clients' proxies too. Those
+    // IDs used to become the query's scope verbatim, which reads another client's routes and
+    // caches them under our host IDs -- and makes rows arrive that say nothing about the routes
+    // cached under our own connection, which is what hostIdIdentifiesRoute assumes cannot happen.
+    // The scope narrows to the event's configured IDs: conn-1 only, not conn-2 as a fallback
+    // would give, and never the unconfigured one.
+    String connId1 = "conn-1";
+    String connId2 = "conn-2";
+    String unconfiguredConnId = "conn-unconfigured";
+    ClientRoutesConfig config =
+        ClientRoutesConfig.builder()
+            .addEndpoint(new ClientRouteProxy(connId1, "nlb1.example.com"))
+            .addEndpoint(new ClientRouteProxy(connId2, "nlb2.example.com"))
+            .build();
+    TestableClientRoutesTopologyMonitor h =
+        new TestableClientRoutesTopologyMonitor(context, config);
+    when(controlConnection.channel()).thenReturn(Mockito.mock(DriverChannel.class));
+    when(controlConnection.init(anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    h.init();
+
+    UUID hostId = UUID.randomUUID();
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            java.util.Arrays.asList(connId1, unconfiguredConnId),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(h.lastCapturedQuery())
+        .contains("'" + connId1 + "'")
+        .doesNotContain(unconfiguredConnId)
+        .doesNotContain("'" + connId2 + "'")
+        .contains("host_id IN (" + hostId + ")");
+  }
+
+  @Test
+  public void should_ignore_an_event_that_names_no_configured_connection_id() {
+    // An event naming connections, none of them ours, proves no route this session caches
+    // changed, so there is nothing to ask the server. Querying anyway was not merely wasted --
+    // scoped to a connection we do not serve it comes back empty, and the sweep then read that
+    // emptiness as a delete and evicted a working route. Distinct from an event naming no
+    // connection at all, which carries no scope and still falls back to the configured IDs
+    // (should_fall_back_to_configured_connection_ids_on_empty_change_event).
+    UUID hostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(ImmutableMap.of(hostId, new ClientRouteRecord(hostId, "127.0.0.1", 9042)));
+    int queriesBefore = handler.capturedQueries.size();
+
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList("conn-not-configured"),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(handler.capturedQueries).hasSize(queriesBefore);
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
   public void should_apply_correct_override_per_connection_id_with_multiple_endpoints()
       throws Exception {
     String connId1 = "conn-1";

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitorTest.java
@@ -1252,6 +1252,66 @@ public class ClientRoutesTopologyMonitorTest {
   }
 
   @Test
+  public void should_keep_rebuilt_route_when_a_row_had_an_unreadable_host_id_and_cache_was_empty()
+      throws Exception {
+    // Evicting nothing is only half the rule: the sweep reads the keep-set as the complete list
+    // of host IDs it may not remove, so the routes this pass just rebuilt have to be in it too.
+    // With an unattributable row in the pass the set is the cached keys, and an empty cache made
+    // that empty -- so hostId was merged by mergeRoutes and removed again by the sweep below it,
+    // in one pass. The pass that discovers a host is exactly the pass with no cache entry for it.
+    UUID hostId = UUID.randomUUID();
+    initHandler();
+    assertThat(handler.getRoutes()).isEmpty();
+
+    AdminRow unreadableRow = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(unreadableRow.isNull("host_id")).thenReturn(true);
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(mockRouteRow(hostId, "127.0.0.9", 9043), unreadableRow));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            Collections.singletonList(hostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(hostId);
+    assertThat(handler.getRoutes().get(hostId).getHostname()).isEqualTo("127.0.0.9");
+    assertThat(handler.getRoutes().get(hostId).getPort()).isEqualTo(9043);
+  }
+
+  @Test
+  public void should_keep_both_a_rebuilt_and_a_carried_over_route_when_a_row_was_unreadable()
+      throws Exception {
+    // The same defect without an empty cache: what decides it is whether the rebuilt host is
+    // already cached, not whether anything is. The cache holds only carriedHostId, so the keep-set
+    // was {carriedHostId} and the sweep removed the freshly rebuilt rebuiltHostId. Both belong:
+    // one because the pass rebuilt it, one because the unattributable row leaves its absence
+    // unproven.
+    UUID rebuiltHostId = UUID.randomUUID();
+    UUID carriedHostId = UUID.randomUUID();
+    initHandler();
+    handler.setRoutes(
+        ImmutableMap.of(carriedHostId, new ClientRouteRecord(carriedHostId, "127.0.0.1", 9042)));
+
+    AdminRow unreadableRow = Mockito.mock(AdminRow.class);
+    Mockito.lenient().when(unreadableRow.isNull("host_id")).thenReturn(true);
+
+    handler.setNextQueryResult(
+        AdminResultTestHelper.mockResult(
+            mockRouteRow(rebuiltHostId, "127.0.0.9", 9043), unreadableRow));
+    eventBus.fire(
+        new ClientRoutesUpdateEvent(
+            "UPDATED",
+            Collections.singletonList(connectionId),
+            java.util.Arrays.asList(rebuiltHostId.toString(), carriedHostId.toString())));
+
+    assertThat(handler.getRoutes()).containsOnlyKeys(rebuiltHostId, carriedHostId);
+    assertThat(handler.getRoutes().get(rebuiltHostId).getHostname()).isEqualTo("127.0.0.9");
+    assertThat(handler.getRoutes().get(rebuiltHostId).getPort()).isEqualTo(9043);
+    assertThat(handler.getRoutes().get(carriedHostId).getHostname()).isEqualTo("127.0.0.1");
+  }
+
+  @Test
   public void should_keep_cached_route_absent_from_a_refresh_that_saw_an_unreadable_row()
       throws Exception {
     // The same rule on the full-refresh writer, in the mixed case: some rows were readable, so


### PR DESCRIPTION
One unusable `system.client_routes` row took the whole refresh down: `ClientRouteRecord`'s constructor threw inside the row loop, discarding every route in that pass.

**Fixes**

- Catch per row, not at the two known throw sites: a malformed `host_id` or port cell costs one route, not the pass.
- Build the query inside that same `try`: a malformed `host_id` off the wire escaped holding the in-flight slot, stalling every later route refresh and the node-list refresh chained onto it (pre-existing since `2dea0bacb1`).
- Resolve the `connection_addr` override before the `address` column, so an empty, absent or undecodable column cannot defeat it.
- Drop an event naming no configured `connection_id` — Scylla broadcasts every changed key, so events routinely name other tenants' proxies and their rows drew our conclusions (same commit). Otherwise query *every* configured ID: a cached record names no connection, so absence is proof only once each has been asked.

**Changes, and what they cost**

- Evict only where the pass can **prove** a host absent. An unusable row is evidence the route exists — a deletion arrives as an *absent* row — so the cached record is kept, indefinitely if the row stays unreadable: dropping it strands the node on an unreachable private address, while a stale route fails fast. Rationale in `keepableHostIds`.
- Nothing evicts such a route, so count the passes carrying each over and report at `ERROR` from the third, with per-host counts.
- The empty-result counter keys on zero rows, not zero rebuilt routes, so unusable rows are reported, not counted as empty.

Verified: `mvn clean test -pl core` — 4233 tests, 0 failures; guards checked by mutation. Not covered: whether the server writes a permanently unusable row.

Filed, not fixed: #1063 (last-write-wins per `host_id`), #1064 (`address` never syntax-checked).

Part of the #890 split. Refs: #890

Fixes DRIVER-1060

