### PR TITLE
ci: block releases with open release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,33 @@ jobs:
 
     permissions:
       contents: write
+      issues: read
 
     env:
       MVNCMD: mvn -B -X -ntp
 
     steps:
+      - name: Check for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --label release-blocker \
+              --limit 1 \
+              --json title,url \
+              --jq '.[0] | select(.) | "\(.url) — \(.title)"'
+          )"
+          if [[ -n "$blocker" ]]; then
+            echo "::error::Release blocked by open issue: $blocker"
+            exit 1
+          fi
+          echo "No open release blockers."
+
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,27 @@ jobs:
           RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
         run: make release-prepare
 
+      - name: Recheck for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --label release-blocker \
+              --limit 1 \
+              --json title,url \
+              --jq '.[0] | select(.) | "\(.url) — \(.title)"'
+          )"
+          if [[ -n "$blocker" ]]; then
+            echo "::error::Release blocked by open issue: $blocker"
+            exit 1
+          fi
+          echo "No open release blockers."
+
       - name: Perform release
         if: inputs.dry-run == false
         env:


### PR DESCRIPTION
## Summary

- block production releases when an open issue has the release-blocker label
- report blocking issue title and URL
- keep dry-run releases available
- grant the workflow token read-only issue access

## Branch coverage

- this PR guards scylla-4.x
- #1078 guards active scylla-3.x

## Validation

- actionlint 1.7.12
- guard succeeds when no blocker exists
- guard fails when an open blocker exists
- API failures fail closed