### PR TITLE
ci: block releases with open release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,27 @@ jobs:
         run: |
           make release-prepare
 
+      - name: Recheck for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --label release-blocker \
+              --limit 1 \
+              --json title,url \
+              --jq '.[0] | select(.) | "\(.url) — \(.title)"'
+          )"
+          if [[ -n "$blocker" ]]; then
+            echo "::error::Release blocked by open issue: $blocker"
+            exit 1
+          fi
+          echo "No open release blockers."
+
       - name: Perform release
         if: inputs.dry-run == false
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,33 @@ jobs:
 
     permissions:
       contents: write
+      issues: read
 
     env:
       MVNCMD: mvn -B -X -ntp
 
     steps:
+      - name: Check for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --label release-blocker \
+              --limit 1 \
+              --json title,url \
+              --jq '.[0] | select(.) | "\(.url) — \(.title)"'
+          )"
+          if [[ -n "$blocker" ]]; then
+            echo "::error::Release blocked by open issue: $blocker"
+            exit 1
+          fi
+          echo "No open release blockers."
+
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
## Summary

- block production releases when an open issue has the release-blocker label
- report blocking issue title and URL
- keep dry-run releases available
- grant the workflow token read-only issue access

## Branch coverage

- this PR guards active scylla-3.x
- #1077 guards scylla-4.x

## Validation

- actionlint 1.7.12
- guard succeeds when no blocker exists
- guard fails when an open blocker exists
- API failures fail closed