### PR TITLE
feat: fall back to contact points on control reconnect (DRIVER-201)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -701,8 +701,17 @@ public enum DefaultDriverOption implements DriverOption {
   CONTROL_CONNECTION_AGREEMENT_WARN("advanced.control-connection.schema-agreement.warn-on-failure"),
 
   /**
-   * Whether to forcibly add original contact points held by MetadataManager to the reconnection
-   * plan, in case there is no live nodes available according to LBP. Experimental.
+   * Whether to append the original contact points held by MetadataManager to the control
+   * connection's reconnection plan, after the live nodes reported by the load balancing policy.
+   * Defaults to {@code true}.
+   *
+   * <p>This is the driver's DNS re-resolution path. A metadata node discovered from the peers table
+   * holds an address resolved once and never re-resolved; a contact point given as a hostname is
+   * kept unresolved (the default) and looked up again through Netty's resolver on each connect, so
+   * once the live nodes are exhausted the contact points find a cluster that moved to new
+   * addresses, as soon as the JVM's DNS cache ({@code networkaddress.cache.ttl}) has expired. A
+   * resolved contact point ({@code advanced.resolve-contact-points = true}, or a programmatic
+   * resolved address) is appended as it is and never re-resolved.
    *
    * <p>Value-type: boolean
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -369,7 +369,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL, Duration.ofMillis(200));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT, Duration.ofSeconds(10));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, true);
-    map.put(TypedDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, false);
+    map.put(TypedDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, true);
     map.put(TypedDriverOption.PREPARE_ON_ALL_NODES, true);
     map.put(TypedDriverOption.REPREPARE_ENABLED, true);
     map.put(TypedDriverOption.REPREPARE_CHECK_SYSTEM_TABLE, false);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -600,7 +600,13 @@ public class TypedDriverOption<ValueT> {
   public static final TypedDriverOption<Boolean> CONTROL_CONNECTION_AGREEMENT_WARN =
       new TypedDriverOption<>(
           DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, GenericType.BOOLEAN);
-  /** Whether to forcibly try original contacts if no live nodes are available */
+  /**
+   * Whether to append the original contact points to the control connection's reconnection plan,
+   * after the live nodes reported by the load balancing policy (defaults to {@code true}).
+   *
+   * <p>A contact point given as a hostname is kept unresolved and looked up again on each connect,
+   * so this is how the driver picks up changed DNS records once the live nodes are exhausted.
+   */
   public static final TypedDriverOption<Boolean> CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS =
       new TypedDriverOption<>(
           DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS, GenericType.BOOLEAN);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -61,7 +61,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -499,6 +498,34 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                                           node,
                                           new Exception("Channel closed during endpoint resolve")));
                                   connect(nodes, newErrors, onSuccess, onFailure);
+                                } else if (isUnusableForControl(resolvedNode)) {
+                                  // Events name the identified node, not the placeholder we
+                                  // dialled, so isControlNode() cannot match them without a
+                                  // blocking endpoint lookup. Re-checked here instead.
+                                  controlNodeState = ControlNodeState.NONE;
+                                  LOG.debug(
+                                      "[{}] New channel opened ({}) but {} is ignored, removed "
+                                          + "or forced down, closing and trying next node",
+                                      logPrefix,
+                                      channel,
+                                      resolvedNode);
+                                  // Null out before forceClose() so that onChannelClosed() does not
+                                  // start a redundant reconnection on top of the connect() retry
+                                  // below.
+                                  ControlConnection.this.channel = null;
+                                  channel.forceClose();
+                                  // Recorded like every other drop; on init this list is what the
+                                  // user sees. A reconnection discards it, leaving the debug log.
+                                  List<Entry<Node, Throwable>> newErrors =
+                                      (errors == null) ? new ArrayList<>() : errors;
+                                  newErrors.add(
+                                      new SimpleEntry<>(
+                                          node,
+                                          new Exception(
+                                              "Control node "
+                                                  + resolvedNode
+                                                  + " is ignored, removed or forced down")));
+                                  connect(nodes, newErrors, onSuccess, onFailure);
                                 } else {
                                   controlNodeState = new ControlNodeState(resolvedNode, null);
                                   context
@@ -687,12 +714,32 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
           && eventNode.getHostId().equals(state.current.getHostId())) {
         return true;
       }
-      if (state.current == null
-          && state.pending != null
-          && Objects.equals(eventNode.getEndPoint(), state.pending.getEndPoint())) {
-        return true;
-      }
-      return false;
+      // Reference identity, not endpoint equality: with unresolved contact points in the plan,
+      // DefaultEndPoint.equals resolves the unresolved side of a mixed pair -- a blocking lookup on
+      // this admin executor, during the DNS outage the fallback exists for. An event naming the
+      // metadata node for a host still being identified cannot match here at all; connect()
+      // re-checks that node with isUnusableForControl() once the resolve completes.
+      return state.current == null && state.pending != null && eventNode == state.pending;
+    }
+
+    /**
+     * Whether an event has already marked this node unusable for the control connection: ignored by
+     * the load balancing policy, or removed or forced down.
+     *
+     * <p>{@link #connect} runs the same checks on the node it dialled, before adopting the channel;
+     * this one runs a turn later, on the node that channel was identified as.
+     *
+     * <p>Keyed by node instance, so it cannot see a node {@code MetadataManager#registerNode}
+     * minted fresh for an unknown host id: that host is resurrected, not rejected. Detecting it
+     * would need a removal record keyed by host id -- rejecting host ids absent from the metadata
+     * would also reject the new nodes of a cluster that moved, which is what the fallback exists to
+     * recover.
+     */
+    private boolean isUnusableForControl(Node node) {
+      NodeState state = lastNodeState.get(node);
+      return lastNodeDistance.get(node) == NodeDistance.IGNORED
+          || (lastNodeState.containsKey(node)
+              && (state == null /*(removed)*/ || state == NodeState.FORCED_DOWN));
     }
 
     private void onDistanceEvent(DistanceEvent event) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -35,10 +35,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -164,9 +161,7 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
       case BEFORE_INIT:
       case DURING_INIT:
         // The contact points are not stored in the metadata yet:
-        List<Node> nodes = new ArrayList<>(context.getMetadataManager().getContactPoints());
-        Collections.shuffle(nodes);
-        return new ConcurrentLinkedQueue<>(nodes);
+        return contactPointPlan();
       case RUNNING:
         LoadBalancingPolicy policy = policiesPerProfile.get(executionProfileName);
         if (policy == null) {
@@ -190,20 +185,30 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
 
     // Before RUNNING, newQueryPlan() already built the plan from the contact points, so appending
     // them again would only duplicate every entry. Once RUNNING, the plan comes from the policy and
-    // is an immutable QueryPlan (add()/addAll() throw), so concatenate rather than mutate. The
-    // nodes retained by MetadataManager are appended, not fresh copies: their identity stays stable
-    // across reconnection rounds, and no throwaway node is minted per round.
+    // is an immutable QueryPlan (add()/addAll() throw), so concatenate rather than mutate.
     if (state == State.RUNNING
         && context
             .getConfig()
             .getDefaultProfile()
             .getBoolean(DefaultDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS)) {
-      Object[] contactNodes = context.getMetadataManager().getContactPoints().toArray();
-      ArrayUtils.shuffleHead(contactNodes, contactNodes.length);
-      return new CompositeQueryPlan(regularQueryPlan, new SimpleQueryPlan(contactNodes));
+      return new CompositeQueryPlan(regularQueryPlan, contactPointPlan());
     }
 
     return regularQueryPlan;
+  }
+
+  /**
+   * The retained contact points, in random order: the whole plan before the session is initialized,
+   * and what the control connection falls back to once the policy's plan is exhausted. One path for
+   * both, so a fallback round tries exactly what the initial connection tried. The nodes are the
+   * ones {@code MetadataManager} retains, not fresh copies: their identity stays stable across
+   * reconnection rounds, and no throwaway node is minted per round.
+   */
+  @NonNull
+  private Queue<Node> contactPointPlan() {
+    Object[] contactNodes = context.getMetadataManager().getContactPoints().toArray();
+    ArrayUtils.shuffleHead(contactNodes, contactNodes.length);
+    return new SimpleQueryPlan(contactNodes);
   }
 
   // when it comes in from the outside

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -190,6 +190,11 @@ public class MetadataManager implements AsyncAutoCloseable {
    * they are never added to metadata and never exposed to user-facing APIs (events, {@link
    * com.datastax.oss.driver.api.core.metadata.Metadata#getNodes()}, or {@link
    * com.datastax.oss.driver.api.core.metadata.NodeStateListener} callbacks).
+   *
+   * <p>The metadata node stores {@code nodeInfo.getEndPoint()} as-is and never re-resolves it. A
+   * contact-point hostname is re-read only through the control connection's reconnection fallback
+   * ({@code advanced.control-connection.reconnection.fallback-to-original-contact-points}), which
+   * re-offers the retained, still-unresolved contact points to Netty's resolver on each connect.
    */
   public CompletionStage<Node> registerNode(NodeInfo nodeInfo) {
     Preconditions.checkNotNull(nodeInfo.getHostId(), "Cannot register node without hostId");

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2347,14 +2347,40 @@ datastax-java-driver {
     }
 
     reconnection {
-      # Whether to forcibly add original contact points held by MetadataManager to the reconnection plan,
-      # in case there is no live nodes available according to LBP.
-      # Experimental.
+      # Whether to append the original contact points to the control connection's reconnection
+      # plan, after the live nodes reported by the load balancing policy.
+      #
+      # This is the driver's DNS re-resolution path. A metadata node discovered from the peers table
+      # holds an address resolved once and never re-resolved. A contact point given as a hostname is
+      # kept unresolved (see `advanced.resolve-contact-points`) and looked up again through Netty's
+      # resolver on each connect, so once a reconnection round has exhausted the live nodes, the
+      # contact points find a cluster that moved to new addresses -- as soon as the JVM's DNS cache
+      # (`networkaddress.cache.ttl`) has expired. A resolved contact point
+      # (`resolve-contact-points = true`, or a programmatic resolved address) is appended as it is
+      # and never re-resolved.
+      #
+      # The cost: the contact points cannot be deduplicated against the live nodes at plan time
+      # (hostnames against resolved addresses), so a round that exhausts the live nodes then tries
+      # each contact point once more -- one connect (`advanced.connection.connect-timeout`) plus the
+      # identity read (`advanced.control-connection.timeout`) each, serially, with the control
+      # connection down meanwhile. Neither timeout covers the name lookup: Netty resolves before
+      # it connects, so an unanswered DNS query costs the JVM resolver's own timeout per contact
+      # point. Set this to false when the contact points are IP literals or their records never
+      # change, or to keep reconnection rounds short; the control connection then re-resolves
+      # nothing.
+      #
+      # A contact point is only an address, not a node: whichever node answers there is registered
+      # under its own host id, so a node the driver had removed can come back this way if it is
+      # still listening behind the record (a decommissioned node during a rolling replacement, for
+      # instance). That is inherent to recovering through contact points -- the driver cannot tell
+      # a node that should be gone from a genuinely new one at a moved address, and rejecting host
+      # ids it does not know would defeat the point. It corrects itself on the next node refresh
+      # that reaches a node still in the cluster.
       #
       # Required: yes
       # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
       # Overridable in a profile: no
-      fallback-to-original-contact-points = false
+      fallback-to-original-contact-points = true
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
@@ -776,6 +777,130 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // The channelOpened event fires for the resolved node, not the contact point
     verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(resolvedNode));
 
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_try_next_node_if_identified_node_became_ignored_during_resolve() {
+    should_try_next_node_if_event_during_contact_point_resolve(true);
+  }
+
+  @Test
+  public void should_try_next_node_if_identified_node_was_forced_down_during_resolve() {
+    should_try_next_node_if_event_during_contact_point_resolve(false);
+  }
+
+  /**
+   * A contact point's identity is only known once its resolve completes, and the event names the
+   * registered metadata node while the placeholder we dialled is what sits in {@code pending} --
+   * two different instances by construction. So the event cannot be matched while the resolve is in
+   * flight, and the check has to run again on the node finally identified. Before that check
+   * existed the control connection settled on a node it had just been told to abandon, and nothing
+   * replayed the event.
+   */
+  private void should_try_next_node_if_event_during_contact_point_resolve(boolean ignored) {
+    // Given -- init on node1, then a reconnection that goes through a contact point
+    when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofNanos(1));
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DriverChannel channel2 = newMockDriverChannel(2);
+    DriverChannel channel3 = newMockDriverChannel(3);
+    DefaultNode contactPoint = TestNodeFactory.newContactPoint(2, context);
+    UUID resolvedHostId = UUID.randomUUID();
+    DefaultNode resolvedNode = TestNodeFactory.newNode(2, resolvedHostId, context);
+
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory)
+            .success(node1, channel1) // init
+            .success(contactPoint, channel2) // reconnect through the contact point
+            .success(node1, channel3) // next node, once channel2 is dropped
+            .build();
+
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(node1);
+    assertThatStage(initFuture).isSuccess();
+    verify(eventBus, VERIFY_TIMEOUT).fire(ChannelEvent.channelOpened(node1));
+
+    // Hold the resolve open so the event lands while the contact point is still unidentified
+    CompletableFuture<NodeInfo> pendingResolve = new CompletableFuture<>();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel2)).thenReturn(pendingResolve);
+    when(metadataManager.registerNode(any()))
+        .thenAnswer(
+            invocation -> {
+              registeredNodes.put(resolvedNode.getHostId(), resolvedNode);
+              return CompletableFuture.completedFuture(resolvedNode);
+            });
+
+    mockQueryPlan(contactPoint, node1);
+    channel1.close();
+    verify(reconnectionSchedule, VERIFY_TIMEOUT).nextDelay();
+    factoryHelper.waitForCall(contactPoint);
+
+    // When -- the node behind that contact point is taken out of service mid-resolve
+    if (ignored) {
+      eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, resolvedNode));
+    } else {
+      eventBus.fire(NodeStateEvent.changed(NodeState.UP, NodeState.FORCED_DOWN, resolvedNode));
+    }
+    pendingResolve.complete(
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel2.getEndPoint())
+            .withHostId(resolvedHostId)
+            .build());
+
+    // Then -- channel2 is dropped rather than adopted, and the next node is tried
+    verify(channel2, VERIFY_TIMEOUT).forceClose();
+    factoryHelper.waitForCall(node1);
+    await().untilAsserted(() -> assertThat(controlConnection.channel()).isEqualTo(channel3));
+    verify(eventBus, never()).fire(ChannelEvent.channelOpened(resolvedNode));
+
+    factoryHelper.verifyNoMoreCalls();
+  }
+
+  @Test
+  public void should_report_dropped_node_in_failure_when_no_candidate_is_usable() {
+    // One contact point in the plan, and the node behind it turns out to be ignored, so there is
+    // nothing left to try. The failure has to name it: an operator otherwise sees the control
+    // connection refusing to come up with nothing saying a channel was opened and deliberately
+    // closed.
+    DriverChannel channel1 = newMockDriverChannel(1);
+    DefaultNode contactPoint = TestNodeFactory.newContactPoint(1, context);
+    UUID resolvedHostId = UUID.randomUUID();
+    DefaultNode resolvedNode = TestNodeFactory.newNode(1, resolvedHostId, context);
+    MockChannelFactoryHelper factoryHelper =
+        MockChannelFactoryHelper.builder(channelFactory).success(contactPoint, channel1).build();
+    mockQueryPlan(contactPoint);
+
+    // Hold the resolve open so the node can be taken out of service while it is unidentified.
+    CompletableFuture<NodeInfo> pendingResolve = new CompletableFuture<>();
+    TopologyMonitor topologyMonitor = context.getTopologyMonitor();
+    when(topologyMonitor.getChannelNodeInfo(channel1)).thenReturn(pendingResolve);
+    when(metadataManager.registerNode(any()))
+        .thenAnswer(
+            invocation -> {
+              registeredNodes.put(resolvedNode.getHostId(), resolvedNode);
+              return CompletableFuture.completedFuture(resolvedNode);
+            });
+
+    CompletionStage<Void> initFuture = controlConnection.init(false, false, false);
+    factoryHelper.waitForCall(contactPoint);
+    eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, resolvedNode));
+    pendingResolve.complete(
+        DefaultNodeInfo.builder()
+            .withEndPoint(channel1.getEndPoint())
+            .withHostId(resolvedHostId)
+            .build());
+
+    assertThatStage(initFuture)
+        .isFailed(
+            error -> {
+              // NoNodeAvailableException is also an AllNodesFailedException, so the errors are
+              // what discriminates: it carries none.
+              assertThat(error).isInstanceOf(AllNodesFailedException.class);
+              assertThat(((AllNodesFailedException) error).getAllErrors())
+                  .containsOnlyKeys(contactPoint);
+            });
+    verify(channel1, VERIFY_TIMEOUT).forceClose();
     factoryHelper.verifyNoMoreCalls();
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -39,6 +39,8 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
 import com.datastax.oss.driver.categories.IsolatedTests;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultProgrammaticDriverConfigLoaderBuilder;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -47,6 +49,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -59,6 +63,26 @@ public class MockResolverIT {
 
   private static final int CLUSTER_WAIT_SECONDS =
       20; // Maximal wait time for cluster nodes to get up
+
+  /**
+   * Generous: a lookup racing the re-point can re-cache the dead addresses for one {@code
+   * networkaddress.cache.ttl}, and each round first fails on the previous cluster's nodes.
+   */
+  private static final int RECOVERY_WAIT_SECONDS = 120;
+
+  /** Bounds the driver noticing only: {@code decommission} already blocked on nodetool. */
+  private static final int DECOMMISSION_WAIT_SECONDS = 120;
+
+  /**
+   * Resolver entries and the JVM's cache of them are process-global and shared by every test here,
+   * so a name one test re-points must not be served to the next.
+   */
+  @Before
+  @After
+  public void clearResolverState() {
+    MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
+    MultimapHostResolverProvider.clearJvmCache();
+  }
 
   private static void waitForAllNodesUp(CqlSession session, int expectedNodes) {
     Awaitility.await()
@@ -190,6 +214,195 @@ public class MockResolverIT {
       }
     }
     session.close();
+  }
+
+  @Test
+  public void should_recover_when_the_cluster_moves_to_new_addresses() {
+    // replace_cluster_test brings the cluster back on the same addresses, so only the contact-point
+    // fallback can show a session finding one that came back on *different* ones.
+    // Four nodes, not three: Cassandra 4 refuses to decommission below system_distributed's
+    // replication factor of 3. RemovedNodeIT sizes its cluster the same way.
+    final int initialNodes = 4;
+    final int movedNodes = 3;
+    DriverConfigLoader loader =
+        new DefaultProgrammaticDriverConfigLoaderBuilder()
+            // Pinned like every other test here: the fallback only re-resolves a contact point
+            // kept unresolved. Leaving the fallback's own default alone is deliberate.
+            .withBoolean(TypedDriverOption.RESOLVE_CONTACT_POINTS.getRawOption(), false)
+            .withBoolean(TypedDriverOption.RECONNECT_ON_INIT.getRawOption(), true)
+            .withDuration(
+                TypedDriverOption.RECONNECTION_BASE_DELAY.getRawOption(), Duration.ofSeconds(1))
+            .withDuration(
+                TypedDriverOption.RECONNECTION_MAX_DELAY.getRawOption(), Duration.ofSeconds(1))
+            .withDuration(
+                TypedDriverOption.CONNECTION_CONNECT_TIMEOUT.getRawOption(), Duration.ofSeconds(2))
+            .withStringList(
+                TypedDriverOption.CONTACT_POINTS.getRawOption(),
+                Collections.singletonList("test.cluster.fake:9042"))
+            .build();
+    CqlSessionBuilder builder = new CqlSessionBuilder().withConfigLoader(loader);
+    CqlSession session = null;
+
+    try {
+      try (CcmBridge ccmBridge =
+          CcmBridge.builder().withNodes(initialNodes).withIpPrefix("127.0.1.").build()) {
+        pointContactPointAt(ccmBridge, initialNodes);
+        ccmBridge.create();
+        ccmBridge.start();
+        session = builder.build();
+        waitForAllNodesUp(session, initialNodes);
+        assertThat(nodesOnPrefix(session, "127.0.1.")).hasSize(initialNodes);
+        // The loader leaves the fallback at its default on purpose; assert it, or a flipped
+        // default would surface as a bare Awaitility timeout below.
+        assertThat(
+                session
+                    .getContext()
+                    .getConfig()
+                    .getDefaultProfile()
+                    .getBoolean(
+                        TypedDriverOption.CONTROL_CONNECTION_RECONNECT_CONTACT_POINTS
+                            .getRawOption()))
+            .isTrue();
+
+        // The node reached through the contact point keeps re-resolving that name in its pool, so
+        // left in place it would find the new cluster by itself and this test would pass with the
+        // fallback off. Decommission rather than stop it: a stopped node stays in the metadata.
+        Node hostnameNode = theNodeNamingTheContactPoint(session);
+        ccmBridge.decommission(ccmNodeIndexOf(ccmBridge, hostnameNode, initialNodes));
+        awaitRemovalOfContactPointNode(session, initialNodes - 1);
+      }
+      // Re-point the name and drop the JVM's cached answers before the new cluster exists, or the
+      // fallback is served the dead addresses for one networkaddress.cache.ttl.
+      try (CcmBridge ccmBridge =
+          CcmBridge.builder().withNodes(movedNodes).withIpPrefix("127.0.2.").build()) {
+        pointContactPointAt(ccmBridge, movedNodes);
+        MultimapHostResolverProvider.clearJvmCache();
+        ccmBridge.create();
+        ccmBridge.start();
+        awaitAllNodesUpOnPrefix(session, "127.0.2.", movedNodes);
+        // The point of the test: the session followed the name and let go of the old cluster.
+        Collection<Node> nodes = session.getMetadata().getNodes().values();
+        assertThat(nodesOnPrefix(session, "127.0.1.")).isEmpty();
+        // The fallback's signature: the node it reached is registered under the name, and only it.
+        assertThat(nodesNamingTheContactPoint(nodes)).hasSize(1);
+        ResultSet rs = session.execute("select * from system.local where key='local'");
+        assertThat(rs.one()).isNotNull();
+      }
+    } finally {
+      // A failure must not leave this session reconnecting against torn-down clusters.
+      if (session != null) {
+        session.close();
+      }
+    }
+  }
+
+  private static void pointContactPointAt(CcmBridge ccmBridge, int numberOfNodes) {
+    MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
+    for (int i = 1; i <= numberOfNodes; i++) {
+      MultimapHostResolverProvider.addResolverEntry(
+          "test.cluster.fake", ccmBridge.getNodeIpAddress(i));
+    }
+  }
+
+  /** The one metadata node registered under the contact point's name; fails if there is not one. */
+  private static Node theNodeNamingTheContactPoint(CqlSession session) {
+    Set<Node> named = nodesNamingTheContactPoint(session.getMetadata().getNodes().values());
+    assertThat(named).hasSize(1);
+    return named.iterator().next();
+  }
+
+  /**
+   * The CCM index of the node {@code node} was identified as, by its broadcast RPC address: its own
+   * endpoint is the contact point's unresolved name.
+   */
+  private static int ccmNodeIndexOf(CcmBridge ccmBridge, Node node, int numberOfNodes) {
+    InetSocketAddress rpcAddress =
+        node.getBroadcastRpcAddress()
+            .orElseThrow(() -> new AssertionError("No broadcast RPC address recorded for " + node));
+    String ip = rpcAddress.getAddress().getHostAddress();
+    for (int i = 1; i <= numberOfNodes; i++) {
+      if (ip.equals(ccmBridge.getNodeIpAddress(i))) {
+        return i;
+      }
+    }
+    throw new AssertionError(node + " (rpc " + ip + ") is not one of the CCM nodes");
+  }
+
+  /**
+   * Waits until the decommissioned node has left the metadata and no remaining node is registered
+   * under the contact point's name.
+   */
+  private static void awaitRemovalOfContactPointNode(CqlSession session, int expectedNodes) {
+    Awaitility.await()
+        .atMost(DECOMMISSION_WAIT_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              Collection<Node> nodes = session.getMetadata().getNodes().values();
+              assertThat(nodes).hasSize(expectedNodes);
+              assertThat(nodesNamingTheContactPoint(nodes)).isEmpty();
+            });
+  }
+
+  /** Waits until every node the session knows sits on {@code ipPrefix} and is up. */
+  private static void awaitAllNodesUpOnPrefix(
+      CqlSession session, String ipPrefix, int numberOfNodes) {
+    Awaitility.await()
+        .atMost(RECOVERY_WAIT_SECONDS, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        // untilAsserted so a timeout names the condition that failed. Up-ness is counted on the
+        // prefix, the total across the metadata: the old cluster leaving is part of the wait.
+        .untilAsserted(
+            () -> {
+              Set<Node> onPrefix = nodesOnPrefix(session, ipPrefix);
+              assertThat(onPrefix).hasSize(numberOfNodes);
+              assertThat(upNodes(onPrefix)).hasSize(numberOfNodes);
+              assertThat(session.getMetadata().getNodes()).hasSize(numberOfNodes);
+            });
+  }
+
+  /**
+   * The metadata nodes sitting in {@code ipPrefix}. The node reached through the contact point
+   * holds the unresolved name, so its broadcast RPC address says where it is.
+   */
+  private static Set<Node> nodesOnPrefix(CqlSession session, String ipPrefix) {
+    return session.getMetadata().getNodes().values().stream()
+        .filter(
+            node -> {
+              String ip = hostAddressOf(node);
+              return ip != null && ip.startsWith(ipPrefix);
+            })
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<Node> upNodes(Set<Node> nodes) {
+    return nodes.stream().filter(n -> n.getUpSinceMillis() > 0).collect(Collectors.toSet());
+  }
+
+  /**
+   * The IP a node sits at: its endpoint's address when resolved, else its broadcast RPC address,
+   * else {@code null}.
+   */
+  private static String hostAddressOf(Node node) {
+    SocketAddress resolved = node.getEndPoint().resolve();
+    if (resolved instanceof InetSocketAddress && !((InetSocketAddress) resolved).isUnresolved()) {
+      return ((InetSocketAddress) resolved).getAddress().getHostAddress();
+    }
+    return node.getBroadcastRpcAddress()
+        .map(address -> address.getAddress().getHostAddress())
+        .orElse(null);
+  }
+
+  /** The nodes whose endpoint carries the contact-point name as its host string. */
+  private static Set<Node> nodesNamingTheContactPoint(Collection<Node> nodes) {
+    return nodes.stream()
+        .filter(
+            node -> {
+              SocketAddress resolved = node.getEndPoint().resolve();
+              return resolved instanceof InetSocketAddress
+                  && "test.cluster.fake".equals(((InetSocketAddress) resolved).getHostString());
+            })
+        .collect(Collectors.toSet());
   }
 
   @SuppressWarnings("unused")

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MultimapHostResolverProvider.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MultimapHostResolverProvider.java
@@ -29,4 +29,13 @@ public class MultimapHostResolverProvider {
     }
     resolver.removeHost(hostname);
   }
+
+  /**
+   * Drops what the JVM has cached from previous lookups, so that the next lookup of a re-pointed
+   * hostname reaches the resolver instead of being served the old answer for {@code
+   * networkaddress.cache.ttl}.
+   */
+  public static synchronized void clearJvmCache() {
+    HostResolutionRequestInterceptor.INSTANCE.clearCache();
+  }
 }

--- a/manual/core/control_connection/README.md
+++ b/manual/core/control_connection/README.md
@@ -31,7 +31,10 @@ When the driver starts, the control connection is established to the first conta
 node goes down, a [reconnection](../reconnection/) is started to find another node; it is governed
 by the same policy as regular connections (`advanced.reconnection-policy` options in the
 [configuration](../configuration/)), and tries the nodes according to a query plan from the
-[load balancing policy](../load_balancing/). 
+[load balancing policy](../load_balancing/). When that plan is exhausted, the original contact points
+are tried again (`advanced.control-connection.reconnection.fallback-to-original-contact-points`, on
+by default), so a contact point given as a hostname is resolved again and a cluster that moved to
+new addresses is found.
 
 The control connection is managed independently from [regular pooled connections](../pooling/), and
 used exclusively for administrative requests. It shows up in [Node.getOpenConnections], as well as

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -29,6 +29,23 @@ datacenter is never populated, so it fired on every session that configured a lo
 contact points actually were. The warning for a configured DC that matches no node in the cluster is
 unchanged. `checkLocalDatacenterCompatibility` is removed, so drop any override of it.
 
+#### The control connection falls back to the contact points by default
+
+`advanced.control-connection.reconnection.fallback-to-original-contact-points` now defaults to
+`true`. Once a control-connection reconnection round has exhausted the live nodes, the original
+contact points are tried again. A contact point given as a hostname is kept unresolved and looked up
+again on each connect, so a cluster that moved to new addresses is found again once the JVM's DNS
+cache (`networkaddress.cache.ttl`) has expired; this is what
+[#215](https://github.com/scylladb/java-driver/issues/215) asked for. A resolved contact point
+(`advanced.resolve-contact-points = true`, or a programmatic `InetSocketAddress` that was already
+resolved) is appended as it is and is not re-resolved.
+
+The cost is one extra connection attempt per contact point per exhausted round: at plan time the
+contact points are hostnames and the live nodes resolved addresses, so the two cannot be
+deduplicated. Set the option to `false` if your contact points are IP literals or their records
+never change, or to keep reconnection rounds short; the control connection then re-resolves
+nothing.
+
 ### 4.19.2.1
 
 #### The driver reports a session identifier, and its configuration, at connection time


### PR DESCRIPTION
The driver reconnects on addresses it resolved once and never re-reads DNS (#215), so a cluster that comes back on new addresses is never found again.

- `fallback-to-original-contact-points` defaults to `true`: once a reconnection round has exhausted the live nodes, the retained, unresolved contact points are tried again and their names resolved afresh.
- Init and fallback build the contact-point plan through one path (`contactPointPlan()`), so a fallback round tries exactly what the initial connection tried.
- `isControlNode` matches the pending node by reference and the identified node is re-checked with `isUnusableForControl`: with unresolved placeholders in the post-init plan, the endpoint `equals` was a blocking DNS lookup per event.
- New `MockResolverIT` case: the node reached through the contact point is decommissioned, then the cluster comes back on a different prefix, so only the fallback can find it.

Verified: full `core` unit suite (3968) green on JDK 11; the three new `ControlConnectionTest` cases red against the previous `ControlConnection`; docs build; `HeartbeatIT` green with the new default on; `MockResolverIT` against ScyllaDB 2026.1.9, which times out with the option forced to `false`. Not covered locally: the Cassandra CCM lanes.

Deferred, with the requirements they carry: #1073 resolves through Netty's configured resolver (`resolveAll`); #1074 tries every address a contact point resolves to, deduplicated, shuffled and capped, each as a labelled `name/ip` candidate; how that node is represented in metadata is #1072.

Fixes #215
Refs: #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)


