### PR TITLE
fix: tolerate unresolved endpoints in GSSAPI and Insights (DRIVER-201)

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBase.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBase.java
@@ -22,12 +22,16 @@ import com.datastax.oss.driver.api.core.auth.AuthenticationException;
 import com.datastax.oss.driver.api.core.auth.Authenticator;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.base.Charsets;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.protocol.internal.util.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -319,13 +323,49 @@ public abstract class DseGssApiAuthProviderBase implements AuthProvider {
                 SUPPORTED_MECHANISMS,
                 options.getAuthorizationId(),
                 protocol,
-                ((InetSocketAddress) endPoint.resolve()).getAddress().getCanonicalHostName(),
+                serverName(endPoint),
                 options.getSaslProperties(),
                 null);
       } catch (LoginException | SaslException e) {
-        throw new AuthenticationException(endPoint, e.getMessage());
+        throw new AuthenticationException(endPoint, "Failed to initialize GSSAPI: " + e, e);
       }
       this.endPoint = endPoint;
+    }
+
+    /**
+     * The host name to build the Kerberos service principal from.
+     *
+     * <p>Kerberos expects the host's canonical name and JGSS will not supply it: it lower-cases
+     * what it is given, and substitutes a canonical name only when that is a longer form of it, so
+     * an IP literal or a CNAME alias would reach the KDC verbatim and be rejected. With {@code
+     * advanced.resolve-contact-points = false} (the default) a contact point's endpoint is
+     * unresolved and {@code getAddress()} is null, so canonicalize the host string rather than
+     * dereferencing null.
+     *
+     * <p>The lookup blocks the connection's event loop, as the {@code login.login()} KDC round trip
+     * above already does; moving either off it needs an asynchronous {@link AuthProvider} contract.
+     */
+    @VisibleForTesting
+    static String serverName(EndPoint endPoint) throws SaslException {
+      SocketAddress socketAddress = endPoint.resolve();
+      if (!(socketAddress instanceof InetSocketAddress)) {
+        throw new SaslException(
+            "Cannot build a Kerberos service principal: "
+                + endPoint
+                + " does not resolve to an IP address");
+      }
+      InetSocketAddress address = (InetSocketAddress) socketAddress;
+      InetAddress inetAddress = address.getAddress();
+      if (inetAddress != null) {
+        return inetAddress.getCanonicalHostName();
+      }
+      String hostString = address.getHostString();
+      try {
+        return InetAddress.getByName(hostString).getCanonicalHostName();
+      } catch (UnknownHostException e) {
+        // Nothing better to name the principal after; let the KDC reject it with its own message.
+        return hostString;
+      }
     }
 
     @NonNull

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
@@ -363,6 +363,12 @@ public class InsightsClient {
     return TimeUnit.MILLISECONDS.toSeconds(insightsConfiguration.getStatusEventDelayMillis());
   }
 
+  /**
+   * Groups the contact points by host string, not host name: for a resolved address that carries no
+   * name — one built from an {@code InetAddress}, or from an IP literal — {@code getHostName()} is
+   * a reverse DNS lookup, and this runs on the admin executor while the startup event is built. The
+   * key is the host as configured; the values are unchanged.
+   */
   @VisibleForTesting
   static Map<String, List<String>> getResolvedContactPoints(Set<InetSocketAddress> contactPoints) {
     if (contactPoints == null) {
@@ -371,7 +377,7 @@ public class InsightsClient {
     return contactPoints.stream()
         .collect(
             Collectors.groupingBy(
-                InetSocketAddress::getHostName,
+                InetSocketAddress::getHostString,
                 Collectors.mapping(AddressFormatter::nullSafeToString, Collectors.toList())));
   }
 

--- a/core/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBaseTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/api/core/auth/DseGssApiAuthProviderBaseTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.dse.driver.api.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.dse.driver.api.core.auth.DseGssApiAuthProviderBase.GssApiAuthenticator;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.internal.core.channel.LocalEndPoint;
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import javax.security.sasl.SaslException;
+import org.junit.Test;
+
+public class DseGssApiAuthProviderBaseTest {
+
+  @Test
+  public void should_not_let_resolution_change_the_server_name() throws Exception {
+    // The principal must name the same host whether or not the contact point was resolved: with
+    // advanced.resolve-contact-points = false (the default) getAddress() is null, and the old code
+    // dereferenced it. "::1" keeps this independent of the local reverse zone, since a canonical
+    // name is either a PTR name or, when that lookup fails, the expanded literal
+    // (InetAddress:686-693), and never the compressed form the host string carries.
+    EndPoint unresolved = new DefaultEndPoint(InetSocketAddress.createUnresolved("::1", 9042));
+    EndPoint resolved =
+        new DefaultEndPoint(new InetSocketAddress(InetAddress.getByName("::1"), 9042));
+
+    assertThat(GssApiAuthenticator.serverName(unresolved))
+        .isEqualTo(GssApiAuthenticator.serverName(resolved))
+        .isNotEqualTo("::1");
+  }
+
+  @Test
+  public void should_canonicalize_an_alias_on_a_resolved_endpoint() throws Exception {
+    // The alias case the javadoc is about: a name that is not the host's canonical name must not
+    // reach the KDC verbatim. getByAddress attaches the name without a lookup, so the host string
+    // is the alias while the canonical name is whatever 127.0.0.1 canonicalizes to, which is never
+    // the alias. Independent of the reverse zone for the same reason as the test above.
+    InetAddress alias = InetAddress.getByAddress("alias.invalid", new byte[] {127, 0, 0, 1});
+    EndPoint endPoint = new DefaultEndPoint(new InetSocketAddress(alias, 9042));
+
+    assertThat(GssApiAuthenticator.serverName(endPoint))
+        .isEqualTo(alias.getCanonicalHostName())
+        .isNotEqualTo("alias.invalid");
+  }
+
+  @Test
+  public void should_fall_back_to_host_string_when_it_cannot_be_canonicalized() throws Exception {
+    // RFC 6761 reserves ".invalid" as guaranteed NXDOMAIN, so the fallback is the only possible
+    // answer and this test needs no working resolver.
+    EndPoint endPoint = new DefaultEndPoint(InetSocketAddress.createUnresolved("db.invalid", 9042));
+
+    assertThat(GssApiAuthenticator.serverName(endPoint)).isEqualTo("db.invalid");
+  }
+
+  @Test
+  public void should_reject_an_endpoint_that_does_not_resolve_to_an_ip() {
+    // EndPoint.resolve() is declared to return SocketAddress, so a custom implementation may hand
+    // back something that is not an InetSocketAddress; the cast used to throw a ClassCastException
+    // that escaped the authenticator's catch clause.
+    assertThatThrownBy(() -> GssApiAuthenticator.serverName(new LocalEndPoint("gssapi-test")))
+        .isInstanceOf(SaslException.class)
+        .hasMessageContaining("does not resolve to an IP address");
+  }
+}

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
@@ -27,7 +27,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,6 +79,7 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.netty.channel.DefaultEventLoop;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
@@ -168,8 +171,11 @@ public class InsightsClientTest {
     assertThat(insightData.getApplicationName()).isEqualTo("app-name");
     assertThat(insightData.getApplicationVersion()).isEqualTo("1.0.0");
     assertThat(insightData.isApplicationNameWasGenerated()).isEqualTo(false);
+    // Keyed on the literal the fixture configured, not on what the loopback's reverse zone calls
+    // it: the fixture's contact point is a resolved InetSocketAddress built from an IP literal, so
+    // it carries no name and grouping on getHostName() used to reverse-resolve it ("localhost").
     assertThat(insightData.getContactPoints())
-        .isEqualTo(ImmutableMap.of("localhost", Collections.singletonList("127.0.0.1:9999")));
+        .isEqualTo(ImmutableMap.of("127.0.0.1", Collections.singletonList("127.0.0.1:9999")));
 
     assertThat(insightData.getInitialControlConnection()).isEqualTo("127.0.0.1:10");
     assertThat(insightData.getLocalAddress()).isEqualTo("127.0.0.1");
@@ -217,7 +223,7 @@ public class InsightsClientTest {
   }
 
   @Test
-  public void should_group_contact_points_by_host_name() {
+  public void should_group_contact_points_by_host_string() {
     // given
     Set<InetSocketAddress> contactPoints =
         ImmutableSet.of(
@@ -238,6 +244,24 @@ public class InsightsClientTest {
 
     // then
     assertThat(resolvedContactPoints).isEqualTo(expected);
+  }
+
+  @Test
+  public void should_not_reverse_resolve_a_contact_point_that_carries_no_name() throws Exception {
+    // A contact point built from an InetAddress carries no host name, so getHostName() is a
+    // reverse lookup on the admin executor whose answer depends on the local reverse zone
+    // ("localhost" with a PTR record, the literal without), while getHostString() looks nothing
+    // up. Without a PTR record no fixture can tell the two apart, so forbid the lookup itself: the
+    // spy is the real address in every other respect and fails the test if it is consulted.
+    InetAddress address = spy(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}));
+    doThrow(new AssertionError("reverse DNS lookup")).when(address).getHostName();
+    Set<InetSocketAddress> contactPoints = ImmutableSet.of(new InetSocketAddress(address, 9042));
+
+    Map<String, List<String>> resolvedContactPoints =
+        InsightsClient.getResolvedContactPoints(contactPoints);
+
+    assertThat(resolvedContactPoints)
+        .isEqualTo(ImmutableMap.of("127.0.0.1", ImmutableList.of("127.0.0.1:9042")));
   }
 
   @Test

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -19,6 +19,19 @@ under the License.
 
 ## Upgrade guide
 
+### 4.19.2.2
+
+#### DSE Insights keys contact points on their host string
+
+The `contactPoints` map in the Insights startup event is now keyed on each contact point's host
+*string* rather than its host *name*. The two differ for a contact point that ends up as a resolved
+`InetSocketAddress` carrying no name — one built from an `InetAddress`, or from an IP literal,
+which includes IP-literal `basic.contact-points` entries whenever
+`advanced.resolve-contact-points = true`. Such a key was whatever a reverse DNS lookup returned,
+and is now the IP literal. Contact points given as host names, and the unresolved contact points
+this driver uses by default, are unaffected. The lookup, which ran on the driver's admin executor
+while the event was built, no longer runs.
+
 ### 4.19.2.1
 
 #### The driver reports a session identifier, and its configuration, at connection time


### PR DESCRIPTION
Two places assumed an endpoint always resolves. Contact points are unresolved by default on this fork (`advanced.resolve-contact-points = false`), so:

- `DseGssApiAuthProviderBase` built the Kerberos service name from `endPoint.resolve().getAddress().getCanonicalHostName()`; for an unresolved endpoint `getAddress()` is `null` and authentication died with an NPE (the 07-28 `SessionBuilder` finding on #890). It now canonicalizes the host string instead: using it verbatim would not work, since JGSS canonicalizes neither an IP literal nor a CNAME alias, and the KDC rejects the principal. A non-IP `SocketAddress` now raises a `SaslException` rather than letting a `ClassCastException` escape the constructor's catch.
- `InsightsClient` grouped contact points by `getHostName()`, a reverse DNS lookup on the admin executor for a resolved address carrying no name — one built from an `InetAddress` or an IP literal, which includes IP-literal `basic.contact-points` when `advanced.resolve-contact-points = true`. It now groups by `getHostString()`, so for those shapes the key changes from the PTR name to the IP literal; noted in the upgrade guide.

Not included: `InsightsClient` also throws on duplicate `connectedNodes` keys when several nodes share a proxy address. Separate defect, follows in the PR that makes SNI and client-route endpoints unresolved.

Verified: `mvn -pl core test -Dtest=DseGssApiAuthProviderBaseTest,InsightsClientTest` (18 tests); against the pre-fix source the two discriminating tests go red (`expected:<"ip6-localhost"> but was:<"::1">`, and a `ClassCastException` on a `LocalAddress` endpoint). Their fixtures do not depend on the local reverse zone: canonicalization falls back to the host address when the PTR lookup fails, so an IPv6 literal never canonicalizes to its compressed form, nor an attached alias to itself. Also `javadoc:javadoc` on JDK 11 and `cd docs && make test`. Not covered: `DseGssApiAuthProviderIT` needs a KDC, so canonicalization is argued from the JDK's `PrincipalName` source, not tested live.

Part of the #890 split. Refs: #890
